### PR TITLE
Adds empty dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Anomaly detection is using Random Cut Forest (RCF) algorithm for detecting anoma
 You should use anomaly detection kibana plugin with Open Distro Alerting kibana plugin [1.2-alpha](https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/tree/opendistro-1.2-alpha). You can also create monitor based on anomaly detector. Scheduled monitor run will trigger anomaly detector and get anomaly result to check if should trigger alert or not based on custom trigger conditions.
 
 ## Current Limitations
-* This is alpha code.
-* We inherit security features from Open Distro for Elasticsearch Alerting.
-* We use Alerting alpha code branch.
-* We will continuously add new unit test cases, but we don't have 100% unit test coverage for now. This is a great area for developers from the community to contribute and help improve test coverage.
-* Please see documentation links and GitHub issues for other details.
+
+- This is alpha code.
+- We inherit security features from Open Distro for Elasticsearch Alerting.
+- We use Alerting alpha code branch.
+- We will continuously add new unit test cases, but we don't have 100% unit test coverage for now. This is a great area for developers from the community to contribute and help improve test coverage.
+- Please see documentation links and GitHub issues for other details.
 
 ## Documentation
 
@@ -34,13 +35,13 @@ Please see our [documentation](https://opendistro.github.io/for-elasticsearch-do
 
 Ultimately, your directory structure should look like this:
 
+<!-- prettier-ignore -->
 ```md
 .
 ├── kibana
 │   └──plugins
 │      └── anomaly-detection-kibana-plugin
 ```
-
 
 ## Build
 
@@ -58,7 +59,6 @@ Example output: `./build/opendistro-anomaly-detection-1.4.2.0.zip`
 
   Runs the plugin tests.
 
-
 ## Contributing to Open Distro for Elasticsearch Anomaly detection Kibana
 
 We welcome you to get involved in development, documentation, testing the anomaly detection plugin. See our [CONTRIBUTING.md](./CONTRIBUTING.md) and join in.
@@ -68,7 +68,6 @@ Since this is a Kibana plugin, it can be useful to review the [Kibana contributi
 ## Code of Conduct
 
 This project has adopted an [Open Source Code of Conduct](https://opendistro.github.io/for-elasticsearch/codeofconduct.html).
-
 
 ## Security issue notifications
 
@@ -80,4 +79,4 @@ See the [LICENSE](./LICENSE.txt) file for our project's licensing. We will ask y
 
 ## Copyright
 
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
+++ b/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
@@ -19,77 +19,21 @@ import {
   EuiLink,
   EuiIcon,
   EuiPage,
-  EuiTitle,
-  EuiPageSideBar,
   EuiPageBody,
-  EuiPageHeader,
-  EuiSideNav,
 } from '@elastic/eui';
 import React, { Component, Fragment } from 'react';
 import { APP_PATH, PLUGIN_NAME } from '../../../../utils/constants';
-
-type EmptyDashboardState = {
-  selectedItemName: string;
-};
+import { SideBar, DashboardHeader } from '../utils/common';
 
 export class EmptyDashboard extends Component<{}, EmptyDashboardState> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      selectedItemName: 'Lion stuff',
-    };
-  }
-
-  selectItem = (name: string) => {
-    this.setState({
-      selectedItemName: name,
-    });
-  };
-
-  createItem = (name: string, id: number, data = {}) => {
-    // NOTE: Duplicate `name` values will cause `id` collisions.
-    return {
-      ...data,
-      id: name,
-      name,
-      isSelected: this.state.selectedItemName === name,
-      onClick: () => this.selectItem(name),
-    };
-  };
-
   render() {
-    const sideNav = [
-      {
-        name: 'Anomaly detection',
-        id: 0,
-        items: [
-          this.createItem('Dashboard', 1, { href: `#${APP_PATH.DASHBOARD}` }),
-          this.createItem('Detectors', 2, {
-            href: `#${APP_PATH.LIST_DETECTORS}`,
-          }),
-        ],
-      },
-    ];
-
     return (
       <EuiPage style={{ flex: 1 }}>
-        <EuiPageSideBar
-          style={{
-            flex: 1,
-            backgroundColor: '#F5F7FA',
-          }}
-        >
-          <EuiSideNav style={{ width: 150 }} items={sideNav} />
-        </EuiPageSideBar>
+        <SideBar />
         <EuiPageBody>
-          <EuiPageHeader>
-            <EuiTitle size="l">
-              <h1>Dashboard</h1>
-            </EuiTitle>
-          </EuiPageHeader>
+          <DashboardHeader />
           <EuiEmptyPrompt
             title={<h2>You have no detectors</h2>}
-            // style={{ maxWidth: '45em' }}
             body={
               <Fragment>
                 <p>Create detector first to detect anomalies in your data.</p>

--- a/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
+++ b/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
@@ -13,58 +13,44 @@
  * permissions and limitations under the License.
  */
 
-import {
-  EuiButton,
-  EuiEmptyPrompt,
-  EuiLink,
-  EuiIcon,
-  EuiPage,
-  EuiPageBody,
-} from '@elastic/eui';
+import { EuiButton, EuiEmptyPrompt, EuiLink, EuiIcon } from '@elastic/eui';
 import React, { Component, Fragment } from 'react';
 import { APP_PATH, PLUGIN_NAME } from '../../../../utils/constants';
-import { SideBar, DashboardHeader } from '../utils/common';
 
-export class EmptyDashboard extends Component<{}, EmptyDashboardState> {
+export class EmptyDashboard extends Component<{}, {}> {
   render() {
     return (
-      <EuiPage style={{ flex: 1 }}>
-        <SideBar />
-        <EuiPageBody>
-          <DashboardHeader />
-          <EuiEmptyPrompt
-            title={<h2>You have no detectors</h2>}
-            body={
-              <Fragment>
-                <p>Create detector first to detect anomalies in your data.</p>
-                <p>
-                  Dashboard will generate insights on the anomalies across all
-                  of your detectors
-                </p>
-                <p>
-                  Read about{' '}
-                  <EuiLink
-                    href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
-                    target="_blank"
-                  >
-                    Get started with Anomaly detection &nbsp;
-                    <EuiIcon size="s" type="popout" />
-                  </EuiLink>{' '}
-                </p>
-              </Fragment>
-            }
-            actions={
-              <EuiButton
-                fill
-                href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}
-                data-test-subj="add_detector"
+      <EuiEmptyPrompt
+        title={<h2>You have no detectors</h2>}
+        body={
+          <Fragment>
+            <p>Create detector first to detect anomalies in your data.</p>
+            <p>
+              Dashboard will generate insights on the anomalies across all of
+              your detectors
+            </p>
+            <p>
+              Read about{' '}
+              <EuiLink
+                href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+                target="_blank"
               >
-                Create detector
-              </EuiButton>
-            }
-          />
-        </EuiPageBody>
-      </EuiPage>
+                Get started with Anomaly detection &nbsp;
+                <EuiIcon size="s" type="popout" />
+              </EuiLink>{' '}
+            </p>
+          </Fragment>
+        }
+        actions={
+          <EuiButton
+            fill
+            href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}
+            data-test-subj="add_detector"
+          >
+            Create detector
+          </EuiButton>
+        }
+      />
     );
   }
 }

--- a/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
+++ b/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiButton,
+  EuiEmptyPrompt,
+  EuiLink,
+  EuiIcon,
+  EuiPage,
+  EuiTitle,
+  EuiPageSideBar,
+  EuiPageBody,
+  EuiPageHeader,
+  EuiSideNav,
+} from '@elastic/eui';
+import React, { Component, Fragment } from 'react';
+import { APP_PATH, PLUGIN_NAME } from '../../../../utils/constants';
+
+type EmptyDashboardState = {
+  selectedItemName: string;
+};
+
+export class EmptyDashboard extends Component<{}, EmptyDashboardState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      selectedItemName: 'Lion stuff',
+    };
+  }
+
+  selectItem = (name: string) => {
+    this.setState({
+      selectedItemName: name,
+    });
+  };
+
+  createItem = (name: string, id: number, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      ...data,
+      id: name,
+      name,
+      isSelected: this.state.selectedItemName === name,
+      onClick: () => this.selectItem(name),
+    };
+  };
+
+  render() {
+    const sideNav = [
+      {
+        name: 'Anomaly detection',
+        id: 0,
+        items: [
+          this.createItem('Dashboard', 1, { href: `#${APP_PATH.DASHBOARD}` }),
+          this.createItem('Detectors', 2, {
+            href: `#${APP_PATH.LIST_DETECTORS}`,
+          }),
+        ],
+      },
+    ];
+
+    return (
+      <EuiPage style={{ flex: 1 }}>
+        <EuiPageSideBar
+          style={{
+            flex: 1,
+            backgroundColor: '#F5F7FA',
+          }}
+        >
+          <EuiSideNav style={{ width: 150 }} items={sideNav} />
+        </EuiPageSideBar>
+        <EuiPageBody>
+          <EuiPageHeader>
+            <EuiTitle size="l">
+              <h1>Dashboard</h1>
+            </EuiTitle>
+          </EuiPageHeader>
+          <EuiEmptyPrompt
+            title={<h2>You have no detectors</h2>}
+            // style={{ maxWidth: '45em' }}
+            body={
+              <Fragment>
+                <p>Create detector first to detect anomalies in your data.</p>
+                <p>
+                  Dashboard will generate insights on the anomalies across all
+                  of your detectors
+                </p>
+                <p>
+                  Read about{' '}
+                  <EuiLink
+                    href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+                    target="_blank"
+                  >
+                    Get started with Anomaly detection &nbsp;
+                    <EuiIcon size="s" type="popout" />
+                  </EuiLink>{' '}
+                </p>
+              </Fragment>
+            }
+            actions={
+              <EuiButton
+                fill
+                href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}
+                data-test-subj="add_detector"
+              >
+                Create detector
+              </EuiButton>
+            }
+          />
+        </EuiPageBody>
+      </EuiPage>
+    );
+  }
+}

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/EmptyDashboard.test.tsx
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/EmptyDashboard.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EmptyDashboard } from '../EmptyDashboard';
+
+describe('<EmptyDetector /> spec', () => {
+  describe('Empty results', () => {
+    test('renders component with empty message', async () => {
+      const { container } = render(<EmptyDashboard />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<EmptyDetector /> spec Empty results renders component with empty message 1`] = `
+<div
+  class="euiPage"
+>
+  <div
+    class="euiPageSideBar"
+    style="background-color: rgb(245, 247, 250);"
+  >
+    <nav
+      class="euiSideNav"
+      style="width: 150px;"
+    >
+      <button
+        class="euiSideNav__mobileToggle euiLink"
+        type="button"
+      >
+        <span
+          class="euiSideNav__mobileWrap"
+        >
+          <span
+            class="euiSideNav__mobileTitle"
+          />
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiSideNav__mobileIcon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <defs>
+              <path
+                d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
+                id="apps-a"
+              />
+            </defs>
+            <use
+              xlink:href="#apps-a"
+            />
+          </svg>
+        </span>
+      </button>
+      <div
+        class="euiSideNav__content"
+        role="menubar"
+      >
+        <div
+          class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
+        >
+          <div
+            aria-label="[object Object]"
+            class="euiSideNavItemButton"
+          >
+            <span
+              class="euiSideNavItemButton__content"
+            >
+              <span
+                class="euiSideNavItemButton__label"
+              >
+                Anomaly detection
+              </span>
+            </span>
+          </div>
+          <div
+            class="euiSideNavItem__items"
+          >
+            <div
+              class="euiSideNavItem euiSideNavItem--trunk"
+            >
+              <a
+                class="euiSideNavItemButton euiSideNavItemButton--isClickable"
+                href="#/dashboard"
+                role="menuitem"
+              >
+                <span
+                  class="euiSideNavItemButton__content"
+                >
+                  <span
+                    class="euiSideNavItemButton__label"
+                  >
+                    Dashboard
+                  </span>
+                </span>
+              </a>
+            </div>
+            <div
+              class="euiSideNavItem euiSideNavItem--trunk"
+            >
+              <a
+                class="euiSideNavItemButton euiSideNavItemButton--isClickable"
+                href="#/list-detectors"
+                role="menuitem"
+              >
+                <span
+                  class="euiSideNavItemButton__content"
+                >
+                  <span
+                    class="euiSideNavItemButton__label"
+                  >
+                    Detectors
+                  </span>
+                </span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+  <div
+    class="euiPageBody"
+  >
+    <div
+      class="euiPageHeader euiPageHeader--responsive"
+    >
+      <h1
+        class="euiTitle euiTitle--large"
+      >
+        Dashboard
+      </h1>
+    </div>
+    <div
+      class="euiEmptyPrompt"
+    >
+      <span
+        class="euiTextColor euiTextColor--subdued"
+      >
+        <h2
+          class="euiTitle euiTitle--medium"
+        >
+          You have no detectors
+        </h2>
+        <div
+          class="euiSpacer euiSpacer--m"
+        />
+        <div
+          class="euiText euiText--medium"
+        >
+          <p>
+            Create detector first to detect anomalies in your data.
+          </p>
+          <p>
+            Dashboard will generate insights on the anomalies across all of your detectors
+          </p>
+          <p>
+            Read about
+             
+            <a
+              class="euiLink euiLink--primary"
+              href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Get started with Anomaly detection  
+              <svg
+                class="euiIcon euiIcon--small"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 14.01h12.49a.5.5 0 1 1 0 1h-13a.5.5 0 0 1-.49-.597V1.5a.5.5 0 0 1 1 0v12.51zm2.354-1.656a.5.5 0 0 1-.708-.708l8-8a.5.5 0 0 1 .708.708l-8 8zM15 5.5a.5.5 0 1 1-1 0v-3a.5.5 0 0 0-.5-.5h-3a.5.5 0 1 1 0-1h3A1.5 1.5 0 0 1 15 2.5v3z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </a>
+             
+          </p>
+        </div>
+      </span>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiSpacer euiSpacer--s"
+      />
+      <a
+        class="euiButton euiButton--primary euiButton--fill"
+        data-test-subj="add_detector"
+        href="opendistro-anomaly-detection#/create-ad"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Create detector
+          </span>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
@@ -2,200 +2,76 @@
 
 exports[`<EmptyDetector /> spec Empty results renders component with empty message 1`] = `
 <div
-  class="euiPage"
+  class="euiEmptyPrompt"
 >
-  <div
-    class="euiPageSideBar"
-    style="background-color: rgb(245, 247, 250);"
+  <span
+    class="euiTextColor euiTextColor--subdued"
   >
-    <nav
-      class="euiSideNav"
-      style="width: 150px;"
+    <h2
+      class="euiTitle euiTitle--medium"
     >
-      <button
-        class="euiSideNav__mobileToggle euiLink"
-        type="button"
-      >
-        <span
-          class="euiSideNav__mobileWrap"
+      You have no detectors
+    </h2>
+    <div
+      class="euiSpacer euiSpacer--m"
+    />
+    <div
+      class="euiText euiText--medium"
+    >
+      <p>
+        Create detector first to detect anomalies in your data.
+      </p>
+      <p>
+        Dashboard will generate insights on the anomalies across all of your detectors
+      </p>
+      <p>
+        Read about
+         
+        <a
+          class="euiLink euiLink--primary"
+          href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <span
-            class="euiSideNav__mobileTitle"
-          />
+          Get started with Anomaly detection  
           <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiSideNav__mobileIcon"
+            class="euiIcon euiIcon--small"
             focusable="false"
             height="16"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
           >
-            <defs>
-              <path
-                d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
-                id="apps-a"
-              />
-            </defs>
-            <use
-              xlink:href="#apps-a"
+            <path
+              d="M2 14.01h12.49a.5.5 0 1 1 0 1h-13a.5.5 0 0 1-.49-.597V1.5a.5.5 0 0 1 1 0v12.51zm2.354-1.656a.5.5 0 0 1-.708-.708l8-8a.5.5 0 0 1 .708.708l-8 8zM15 5.5a.5.5 0 1 1-1 0v-3a.5.5 0 0 0-.5-.5h-3a.5.5 0 1 1 0-1h3A1.5 1.5 0 0 1 15 2.5v3z"
+              fill-rule="evenodd"
             />
           </svg>
-        </span>
-      </button>
-      <div
-        class="euiSideNav__content"
-        role="menubar"
-      >
-        <div
-          class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
-        >
-          <div
-            aria-label="[object Object]"
-            class="euiSideNavItemButton"
-          >
-            <span
-              class="euiSideNavItemButton__content"
-            >
-              <span
-                class="euiSideNavItemButton__label"
-              >
-                Anomaly detection
-              </span>
-            </span>
-          </div>
-          <div
-            class="euiSideNavItem__items"
-          >
-            <div
-              class="euiSideNavItem euiSideNavItem--trunk"
-            >
-              <a
-                class="euiSideNavItemButton euiSideNavItemButton--isClickable"
-                href="#/dashboard"
-                role="menuitem"
-              >
-                <span
-                  class="euiSideNavItemButton__content"
-                >
-                  <span
-                    class="euiSideNavItemButton__label"
-                  >
-                    Dashboard
-                  </span>
-                </span>
-              </a>
-            </div>
-            <div
-              class="euiSideNavItem euiSideNavItem--trunk"
-            >
-              <a
-                class="euiSideNavItemButton euiSideNavItemButton--isClickable"
-                href="#/list-detectors"
-                role="menuitem"
-              >
-                <span
-                  class="euiSideNavItemButton__content"
-                >
-                  <span
-                    class="euiSideNavItemButton__label"
-                  >
-                    Detectors
-                  </span>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
-  </div>
-  <div
-    class="euiPageBody"
-  >
-    <div
-      class="euiPageHeader euiPageHeader--responsive"
-    >
-      <h1
-        class="euiTitle euiTitle--large"
-      >
-        Dashboard
-      </h1>
+        </a>
+         
+      </p>
     </div>
-    <div
-      class="euiEmptyPrompt"
+  </span>
+  <div
+    class="euiSpacer euiSpacer--l"
+  />
+  <div
+    class="euiSpacer euiSpacer--s"
+  />
+  <a
+    class="euiButton euiButton--primary euiButton--fill"
+    data-test-subj="add_detector"
+    href="opendistro-anomaly-detection#/create-ad"
+  >
+    <span
+      class="euiButton__content"
     >
       <span
-        class="euiTextColor euiTextColor--subdued"
+        class="euiButton__text"
       >
-        <h2
-          class="euiTitle euiTitle--medium"
-        >
-          You have no detectors
-        </h2>
-        <div
-          class="euiSpacer euiSpacer--m"
-        />
-        <div
-          class="euiText euiText--medium"
-        >
-          <p>
-            Create detector first to detect anomalies in your data.
-          </p>
-          <p>
-            Dashboard will generate insights on the anomalies across all of your detectors
-          </p>
-          <p>
-            Read about
-             
-            <a
-              class="euiLink euiLink--primary"
-              href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Get started with Anomaly detection  
-              <svg
-                class="euiIcon euiIcon--small"
-                focusable="false"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M2 14.01h12.49a.5.5 0 1 1 0 1h-13a.5.5 0 0 1-.49-.597V1.5a.5.5 0 0 1 1 0v12.51zm2.354-1.656a.5.5 0 0 1-.708-.708l8-8a.5.5 0 0 1 .708.708l-8 8zM15 5.5a.5.5 0 1 1-1 0v-3a.5.5 0 0 0-.5-.5h-3a.5.5 0 1 1 0-1h3A1.5 1.5 0 0 1 15 2.5v3z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </a>
-             
-          </p>
-        </div>
+        Create detector
       </span>
-      <div
-        class="euiSpacer euiSpacer--l"
-      />
-      <div
-        class="euiSpacer euiSpacer--s"
-      />
-      <a
-        class="euiButton euiButton--primary euiButton--fill"
-        data-test-subj="add_detector"
-        href="opendistro-anomaly-detection#/create-ad"
-      >
-        <span
-          class="euiButton__content"
-        >
-          <span
-            class="euiButton__text"
-          >
-            Create detector
-          </span>
-        </span>
-      </a>
-    </div>
-  </div>
+    </span>
+  </a>
 </div>
 `;

--- a/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
+++ b/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { EuiPageHeader, EuiTitle } from '@elastic/eui';
+export const DashboardHeader = () => {
+  return (
+    <EuiPageHeader>
+      <EuiTitle size="l">
+        <h1>Dashboard</h1>
+      </EuiTitle>
+    </EuiPageHeader>
+  );
+};

--- a/public/pages/Dashboard/Components/utils/SideBar.tsx
+++ b/public/pages/Dashboard/Components/utils/SideBar.tsx
@@ -1,11 +1,6 @@
 import { APP_PATH } from '../../../../utils/constants';
 import React, { Component } from 'react';
-import {
-  EuiSideNav,
-  EuiPageSideBar,
-  EuiPageHeader,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiSideNav, EuiPageSideBar } from '@elastic/eui';
 
 type SideBarState = {
   selectedItemName: string;
@@ -62,13 +57,3 @@ export class SideBar extends Component<{}, SideBarState> {
     );
   }
 }
-
-export const DashboardHeader = () => {
-  return (
-    <EuiPageHeader>
-      <EuiTitle size="l">
-        <h1>Dashboard</h1>
-      </EuiTitle>
-    </EuiPageHeader>
-  );
-};

--- a/public/pages/Dashboard/Components/utils/common.tsx
+++ b/public/pages/Dashboard/Components/utils/common.tsx
@@ -1,0 +1,74 @@
+import { APP_PATH } from '../../../../utils/constants';
+import React, { Component } from 'react';
+import {
+  EuiSideNav,
+  EuiPageSideBar,
+  EuiPageHeader,
+  EuiTitle,
+} from '@elastic/eui';
+
+type SideBarState = {
+  selectedItemName: string;
+};
+
+export class SideBar extends Component<{}, SideBarState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      selectedItemName: 'Lion stuff',
+    };
+  }
+
+  selectItem = (name: string) => {
+    this.setState({
+      selectedItemName: name,
+    });
+  };
+
+  createItem = (name: string, id: number, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      ...data,
+      id: name,
+      name,
+      isSelected: this.state.selectedItemName === name,
+      onClick: () => this.selectItem(name),
+    };
+  };
+
+  render() {
+    const sideNav = [
+      {
+        name: 'Anomaly detection',
+        id: 0,
+        items: [
+          this.createItem('Dashboard', 1, { href: `#${APP_PATH.DASHBOARD}` }),
+          this.createItem('Detectors', 2, {
+            href: `#${APP_PATH.LIST_DETECTORS}`,
+          }),
+        ],
+      },
+    ];
+
+    return (
+      <EuiPageSideBar
+        style={{
+          flex: 1,
+          backgroundColor: '#F5F7FA',
+        }}
+      >
+        <EuiSideNav style={{ width: 150 }} items={sideNav} />
+      </EuiPageSideBar>
+    );
+  }
+}
+
+export const DashboardHeader = () => {
+  return (
+    <EuiPageHeader>
+      <EuiTitle size="l">
+        <h1>Dashboard</h1>
+      </EuiTitle>
+    </EuiPageHeader>
+  );
+};

--- a/public/pages/Dashboard/Container/Dashboard.tsx
+++ b/public/pages/Dashboard/Container/Dashboard.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import React, { useEffect, useCallback, useState } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from '../../../redux/reducers';
 import { getDetectorList } from '../../../redux/reducers/ad';
@@ -24,10 +24,16 @@ import {
   EuiTitle,
   EuiPageHeader,
   EuiPage,
+  EuiPageBody,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
+import { SideBar } from '../Components/utils/SideBar';
+import { DashboardHeader } from '../Components/utils/DashboardHeader';
 
 export const Dashboard = () => {
   const dispatch = useDispatch();
+
+  const isLoading = useSelector((state: AppState) => state.ad.requesting);
 
   // useCallBack ensures we don't recreate the funciton
   const onRefreshPage = useCallback(
@@ -48,21 +54,38 @@ export const Dashboard = () => {
     (state: AppState) => state.ad.totalDetectors
   );
 
+  // onRefreshPage is called whenever onRefreshPage funciton is recreated
   useEffect(() => {
     onRefreshPage();
-  });
+  }, [onRefreshPage]);
 
-  return totalDetectors == 0 ? (
-    <EmptyDashboard />
-  ) : (
-    <EuiPage>
-      <EuiPageHeader>
-        <EuiPageHeaderSection>
-          <EuiTitle size="l">
-            <h1>Page under construction</h1>
-          </EuiTitle>
-        </EuiPageHeaderSection>
-      </EuiPageHeader>
+  return (
+    <EuiPage style={{ flex: 1 }}>
+      <SideBar />
+      <EuiPageBody>
+        <DashboardHeader />
+        {isLoading == true ? (
+          <div>
+            <EuiLoadingSpinner size="s" />
+            &nbsp;&nbsp;
+            <EuiLoadingSpinner size="m" />
+            &nbsp;&nbsp;
+            <EuiLoadingSpinner size="l" />
+            &nbsp;&nbsp;
+            <EuiLoadingSpinner size="xl" />
+          </div>
+        ) : totalDetectors == 0 ? (
+          <EmptyDashboard />
+        ) : (
+          <EuiPageHeader>
+            <EuiPageHeaderSection>
+              <EuiTitle size="l">
+                <h1>Page under construction</h1>
+              </EuiTitle>
+            </EuiPageHeaderSection>
+          </EuiPageHeader>
+        )}
+      </EuiPageBody>
     </EuiPage>
   );
 };

--- a/public/pages/Dashboard/Container/Dashboard.tsx
+++ b/public/pages/Dashboard/Container/Dashboard.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { useEffect, useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppState } from '../../../redux/reducers';
+import { getDetectorList } from '../../../redux/reducers/ad';
+import { SORT_DIRECTION } from '../../../../server/utils/constants';
+import { EmptyDashboard } from '../Components/EmptyDashboard/EmptyDashboard';
+import {
+  EuiPageHeaderSection,
+  EuiTitle,
+  EuiPageHeader,
+  EuiPage,
+} from '@elastic/eui';
+
+export const Dashboard = () => {
+  const dispatch = useDispatch();
+
+  // useCallBack ensures we don't recreate the funciton
+  const onRefreshPage = useCallback(
+    () =>
+      dispatch(
+        getDetectorList({
+          from: 0,
+          size: 1,
+          search: '',
+          sortDirection: SORT_DIRECTION.DESC,
+          sortField: 'name',
+        })
+      ),
+    []
+  );
+
+  const totalDetectors = useSelector(
+    (state: AppState) => state.ad.totalDetectors
+  );
+
+  useEffect(() => {
+    onRefreshPage();
+  });
+
+  return totalDetectors == 0 ? (
+    <EmptyDashboard />
+  ) : (
+    <EuiPage>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>Page under construction</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
+    </EuiPage>
+  );
+};

--- a/public/pages/Dashboard/Container/__tests__/Dashboard.test.tsx
+++ b/public/pages/Dashboard/Container/__tests__/Dashboard.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { render, wait } from '@testing-library/react';
+import { Dashboard } from '../Dashboard';
+import { Provider } from 'react-redux';
+import { MemoryRouter as Router, Route, Switch } from 'react-router-dom';
+import configureStore from '../../../../redux/configureStore';
+import { httpClientMock } from '../../../../../test/mocks';
+import moment from 'moment';
+
+const renderWithRouter = () => ({
+  ...render(
+    <Provider store={configureStore(httpClientMock)}>
+      <Router>
+        <Switch>
+          <Route render={() => <Dashboard />} />
+        </Switch>
+      </Router>
+    </Provider>
+  ),
+});
+
+describe('Dashboard test', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('Empty results', () => {
+    test('should display empty dashboard when there is no detector', async () => {
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        data: { ok: true, response: { detectorList: [], totalDetectors: 0 } },
+      });
+      const { getByText } = renderWithRouter();
+      await wait();
+      getByText('Create detector first to detect anomalies in your data.');
+    });
+    // There are some trouble fixing dynamic import will fix this later
+    test('should not display empty dashboard if there are detector', async () => {
+      const randomDetectors = new Array(40).fill(null).map((_, index) => {
+        const hasAnomaly = Math.random() > 0.5;
+        return {
+          id: `detector_id_${index}`,
+          name: `detector_name_${index}`,
+          totalAnomalies: hasAnomaly ? Math.floor(Math.random() * 10) : 0,
+          lastActiveAnomaly: hasAnomaly ? Date.now() + index : 0,
+        };
+      });
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        data: {
+          ok: true,
+          response: {
+            detectorList: randomDetectors.slice(0, 20),
+            totalDetectors: randomDetectors.length,
+          },
+        },
+      });
+      const { getByText } = renderWithRouter();
+      await wait();
+      getByText('Page under construction');
+    });
+  });
+});

--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -20,6 +20,8 @@ import { CreateDetector } from '../createDetector';
 import { DetectorList } from '../DetectorsList';
 import { ListRouterParams } from '../DetectorsList/List/List';
 import { PreviewDetector } from '../PreviewDetector/containers/PreviewDetector';
+import { Dashboard } from '../Dashboard/Container/Dashboard';
+import { APP_PATH } from '../../utils/constants';
 
 interface MainProps {}
 
@@ -51,7 +53,12 @@ export function Main(mainProps: MainProps) {
         path="/detectors/:detectorId/features/"
         render={(props: RouteComponentProps) => <PreviewDetector {...props} />}
       />
-      <Redirect to="/detectors" />
+      <Route
+        exact
+        path={APP_PATH.DASHBOARD}
+        render={(props: RouteComponentProps) => <Dashboard />}
+      />
+      <Redirect to="/dashboard" />
     </Switch>
   );
 }

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -32,6 +32,8 @@ export const BREADCRUMBS = Object.freeze({
 
 export const APP_PATH = {
   CREATE_DETECTOR: '/create-ad',
+  DASHBOARD: '/dashboard',
+  LIST_DETECTORS: '/list-detectors',
 };
 export const PLUGIN_NAME = 'opendistro-anomaly-detection';
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

<img width="1224" alt="Screen Shot 2020-03-22 at 9 13 19 PM" src="https://user-images.githubusercontent.com/5303417/77280640-1f021580-6c82-11ea-8bb8-f88325dc4b78.png">


The dashboard page is the first page that customers see when they click Anomaly detection in the side navigation.  If there is at least one detector, we show the detailed dashboard page. Otherwise, we show an empty dashboard page. This CR adds the empty dashboard page. This CR also adds logic for redirecting to a detailed or empty dashboard page.

Testing done:
- manual testing to verify the workflow
- Add snapshot unit test for the empty dashboard page.
- Add unit test for redirect logic

Note: The newly added unit tests and some other 10 test suites fail after the recent commit adds @babel/transform-runtime. Without that commit, all tests pass. Will work with the commit author to address that before pushing the PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
