### PR TITLE
Modify create/update detector page for new UI design

### DIFF
--- a/public/pages/createDetector/components/DataFilters/DataFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/DataFilter.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiHorizontalRule,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFormRow, EuiHorizontalRule, EuiSelect } from '@elastic/eui';
 import { Field, FieldProps, FormikProps } from 'formik';
 import React, { Fragment } from 'react';
-import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { getError, isInvalid, required } from '../../../../utils/utils';
 import { ADFormikValues } from '../../containers/models/interfaces';
 import { FILTER_TYPES_OPTIONS } from './utils/constant';
@@ -36,53 +28,46 @@ interface DataFilterProps {
 
 function DataFilter(props: DataFilterProps) {
   return (
-    <ContentPanel
-      title="Data filter"
-      titleSize="s"
-      panelStyles={{ paddingBottom: '0px' }}
-      bodyStyles={{ padding: '0px' }}
-      horizontalRuleClassName={'filters-panel'}
-    >
-      <Fragment>
-        <Field name={`filterType`} validate={required}>
-          {({ field, form }: FieldProps) => (
-            <Fragment>
-              <EuiFlexGroup direction="column" style={{ padding: '10px' }}>
-                <EuiFlexItem style={{ marginBottom: '0' }}>
-                  <EuiFormRow>
-                    <EuiText size="s">
-                      Filters let you choose a subset of data from your data
-                      source. Make a simple filter, or use the Elasticsearch
-                      Query DSL for advanced filters.
-                    </EuiText>
-                  </EuiFormRow>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiFormRow
-                    label="Filter type"
-                    isInvalid={isInvalid(field.name, form)}
-                    error={getError(field.name, form)}
-                  >
-                    <EuiSelect
-                      {...field}
-                      options={FILTER_TYPES_OPTIONS}
-                      isInvalid={isInvalid(field.name, form)}
-                    />
-                  </EuiFormRow>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiHorizontalRule margin="none" />
-              {field.value === FILTER_TYPES.SIMPLE ? (
-                <SimpleFilter formikProps={props.formikProps} />
-              ) : (
-                <QueryDataFilter />
-              )}
-            </Fragment>
+    <Field name={`filterType`} validate={required}>
+      {({ field, form }: FieldProps) => (
+        <Fragment>
+          <EuiFormRow
+            fullWidth
+            label={
+              <div>
+                <p>
+                  Data fiter
+                  <span className="optional">- optional</span>
+                </p>
+                <p className="sublabel">
+                  Choose a subset of your data source to focus your data stream
+                  and reduce noisy data.
+                </p>
+                <p className="sublabel">
+                  Use the visual editor to create a simple filter, or use the
+                  Elasticsearch query DSL to create more advanced filters.
+                </p>
+              </div>
+            }
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiSelect
+              {...field}
+              options={FILTER_TYPES_OPTIONS}
+              isInvalid={isInvalid(field.name, form)}
+            />
+          </EuiFormRow>
+          <EuiHorizontalRule margin="none" />
+          {field.value === FILTER_TYPES.SIMPLE ? (
+            <SimpleFilter formikProps={props.formikProps} />
+          ) : (
+            <QueryDataFilter />
           )}
-        </Field>
-      </Fragment>
-    </ContentPanel>
+        </Fragment>
+      )}
+    </Field>
   );
 }
 
-export { DataFilter };
+export { DataFilter, DataFilterProps };

--- a/public/pages/createDetector/components/DataFilters/DataFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/DataFilter.tsx
@@ -22,6 +22,7 @@ import { FILTER_TYPES_OPTIONS } from './utils/constant';
 import { SimpleFilter } from './SimpleFilter';
 import { QueryDataFilter } from './QueryDataFilter';
 import { FILTER_TYPES } from '../../../../models/interfaces';
+import { FormattedFormRow } from '../FormattedFormRow/FormattedFormRow';
 interface DataFilterProps {
   formikProps: FormikProps<ADFormikValues>;
 }
@@ -31,24 +32,18 @@ function DataFilter(props: DataFilterProps) {
     <Field name={`filterType`} validate={required}>
       {({ field, form }: FieldProps) => (
         <Fragment>
-          <EuiFormRow
+          <FormattedFormRow
             fullWidth
-            label={
-              <div>
-                <p>
-                  Data fiter
-                  <span className="optional">- optional</span>
-                </p>
-                <p className="sublabel">
-                  Choose a subset of your data source to focus your data stream
-                  and reduce noisy data.
-                </p>
-                <p className="sublabel">
-                  Use the visual editor to create a simple filter, or use the
-                  Elasticsearch query DSL to create more advanced filters.
-                </p>
-              </div>
+            formattedTitle={
+              <p>
+                Data fiter
+                <span className="optional">- optional</span>
+              </p>
             }
+            hint={[
+              'Choose a subset of your data source to focus your data stream and reduce noisy data.',
+              'Use the visual editor to create a simple filter, or use the Elasticsearch query DSL to create more advanced filters.',
+            ]}
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -57,7 +52,7 @@ function DataFilter(props: DataFilterProps) {
               options={FILTER_TYPES_OPTIONS}
               isInvalid={isInvalid(field.name, form)}
             />
-          </EuiFormRow>
+          </FormattedFormRow>
           <EuiHorizontalRule margin="none" />
           {field.value === FILTER_TYPES.SIMPLE ? (
             <SimpleFilter formikProps={props.formikProps} />

--- a/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
@@ -17,13 +17,14 @@ import {
   EuiAccordion,
   EuiButton,
   EuiComboBox,
-  EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
   EuiHorizontalRule,
   EuiSelect,
   EuiPanel,
+  EuiText,
+  EuiSpacer,
 } from '@elastic/eui';
 import {
   Field,
@@ -61,19 +62,16 @@ export const SimpleFilter = (props: DataFilterProps) => {
   const darkMode = darkModeEnabled();
   const selectedIndices = get(props, 'formikProps.values.index[0].label', '');
   //Reset, if selectedIndices change filter could become invalid
-  useEffect(
-    () => {
-      const initialIndex = get(
-        props,
-        'formikProps.initialValues.index[0].label',
-        undefined
-      );
-      if (initialIndex !== selectedIndices) {
-        props.formikProps.setFieldValue('filters', []);
-      }
-    },
-    [selectedIndices]
-  );
+  useEffect(() => {
+    const initialIndex = get(
+      props,
+      'formikProps.initialValues.index[0].label',
+      undefined
+    );
+    if (initialIndex !== selectedIndices) {
+      props.formikProps.setFieldValue('filters', []);
+    }
+  }, [selectedIndices]);
   const lightModeStyles = {
     backgroundColor: '#F6F6F6',
   };
@@ -209,15 +207,19 @@ export const SimpleFilter = (props: DataFilterProps) => {
               );
             })}
             {values.filters.length === 0 ? (
-              <EuiEmptyPrompt
-                body={
-                  <p>
-                    You can optionally create filters to focus your data stream
-                    and reduce noisy data.
+              <div className="no-data-filter-rectangle">
+                <EuiText>
+                  <p className="no-data-filter-title">No data filter</p>
+                </EuiText>
+                <EuiSpacer size="s" />
+                <EuiText>
+                  <p className="sublabel-center">
+                    Use data filter to reduce noisy data
                   </p>
-                }
-                actions={[<AddFilterButton unshift={unshift} />]}
-              />
+                </EuiText>
+                <EuiSpacer size="s" />
+                <AddFilterButton unshift={unshift} />
+              </div>
             ) : null}
           </EuiPanel>
         </Fragment>

--- a/public/pages/createDetector/components/DataFilters/__tests__/DataFilters.test.tsx
+++ b/public/pages/createDetector/components/DataFilters/__tests__/DataFilters.test.tsx
@@ -53,9 +53,7 @@ const renderDataFilter = (initialValue: ADFormikValues) => ({
 describe('<DataFilter /> spec', () => {
   test('renders empty message if no filters are available', async () => {
     const { getByText, getAllByText } = renderDataFilter(INITIAL_VALUES);
-    getByText(
-      'You can optionally create filters to focus your data stream and reduce noisy data.'
-    );
+    getByText('Use data filter to reduce noisy data');
     expect(getAllByText('Add filter')).not.toBeNull();
     expect(getAllByText('Add filter').length).toBe(2);
   });

--- a/public/pages/createDetector/components/DetectorInfo/DetectorInfo.tsx
+++ b/public/pages/createDetector/components/DetectorInfo/DetectorInfo.tsx
@@ -13,12 +13,13 @@
  * permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiFieldText, EuiTextArea, EuiFormRow } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { getError, isInvalid } from '../../../../utils/utils';
 import { validateDetectorDesc } from './utils/validation';
+import { FormattedFormRow } from '../FormattedFormRow/FormattedFormRow';
 
 interface DetectorInfoProps {
   onValidateDetectorName: (detectorName: string) => Promise<any>;
@@ -28,16 +29,10 @@ function DetectorInfo(props: DetectorInfoProps) {
     <ContentPanel title="Name and description" titleSize="s">
       <Field name="detectorName" validate={props.onValidateDetectorName}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
-            label={
-              <div>
-                <p>Name</p>
-                <p className="sublabel">
-                  Specify a unique and descriptive name that is easy to
-                  recognize.
-                </p>
-              </div>
-            }
+          <FormattedFormRow
+            title="Name"
+            hint="Specify a unique and descriptive name that is easy to
+          recognize."
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -48,22 +43,18 @@ function DetectorInfo(props: DetectorInfoProps) {
               isInvalid={isInvalid(field.name, form)}
               {...field}
             />
-          </EuiFormRow>
+          </FormattedFormRow>
         )}
       </Field>
       <Field name="detectorDescription" validate={validateDetectorDesc}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
-            label={
-              <div>
-                <p>
-                  Description <span className="optional">- optional</span>
-                </p>
-                <p className="sublabel">
-                  Describe the purpose of the detector.
-                </p>
-              </div>
+          <FormattedFormRow
+            formattedTitle={
+              <p>
+                Description <span className="optional">- optional</span>
+              </p>
             }
+            hint="Describe the purpose of the detector."
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -75,7 +66,7 @@ function DetectorInfo(props: DetectorInfoProps) {
               {...field}
               isInvalid={isInvalid(field.name, form)}
             />
-          </EuiFormRow>
+          </FormattedFormRow>
         )}
       </Field>
     </ContentPanel>

--- a/public/pages/createDetector/components/DetectorInfo/DetectorInfo.tsx
+++ b/public/pages/createDetector/components/DetectorInfo/DetectorInfo.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFormRow, EuiText, EuiTextArea } from '@elastic/eui';
+import { EuiFieldText, EuiFormRow, EuiTextArea } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
@@ -25,23 +25,26 @@ interface DetectorInfoProps {
 }
 function DetectorInfo(props: DetectorInfoProps) {
   return (
-    <ContentPanel title="Define detector" titleSize="s">
-      <EuiFormRow>
-        <EuiText size="s">
-          To define a detector, you start by providing a name and description.
-        </EuiText>
-      </EuiFormRow>
+    <ContentPanel title="Name and description" titleSize="s">
       <Field name="detectorName" validate={props.onValidateDetectorName}>
         {({ field, form }: FieldProps) => (
           <EuiFormRow
-            label=" Detector name"
+            label={
+              <div>
+                <p>Name</p>
+                <p className="sublabel">
+                  Specify a unique and descriptive name that is easy to
+                  recognize.
+                </p>
+              </div>
+            }
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
             <EuiFieldText
               name="detectorName"
               id="detectorName"
-              placeholder="sample detector"
+              placeholder="Enter detector name"
               isInvalid={isInvalid(field.name, form)}
               {...field}
             />
@@ -51,7 +54,16 @@ function DetectorInfo(props: DetectorInfoProps) {
       <Field name="detectorDescription" validate={validateDetectorDesc}>
         {({ field, form }: FieldProps) => (
           <EuiFormRow
-            label="Description"
+            label={
+              <div>
+                <p>
+                  Description <span className="optional">- optional</span>
+                </p>
+                <p className="sublabel">
+                  Describe the purpose of the detector.
+                </p>
+              </div>
+            }
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -59,7 +71,7 @@ function DetectorInfo(props: DetectorInfoProps) {
               name="detectorDescription"
               id="detectorDescription"
               rows={3}
-              placeholder="Description for detector"
+              placeholder="Describe the detector"
               {...field}
               isInvalid={isInvalid(field.name, form)}
             />

--- a/public/pages/createDetector/components/DetectorInfo/__tests__/DetectorInfo.test.tsx
+++ b/public/pages/createDetector/components/DetectorInfo/__tests__/DetectorInfo.test.tsx
@@ -46,9 +46,9 @@ describe('<DetectorInfo /> spec', () => {
       </Formik>
     );
     expect(queryByText('Required')).toBeNull();
-    fireEvent.focus(getByPlaceholderText('sample detector'));
+    fireEvent.focus(getByPlaceholderText('Enter detector name'));
 
-    fireEvent.blur(getByPlaceholderText('sample detector'));
+    fireEvent.blur(getByPlaceholderText('Enter detector name'));
     expect(handleValidateName).toHaveBeenCalledWith('');
     expect(handleValidateName).toHaveBeenCalledTimes(1);
     expect(findByText('Required')).not.toBeNull();
@@ -67,8 +67,8 @@ describe('<DetectorInfo /> spec', () => {
       </Formik>
     );
     expect(queryByText('Required')).toBeNull();
-    fireEvent.focus(getByPlaceholderText('Description for detector'));
-    fireEvent.blur(getByPlaceholderText('Description for detector'));
+    fireEvent.focus(getByPlaceholderText('Describe the detector'));
+    fireEvent.blur(getByPlaceholderText('Describe the detector'));
     expect(findByText('Required')).not.toBeNull();
   });
 });

--- a/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
+++ b/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
         <h3
           class="euiTitle euiTitle--small"
         >
-          Define detector
+          Name and description
         </h3>
       </div>
       <div
@@ -41,23 +41,21 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
         class="euiFormRow"
         id="random_id-row"
       >
-        <div
-          class="euiText euiText--small"
-          id="random_id"
-        >
-          To define a detector, you start by providing a name and description.
-        </div>
-      </div>
-      <div
-        class="euiFormRow"
-        id="random_id-row"
-      >
         <label
           aria-invalid="false"
           class="euiFormLabel"
           for="random_id"
         >
-           Detector name
+          <div>
+            <p>
+              Name
+            </p>
+            <p
+              class="sublabel"
+            >
+              Specify a unique and descriptive name that is easy to recognize.
+            </p>
+          </div>
         </label>
         <div
           class="euiFormControlLayout"
@@ -69,7 +67,7 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
               class="euiFieldText"
               id="random_id"
               name="detectorName"
-              placeholder="sample detector"
+              placeholder="Enter detector name"
               type="text"
               value=""
             />
@@ -85,13 +83,27 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
           class="euiFormLabel"
           for="random_id"
         >
-          Description
+          <div>
+            <p>
+              Description 
+              <span
+                class="optional"
+              >
+                - optional
+              </span>
+            </p>
+            <p
+              class="sublabel"
+            >
+              Describe the purpose of the detector.
+            </p>
+          </div>
         </label>
         <textarea
           class="euiTextArea euiTextArea--resizeVertical"
           id="random_id"
           name="detectorDescription"
-          placeholder="Description for detector"
+          placeholder="Describe the detector"
           rows="3"
         />
       </div>

--- a/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
+++ b/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
@@ -39,17 +39,22 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
     >
       <div
         class="euiFormRow"
+        hint="Specify a unique and descriptive name that is easy to recognize."
         id="random_id-row"
+        title="Name"
       >
         <label
           aria-invalid="false"
           class="euiFormLabel"
           for="random_id"
         >
-          <div>
+          <div
+            style="line-height: 8px;"
+          >
             <p>
               Name
             </p>
+            <br />
             <p
               class="sublabel"
             >
@@ -76,6 +81,8 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
       </div>
       <div
         class="euiFormRow"
+        formattedtitle="[object Object]"
+        hint="Describe the purpose of the detector."
         id="random_id-row"
       >
         <label
@@ -83,7 +90,9 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
           class="euiFormLabel"
           for="random_id"
         >
-          <div>
+          <div
+            style="line-height: 8px;"
+          >
             <p>
               Description 
               <span
@@ -92,6 +101,7 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
                 - optional
               </span>
             </p>
+            <br />
             <p
               class="sublabel"
             >

--- a/public/pages/createDetector/components/DetectorInfo/utils/__tests__/validation.test.ts
+++ b/public/pages/createDetector/components/DetectorInfo/utils/__tests__/validation.test.ts
@@ -4,11 +4,6 @@ import { validateDetectorDesc } from '../validation';
 describe('validations', () => {
   describe('validateDetectorDesc', () => {
     const descriptionGenerator = new chance('seed');
-    test('should throw if empty', () => {
-      expect(() => validateDetectorDesc('')).toThrowError(
-        'Detector description can not be empty'
-      );
-    });
     test('should throw size limit if exceed  400', () => {
       expect(() =>
         validateDetectorDesc(descriptionGenerator.paragraph({ length: 500 }))

--- a/public/pages/createDetector/components/DetectorInfo/utils/validation.ts
+++ b/public/pages/createDetector/components/DetectorInfo/utils/validation.ts
@@ -19,9 +19,6 @@ import { isEmpty } from 'lodash';
 export const validateDetectorDesc = (
   description: string
 ): Error | undefined => {
-  if (isEmpty(description)) {
-    throw 'Detector description can not be empty';
-  }
   if (description.length > 400) {
     throw 'Description Should not exceed 400 characters';
   }

--- a/public/pages/createDetector/components/FormattedFormRow/FormattedFormRow.tsx
+++ b/public/pages/createDetector/components/FormattedFormRow/FormattedFormRow.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { ReactElement, ReactNode } from 'react';
+import { EuiFormRow } from '@elastic/eui';
+
+type FormattedFormRowProps = {
+  title?: string;
+  formattedTitle?: ReactNode;
+  children: ReactElement;
+  hint?: string | string[];
+  isInvalid?: boolean;
+  error?: ReactNode | ReactNode[];
+  fullWidth?: boolean;
+  helpText?: string;
+};
+
+export const FormattedFormRow = (props: FormattedFormRowProps) => {
+  let hints;
+  if (props.hint) {
+    const hintTexts = Array.isArray(props.hint) ? props.hint : [props.hint];
+    hints = hintTexts.map((hint, i) => {
+      return <p className="sublabel">{hint}</p>;
+    });
+  }
+
+  return (
+    <EuiFormRow
+      label={
+        <div style={{ lineHeight: '8px' }}>
+          {props.formattedTitle ? props.formattedTitle : <p>{props.title}</p>}
+          <br />
+          {hints}
+        </div>
+      }
+      {...props}
+    >
+      {props.children}
+    </EuiFormRow>
+  );
+};

--- a/public/pages/createDetector/components/Settings/Settings.tsx
+++ b/public/pages/createDetector/components/Settings/Settings.tsx
@@ -16,7 +16,6 @@
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import {
   EuiFieldNumber,
-  EuiFormRow,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -29,6 +28,7 @@ import {
   validatePositiveInteger,
   validateNonNegativeInteger,
 } from '../../../../utils/utils';
+import { FormattedFormRow } from '../FormattedFormRow/FormattedFormRow';
 
 export const Settings = () => {
   return (
@@ -37,22 +37,16 @@ export const Settings = () => {
         {({ field, form }: FieldProps) => (
           <EuiFlexGroup>
             <EuiFlexItem style={{ maxWidth: '70%' }}>
-              <EuiFormRow
+              <FormattedFormRow
                 fullWidth
-                label={
-                  <div>
-                    <p>Detector interval</p>
-                    <p className="sublabel">
-                      Define how often the detector collects data to generate
-                      anomalies. The shorter the interval is, the more real time
-                      the detector results will be. The detector interval,
-                      together with data ingestion speed, also determines the
-                      preparation time of the detector. Long intervals and slow
-                      ingestion speed means the detector takes longer time to
-                      collect sufficient data to generate anomalies.
-                    </p>
-                  </div>
-                }
+                title="Detector interval"
+                hint="Define how often the detector collects data to generate
+                anomalies. The shorter the interval is, the more real time
+                the detector results will be. The detector interval,
+                together with data ingestion speed, also determines the
+                preparation time of the detector. Long intervals and slow
+                ingestion speed means the detector takes longer time to
+                collect sufficient data to generate anomalies."
                 isInvalid={isInvalid(field.name, form)}
                 error={getError(field.name, form)}
               >
@@ -72,24 +66,18 @@ export const Settings = () => {
                     </EuiText>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-              </EuiFormRow>
+              </FormattedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
         )}
       </Field>
       <Field name="windowDelay" validate={validateNonNegativeInteger}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <FormattedFormRow
             fullWidth
-            label={
-              <div>
-                <p>Window delay</p>
-                <p className="sublabel">
-                  Specify a window of delay for a detector to fetch data, if you
-                  need to account for extra processing time.
-                </p>
-              </div>
-            }
+            title="Window delay"
+            hint="Specify a window of delay for a detector to fetch data, if you
+            need to account for extra processing time."
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -109,7 +97,7 @@ export const Settings = () => {
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
-          </EuiFormRow>
+          </FormattedFormRow>
         )}
       </Field>
     </ContentPanel>

--- a/public/pages/createDetector/components/Settings/Settings.tsx
+++ b/public/pages/createDetector/components/Settings/Settings.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+import {
+  EuiFieldNumber,
+  EuiFormRow,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+} from '@elastic/eui';
+import { Field, FieldProps } from 'formik';
+import React from 'react';
+import {
+  isInvalid,
+  getError,
+  validatePositiveInteger,
+  validateNonNegativeInteger,
+} from '../../../../utils/utils';
+
+export const Settings = () => {
+  return (
+    <ContentPanel title="Detector operation settings" titleSize="s">
+      <Field name="detectionInterval" validate={validatePositiveInteger}>
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            fullWidth
+            label={
+              <div>
+                <p>Detector interval</p>
+                <p className="sublabel">
+                  Define how often the detector collects data to generate
+                  anomalies. The shorter the interval is, the more real time the
+                  detector results will be. The detector interval, together with
+                  data ingestion speed, also determines the preparation time of
+                  the detector. Long intervals and slow ingestion speed means
+                  the detector takes longer time to collect sufficient data to
+                  generate anomalies.
+                </p>
+              </div>
+            }
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiFieldNumber
+                  name="detectionInterval"
+                  id="detectionInterval"
+                  placeholder="Detector interval"
+                  data-test-subj="detectionInterval"
+                  {...field}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText>
+                  <p className="minutes">minutes</p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFormRow>
+        )}
+      </Field>
+      <Field name="windowDelay" validate={validateNonNegativeInteger}>
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            fullWidth
+            label={
+              <div>
+                <p>Window delay</p>
+                <p className="sublabel">
+                  Specify a window of delay for a detector to fetch data, if you
+                  need to account for extra processing time.
+                </p>
+              </div>
+            }
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiFieldNumber
+                  name="windowDelay"
+                  id="windowDelay"
+                  placeholder="Window delay"
+                  data-test-subj="windowDelay"
+                  {...field}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText>
+                  <p className="minutes">minutes</p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFormRow>
+        )}
+      </Field>
+    </ContentPanel>
+  );
+};

--- a/public/pages/createDetector/components/Settings/Settings.tsx
+++ b/public/pages/createDetector/components/Settings/Settings.tsx
@@ -35,42 +35,46 @@ export const Settings = () => {
     <ContentPanel title="Detector operation settings" titleSize="s">
       <Field name="detectionInterval" validate={validatePositiveInteger}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
-            fullWidth
-            label={
-              <div>
-                <p>Detector interval</p>
-                <p className="sublabel">
-                  Define how often the detector collects data to generate
-                  anomalies. The shorter the interval is, the more real time the
-                  detector results will be. The detector interval, together with
-                  data ingestion speed, also determines the preparation time of
-                  the detector. Long intervals and slow ingestion speed means
-                  the detector takes longer time to collect sufficient data to
-                  generate anomalies.
-                </p>
-              </div>
-            }
-            isInvalid={isInvalid(field.name, form)}
-            error={getError(field.name, form)}
-          >
-            <EuiFlexGroup gutterSize="s" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiFieldNumber
-                  name="detectionInterval"
-                  id="detectionInterval"
-                  placeholder="Detector interval"
-                  data-test-subj="detectionInterval"
-                  {...field}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiText>
-                  <p className="minutes">minutes</p>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFormRow>
+          <EuiFlexGroup>
+            <EuiFlexItem style={{ maxWidth: '70%' }}>
+              <EuiFormRow
+                fullWidth
+                label={
+                  <div>
+                    <p>Detector interval</p>
+                    <p className="sublabel">
+                      Define how often the detector collects data to generate
+                      anomalies. The shorter the interval is, the more real time
+                      the detector results will be. The detector interval,
+                      together with data ingestion speed, also determines the
+                      preparation time of the detector. Long intervals and slow
+                      ingestion speed means the detector takes longer time to
+                      collect sufficient data to generate anomalies.
+                    </p>
+                  </div>
+                }
+                isInvalid={isInvalid(field.name, form)}
+                error={getError(field.name, form)}
+              >
+                <EuiFlexGroup gutterSize="s" alignItems="center">
+                  <EuiFlexItem grow={false}>
+                    <EuiFieldNumber
+                      name="detectionInterval"
+                      id="detectionInterval"
+                      placeholder="Detector interval"
+                      data-test-subj="detectionInterval"
+                      {...field}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiText>
+                      <p className="minutes">minutes</p>
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         )}
       </Field>
       <Field name="windowDelay" validate={validateNonNegativeInteger}>

--- a/public/pages/createDetector/components/createDetector.scss
+++ b/public/pages/createDetector/components/createDetector.scss
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+$font-stack: Helvetica Neue, Helvetica, Arial, sans-serif;
+
+.optional {
+  color: #16191f;
+  font-size: 12px;
+  line-height: 16px;
+  line-height: 16px;
+  font-family: $font-stack;
+  text-align: left;
+  font-style: oblique;
+  font-weight: normal;
+}
+
+@mixin mixin_sublabel($align) {
+  color: #69707d;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: normal;
+  font-family: $font-stack;
+  text-align: $align;
+}
+
+.sublabel {
+  @include mixin_sublabel(left);
+}
+
+.sublabel-center {
+  @include mixin_sublabel(center);
+}
+
+.no-data-filter-rectangle {
+  text-align: center;
+  margin: auto;
+}
+
+.no-data-filter-title {
+  color: #69707d;
+  font-family: $font-stack;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 17px;
+  text-align: center;
+}
+
+.minutes {
+  height: 17px;
+  width: 62px;
+  color: #16191f;
+  font-family: $font-stack;
+  font-size: 14px;
+  letter-spacing: -0.07px;
+  line-height: 17px;
+}

--- a/public/pages/createDetector/components/createDetector.scss
+++ b/public/pages/createDetector/components/createDetector.scss
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-$font-stack: Helvetica Neue, Helvetica, Arial, sans-serif;
+$font-stack: Helvetica;
 
 .optional {
   color: #16191f;

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -115,8 +115,6 @@ export function CreateDetector(props: CreateADProps) {
   };
 
   const handleSubmit = async (values: ADFormikValues, formikBag: any) => {
-    console.log('hello');
-    console.log(values);
     const apiRequest = formikToDetector(values, detector);
     try {
       if (props.isEdit) {

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -43,7 +43,6 @@ import {
 } from '../../../redux/reducers/ad';
 import { BREADCRUMBS } from '../../../utils/constants';
 import { getErrorMessage } from '../../../utils/utils';
-import { DataFilter } from '../components/DataFilters';
 import { DetectorInfo } from '../components/DetectorInfo';
 import { useFetchDetectorInfo } from '../hooks/useFetchDetectorInfo';
 import { DataSource } from './DataSource/index';
@@ -51,6 +50,7 @@ import { ADFormikValues } from './models/interfaces';
 import { detectorToFormik } from './utils/detectorToFormik';
 import { formikToDetector } from './utils/formikToDetector';
 import { Detector } from '../../../models/interfaces';
+import { Settings } from '../components/Settings/Settings';
 
 interface CreateRouterProps {
   detectorId?: string;
@@ -78,15 +78,12 @@ export function CreateDetector(props: CreateADProps) {
     ]);
   });
   // If no detector found with ID, redirect it to list
-  useEffect(
-    () => {
-      if (props.isEdit && hasError) {
-        toastNotifications.addDanger('Unable to find detector for edit');
-        props.history.push(`/detectors`);
-      }
-    },
-    [props.isEdit]
-  );
+  useEffect(() => {
+    if (props.isEdit && hasError) {
+      toastNotifications.addDanger('Unable to find detector for edit');
+      props.history.push(`/detectors`);
+    }
+  }, [props.isEdit]);
 
   const handleUpdate = async (detectorToBeUpdated: Detector) => {
     try {
@@ -118,6 +115,8 @@ export function CreateDetector(props: CreateADProps) {
   };
 
   const handleSubmit = async (values: ADFormikValues, formikBag: any) => {
+    console.log('hello');
+    console.log(values);
     const apiRequest = formikToDetector(values, detector);
     try {
       if (props.isEdit) {
@@ -187,9 +186,9 @@ export function CreateDetector(props: CreateADProps) {
             <Fragment>
               <DetectorInfo onValidateDetectorName={handleValidateName} />
               <EuiSpacer />
-              <DataSource />
+              <DataSource formikProps={formikProps} />
               <EuiSpacer />
-              <DataFilter formikProps={formikProps} />
+              <Settings />
               <EuiSpacer />
               <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
                 <EuiFlexItem grow={false}>
@@ -205,7 +204,7 @@ export function CreateDetector(props: CreateADProps) {
                     //@ts-ignore
                     onClick={formikProps.handleSubmit}
                   >
-                    {props.isEdit ? 'Update' : 'Create'}
+                    {props.isEdit ? 'Save change' : 'Create'}
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -13,10 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import { EuiComboBox, EuiFormRow, EuiSelect, EuiText } from '@elastic/eui';
+import { EuiComboBox, EuiFormRow, EuiSelect } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import { debounce, get } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { CatIndex, IndexAlias } from '../../../../../server/models/types';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
@@ -30,8 +30,12 @@ import { getError, isInvalid, required } from '../../../../utils/utils';
 import { IndexOption } from '../../components/Datasource/IndexOption';
 import { getVisibleOptions, sanitizeSearchText } from './utils/helpers';
 import { validateIndex } from './utils/validate';
+import {
+  DataFilterProps,
+  DataFilter,
+} from '../../components/DataFilters/DataFilter';
 
-function DataSource() {
+function DataSource(props: DataFilterProps) {
   const dispatch = useDispatch();
   const [queryText, setQueryText] = useState('');
   const elasticsearchState = useSelector(
@@ -71,17 +75,19 @@ function DataSource() {
   const visibleAliases = get(elasticsearchState, 'aliases', []) as IndexAlias[];
 
   return (
-    <ContentPanel title="Datasource" titleSize="s">
-      <EuiFormRow>
-        <EuiText size="s">
-          Anomaly detector uses an index or an index pattern as the datasource.
-        </EuiText>
-      </EuiFormRow>
+    <ContentPanel title="Data Source" titleSize="s">
       <Field name="index" validate={validateIndex}>
         {({ field, form }: FieldProps) => {
           return (
             <EuiFormRow
-              label="Index"
+              label={
+                <div>
+                  <p>Index</p>
+                  <p className="sublabel">
+                    Choose an index or index pattern as the data source.
+                  </p>
+                </div>
+              }
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
               helpText="You can use a wildcard (*) in your index pattern"
@@ -125,20 +131,27 @@ function DataSource() {
       <Field name="timeField" validate={required}>
         {({ field, form }: FieldProps) => (
           <EuiFormRow
-            label="Timestamp field"
+            label={
+              <div>
+                <p>Timestamp field</p>
+                <p className="sublabel">
+                  Choose the time field you want to use for time filter.
+                </p>
+              </div>
+            }
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
-            helpText="Choose the time field you want to use for time filter"
           >
             <EuiSelect
               {...field}
               id="timeField"
-              placeholder="Choose timestamp field"
+              placeholder="Find timestamp"
               options={timeStampFieldOptions}
             />
           </EuiFormRow>
         )}
       </Field>
+      <DataFilter formikProps={props.formikProps} />
     </ContentPanel>
   );
 }

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -34,6 +34,7 @@ import {
   DataFilterProps,
   DataFilter,
 } from '../../components/DataFilters/DataFilter';
+import { FormattedFormRow } from '../../components/FormattedFormRow/FormattedFormRow';
 
 function DataSource(props: DataFilterProps) {
   const dispatch = useDispatch();
@@ -79,15 +80,9 @@ function DataSource(props: DataFilterProps) {
       <Field name="index" validate={validateIndex}>
         {({ field, form }: FieldProps) => {
           return (
-            <EuiFormRow
-              label={
-                <div>
-                  <p>Index</p>
-                  <p className="sublabel">
-                    Choose an index or index pattern as the data source.
-                  </p>
-                </div>
-              }
+            <FormattedFormRow
+              title="Index"
+              hint="Choose an index or index pattern as the data source."
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
               helpText="You can use a wildcard (*) in your index pattern"
@@ -124,21 +119,15 @@ function DataSource(props: DataFilterProps) {
                   />
                 )}
               />
-            </EuiFormRow>
+            </FormattedFormRow>
           );
         }}
       </Field>
       <Field name="timeField" validate={required}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
-            label={
-              <div>
-                <p>Timestamp field</p>
-                <p className="sublabel">
-                  Choose the time field you want to use for time filter.
-                </p>
-              </div>
-            }
+          <FormattedFormRow
+            title="Timestamp field"
+            hint="Choose the time field you want to use for time filter."
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
@@ -148,7 +137,7 @@ function DataSource(props: DataFilterProps) {
               placeholder="Find timestamp"
               options={timeStampFieldOptions}
             />
-          </EuiFormRow>
+          </FormattedFormRow>
         )}
       </Field>
       <DataFilter formikProps={props.formikProps} />

--- a/public/pages/createDetector/containers/__tests__/CreateDetector.test.tsx
+++ b/public/pages/createDetector/containers/__tests__/CreateDetector.test.tsx
@@ -29,6 +29,7 @@ import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
 import configureStore from '../../../../redux/configureStore';
 import { httpClientMock } from '../../../../../test/mocks';
 import userEvent from '@testing-library/user-event';
+import { UNITS } from '../../../../models/interfaces';
 
 const renderWithRouter = (isEdit: boolean = false) => ({
   ...render(
@@ -96,12 +97,12 @@ describe('<CreateDetector /> spec', () => {
         },
       });
       const { getByPlaceholderText, getByText } = renderWithRouter();
-      fireEvent.focus(getByPlaceholderText('sample detector'));
+      fireEvent.focus(getByPlaceholderText('Enter detector name'));
       userEvent.type(
-        getByPlaceholderText('sample detector'),
+        getByPlaceholderText('Enter detector name'),
         randomDetector.name
       );
-      fireEvent.blur(getByPlaceholderText('sample detector'));
+      fireEvent.blur(getByPlaceholderText('Enter detector name'));
       await wait(() => {
         getByText('Duplicate detector name');
       });

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -535,61 +535,70 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
         style="padding: 0px 10px;"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="random_id-row"
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <label
-            aria-invalid="false"
-            class="euiFormLabel"
-            for="random_id"
-          >
-            <div>
-              <p>
-                Detector interval
-              </p>
-              <p
-                class="sublabel"
-              >
-                Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be. The detector interval, together with data ingestion speed, also determines the preparation time of the detector. Long intervals and slow ingestion speed means the detector takes longer time to collect sufficient data to generate anomalies.
-              </p>
-            </div>
-          </label>
           <div
-            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            id="random_id"
+            class="euiFlexItem"
+            style="max-width: 70%;"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFormRow euiFormRow--fullWidth"
+              id="random_id-row"
             >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel"
+                for="random_id"
+              >
+                <div>
+                  <p>
+                    Detector interval
+                  </p>
+                  <p
+                    class="sublabel"
+                  >
+                    Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be. The detector interval, together with data ingestion speed, also determines the preparation time of the detector. Long intervals and slow ingestion speed means the detector takes longer time to collect sufficient data to generate anomalies.
+                  </p>
+                </div>
+              </label>
               <div
-                class="euiFormControlLayout"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                id="random_id"
               >
                 <div
-                  class="euiFormControlLayout__childrenWrapper"
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <input
-                    class="euiFieldNumber"
-                    data-test-subj="detectionInterval"
-                    id="detectionInterval"
-                    name="detectionInterval"
-                    placeholder="Detector interval"
-                    type="number"
-                    value="10"
-                  />
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <input
+                        class="euiFieldNumber"
+                        data-test-subj="detectionInterval"
+                        id="detectionInterval"
+                        name="detectionInterval"
+                        placeholder="Detector interval"
+                        type="number"
+                        value="10"
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiText euiText--medium"
-              >
-                <p
-                  class="minutes"
+                <div
+                  class="euiFlexItem"
                 >
-                  minutes
-                </p>
+                  <div
+                    class="euiText euiText--medium"
+                  >
+                    <p
+                      class="minutes"
+                    >
+                      minutes
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           <h3
             class="euiTitle euiTitle--small"
           >
-            Define detector
+            Name and description
           </h3>
         </div>
         <div
@@ -60,23 +60,21 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           class="euiFormRow"
           id="random_id-row"
         >
-          <div
-            class="euiText euiText--small"
-            id="random_id"
-          >
-            To define a detector, you start by providing a name and description.
-          </div>
-        </div>
-        <div
-          class="euiFormRow"
-          id="random_id-row"
-        >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-             Detector name
+            <div>
+              <p>
+                Name
+              </p>
+              <p
+                class="sublabel"
+              >
+                Specify a unique and descriptive name that is easy to recognize.
+              </p>
+            </div>
           </label>
           <div
             class="euiFormControlLayout"
@@ -88,7 +86,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
                 class="euiFieldText"
                 id="random_id"
                 name="detectorName"
-                placeholder="sample detector"
+                placeholder="Enter detector name"
                 type="text"
                 value=""
               />
@@ -104,13 +102,27 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
             class="euiFormLabel"
             for="random_id"
           >
-            Description
+            <div>
+              <p>
+                Description 
+                <span
+                  class="optional"
+                >
+                  - optional
+                </span>
+              </p>
+              <p
+                class="sublabel"
+              >
+                Describe the purpose of the detector.
+              </p>
+            </div>
           </label>
           <textarea
             class="euiTextArea euiTextArea--resizeVertical"
             id="random_id"
             name="detectorDescription"
-            placeholder="Description for detector"
+            placeholder="Describe the detector"
             rows="3"
           />
         </div>
@@ -133,7 +145,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           <h3
             class="euiTitle euiTitle--small"
           >
-            Datasource
+            Data Source
           </h3>
         </div>
         <div
@@ -158,23 +170,21 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           class="euiFormRow"
           id="random_id-row"
         >
-          <div
-            class="euiText euiText--small"
-            id="random_id"
-          >
-            Anomaly detector uses an index or an index pattern as the datasource.
-          </div>
-        </div>
-        <div
-          class="euiFormRow"
-          id="random_id-row"
-        >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-            Index
+            <div>
+              <p>
+                Index
+              </p>
+              <p
+                class="sublabel"
+              >
+                Choose an index or index pattern as the data source.
+              </p>
+            </div>
           </label>
           <div
             aria-describedby="random_id-help"
@@ -265,7 +275,16 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
             class="euiFormLabel"
             for="random_id"
           >
-            Timestamp field
+            <div>
+              <p>
+                Timestamp field
+              </p>
+              <p
+                class="sublabel"
+              >
+                Choose the time field you want to use for time filter.
+              </p>
+            </div>
           </label>
           <div
             class="euiFormControlLayout"
@@ -274,11 +293,10 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
               class="euiFormControlLayout__childrenWrapper"
             >
               <select
-                aria-describedby="random_id-help"
                 class="euiSelect"
                 id="random_id"
                 name="timeField"
-                placeholder="Choose timestamp field"
+                placeholder="Find timestamp"
               >
                 <option
                   value=""
@@ -315,139 +333,87 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
               </div>
             </div>
           </div>
-          <div
-            class="euiFormHelpText euiFormRow__text"
-            id="random_id-help"
-          >
-            Choose the time field you want to use for time filter
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
-    <div
-      class="euiPanel euiPanel--paddingMedium"
-      style="padding-left: 0px; padding-right: 0px; padding-bottom: 0px;"
-    >
-      <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style="padding: 0px 10px;"
-      >
-        <div
-          class="euiFlexItem"
-        >
-          <h3
-            class="euiTitle euiTitle--small"
-          >
-            Data filter
-          </h3>
         </div>
         <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
+          class="euiFormRow euiFormRow--fullWidth"
+          id="random_id-row"
         >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <label
+            aria-invalid="false"
+            class="euiFormLabel"
+            for="random_id"
           >
-            <div
-              class="euiFlexItem"
-            />
-          </div>
-        </div>
-      </div>
-      <hr
-        class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall filters-panel"
-      />
-      <div
-        style="padding: 0px;"
-      >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          style="padding: 10px;"
-        >
-          <div
-            class="euiFlexItem"
-            style="margin-bottom: 0px;"
-          >
-            <div
-              class="euiFormRow"
-              id="random_id-row"
-            >
-              <div
-                class="euiText euiText--small"
-                id="random_id"
-              >
-                Filters let you choose a subset of data from your data source. Make a simple filter, or use the Elasticsearch Query DSL for advanced filters.
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiFormRow"
-              id="random_id-row"
-            >
-              <label
-                aria-invalid="false"
-                class="euiFormLabel"
-                for="random_id"
-              >
-                Filter type
-              </label>
-              <div
-                class="euiFormControlLayout"
-              >
-                <div
-                  class="euiFormControlLayout__childrenWrapper"
+            <div>
+              <p>
+                Data fiter
+                <span
+                  class="optional"
                 >
-                  <select
-                    class="euiSelect"
-                    id="random_id"
-                    name="filterType"
+                  - optional
+                </span>
+              </p>
+              <p
+                class="sublabel"
+              >
+                Choose a subset of your data source to focus your data stream and reduce noisy data.
+              </p>
+              <p
+                class="sublabel"
+              >
+                Use the visual editor to create a simple filter, or use the Elasticsearch query DSL to create more advanced filters.
+              </p>
+            </div>
+          </label>
+          <div
+            class="euiFormControlLayout"
+          >
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <select
+                class="euiSelect"
+                id="random_id"
+                name="filterType"
+              >
+                <option
+                  value="simple_filter"
+                >
+                  Visual editor
+                </option>
+                <option
+                  value="custom_filter"
+                >
+                  Custom expression
+                </option>
+              </select>
+              <div
+                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+              >
+                <span
+                  class="euiFormControlLayoutCustomIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                    focusable="false"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
                   >
-                    <option
-                      value="simple_filter"
-                    >
-                      Visual editor
-                    </option>
-                    <option
-                      value="custom_filter"
-                    >
-                      Custom expression
-                    </option>
-                  </select>
-                  <div
-                    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                  >
-                    <span
-                      class="euiFormControlLayoutCustomIcon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                        focusable="false"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink"
-                      >
-                        <defs>
-                          <path
-                            d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                            id="arrow_down-a"
-                          />
-                        </defs>
-                        <use
-                          fill-rule="nonzero"
-                          xlink:href="#arrow_down-a"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </div>
+                    <defs>
+                      <path
+                        d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                        id="arrow_down-a"
+                      />
+                    </defs>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#arrow_down-a"
+                    />
+                  </svg>
+                </span>
               </div>
             </div>
           </div>
@@ -486,45 +452,204 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           style="background-color: rgb(246, 246, 246);"
         >
           <div
-            class="euiEmptyPrompt"
+            class="no-data-filter-rectangle"
           >
-            <span
-              class="euiTextColor euiTextColor--subdued"
-            >
-              <div
-                class="euiText euiText--medium"
-              >
-                <p>
-                  You can optionally create filters to focus your data stream and reduce noisy data.
-                </p>
-              </div>
-            </span>
             <div
-              class="euiSpacer euiSpacer--l"
-            />
+              class="euiText euiText--medium"
+            >
+              <p
+                class="no-data-filter-title"
+              >
+                No data filter
+              </p>
+            </div>
             <div
               class="euiSpacer euiSpacer--s"
             />
             <div
-              class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentCenter euiFlexGroup--directionColumn euiFlexGroup--responsive"
+              class="euiText euiText--medium"
+            >
+              <p
+                class="sublabel-center"
+              >
+                Use data filter to reduce noisy data
+              </p>
+            </div>
+            <div
+              class="euiSpacer euiSpacer--s"
+            />
+            <button
+              class="euiButton euiButton--primary"
+              type="button"
+            >
+              <span
+                class="euiButton__content"
+              >
+                <span
+                  class="euiButton__text"
+                >
+                  Add filter
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--l"
+    />
+    <div
+      class="euiPanel euiPanel--paddingMedium"
+      style="padding-left: 0px; padding-right: 0px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px 10px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <h3
+            class="euiTitle euiTitle--small"
+          >
+            Detector operation settings
+          </h3>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <hr
+        class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+      />
+      <div
+        style="padding: 0px 10px;"
+      >
+        <div
+          class="euiFormRow euiFormRow--fullWidth"
+          id="random_id-row"
+        >
+          <label
+            aria-invalid="false"
+            class="euiFormLabel"
+            for="random_id"
+          >
+            <div>
+              <p>
+                Detector interval
+              </p>
+              <p
+                class="sublabel"
+              >
+                Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be. The detector interval, together with data ingestion speed, also determines the preparation time of the detector. Long intervals and slow ingestion speed means the detector takes longer time to collect sufficient data to generate anomalies.
+              </p>
+            </div>
+          </label>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            id="random_id"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <div
-                class="euiFlexItem euiFlexItem--flexGrowZero"
+                class="euiFormControlLayout"
               >
-                <button
-                  class="euiButton euiButton--primary"
-                  type="button"
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
                 >
-                  <span
-                    class="euiButton__content"
-                  >
-                    <span
-                      class="euiButton__text"
-                    >
-                      Add filter
-                    </span>
-                  </span>
-                </button>
+                  <input
+                    class="euiFieldNumber"
+                    data-test-subj="detectionInterval"
+                    id="detectionInterval"
+                    name="detectionInterval"
+                    placeholder="Detector interval"
+                    type="number"
+                    value="10"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiText euiText--medium"
+              >
+                <p
+                  class="minutes"
+                >
+                  minutes
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFormRow euiFormRow--fullWidth"
+          id="random_id-row"
+        >
+          <label
+            aria-invalid="false"
+            class="euiFormLabel"
+            for="random_id"
+          >
+            <div>
+              <p>
+                Window delay
+              </p>
+              <p
+                class="sublabel"
+              >
+                Specify a window of delay for a detector to fetch data, if you need to account for extra processing time.
+              </p>
+            </div>
+          </label>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            id="random_id"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFormControlLayout"
+              >
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
+                >
+                  <input
+                    class="euiFieldNumber"
+                    data-test-subj="windowDelay"
+                    id="windowDelay"
+                    name="windowDelay"
+                    placeholder="Window delay"
+                    type="number"
+                    value="0"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiText euiText--medium"
+              >
+                <p
+                  class="minutes"
+                >
+                  minutes
+                </p>
               </div>
             </div>
           </div>

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -58,17 +58,22 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
       >
         <div
           class="euiFormRow"
+          hint="Specify a unique and descriptive name that is easy to recognize."
           id="random_id-row"
+          title="Name"
         >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Name
               </p>
+              <br />
               <p
                 class="sublabel"
               >
@@ -95,6 +100,8 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
         </div>
         <div
           class="euiFormRow"
+          formattedtitle="[object Object]"
+          hint="Describe the purpose of the detector."
           id="random_id-row"
         >
           <label
@@ -102,7 +109,9 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Description 
                 <span
@@ -111,6 +120,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
                   - optional
                 </span>
               </p>
+              <br />
               <p
                 class="sublabel"
               >
@@ -168,17 +178,22 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
       >
         <div
           class="euiFormRow"
+          hint="Choose an index or index pattern as the data source."
           id="random_id-row"
+          title="Index"
         >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Index
               </p>
+              <br />
               <p
                 class="sublabel"
               >
@@ -268,17 +283,22 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
         </div>
         <div
           class="euiFormRow"
+          hint="Choose the time field you want to use for time filter."
           id="random_id-row"
+          title="Timestamp field"
         >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Timestamp field
               </p>
+              <br />
               <p
                 class="sublabel"
               >
@@ -336,6 +356,8 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
         </div>
         <div
           class="euiFormRow euiFormRow--fullWidth"
+          formattedtitle="[object Object]"
+          hint="Choose a subset of your data source to focus your data stream and reduce noisy data.,Use the visual editor to create a simple filter, or use the Elasticsearch query DSL to create more advanced filters."
           id="random_id-row"
         >
           <label
@@ -343,7 +365,9 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Data fiter
                 <span
@@ -352,6 +376,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
                   - optional
                 </span>
               </p>
+              <br />
               <p
                 class="sublabel"
               >
@@ -543,17 +568,22 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           >
             <div
               class="euiFormRow euiFormRow--fullWidth"
+              hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be. The detector interval, together with data ingestion speed, also determines the preparation time of the detector. Long intervals and slow ingestion speed means the detector takes longer time to collect sufficient data to generate anomalies."
               id="random_id-row"
+              title="Detector interval"
             >
               <label
                 aria-invalid="false"
                 class="euiFormLabel"
                 for="random_id"
               >
-                <div>
+                <div
+                  style="line-height: 8px;"
+                >
                   <p>
                     Detector interval
                   </p>
+                  <br />
                   <p
                     class="sublabel"
                   >
@@ -605,17 +635,22 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
         </div>
         <div
           class="euiFormRow euiFormRow--fullWidth"
+          hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
           id="random_id-row"
+          title="Window delay"
         >
           <label
             aria-invalid="false"
             class="euiFormLabel"
             for="random_id"
           >
-            <div>
+            <div
+              style="line-height: 8px;"
+            >
               <p>
                 Window delay
               </p>
+              <br />
               <p
                 class="sublabel"
               >

--- a/public/pages/createDetector/containers/models/interfaces.ts
+++ b/public/pages/createDetector/containers/models/interfaces.ts
@@ -23,4 +23,6 @@ export interface ADFormikValues {
   filters: UIFilter[];
   filterType: FILTER_TYPES;
   filterQuery: string;
+  detectionInterval: number;
+  windowDelay: number;
 }

--- a/public/pages/createDetector/containers/utils/__tests__/detectorToFormik.test.ts
+++ b/public/pages/createDetector/containers/utils/__tests__/detectorToFormik.test.ts
@@ -35,6 +35,8 @@ describe('adToFormik', () => {
       filterQuery: JSON.stringify(randomDetector.filterQuery || {}, null, 4),
       index: [{ label: randomDetector.indices[0] }], // Currently we support only one index
       timeField: randomDetector.timeField,
+      detectionInterval: randomDetector.detectionInterval.period.interval,
+      windowDelay: randomDetector.windowDelay.period.interval,
     });
   });
   test('should return if detector does not have metadata', () => {
@@ -50,6 +52,8 @@ describe('adToFormik', () => {
       filterQuery: JSON.stringify(randomDetector.filterQuery || {}, null, 4),
       index: [{ label: randomDetector.indices[0] }], // Currently we support only one index
       timeField: randomDetector.timeField,
+      detectionInterval: randomDetector.detectionInterval.period.interval,
+      windowDelay: randomDetector.windowDelay.period.interval,
     });
   });
 });

--- a/public/pages/createDetector/containers/utils/__tests__/formikToDetector.test.ts
+++ b/public/pages/createDetector/containers/utils/__tests__/formikToDetector.test.ts
@@ -22,6 +22,7 @@ import {
   OPERATORS_MAP,
   UIFilter,
   FILTER_TYPES,
+  UNITS,
 } from '../../../../../models/interfaces';
 import { DATA_TYPES } from '../../../../../utils/constants';
 
@@ -35,9 +36,13 @@ describe('formikToAd', () => {
         detectorDescription: randomDetector.description,
         index: [{ label: randomDetector.indices[0] }],
         timeField: randomDetector.timeField,
+        detectionInterval: randomDetector.detectionInterval.period.interval,
+        windowDelay: randomDetector.windowDelay.period.interval,
       },
       {} as Detector
     );
+    console.log(ad);
+    console.log(randomDetector);
     expect(ad).toEqual({
       name: randomDetector.name,
       description: randomDetector.description,
@@ -49,6 +54,18 @@ describe('formikToAd', () => {
         filters: [],
       },
       timeField: randomDetector.timeField,
+      detectionInterval: {
+        period: {
+          interval: randomDetector.detectionInterval.period.interval,
+          unit: UNITS.MINUTES,
+        },
+      },
+      windowDelay: {
+        period: {
+          interval: randomDetector.windowDelay.period.interval,
+          unit: UNITS.MINUTES,
+        },
+      },
     });
   });
   test('should convert formikValues to API call with filters', () => {
@@ -66,6 +83,8 @@ describe('formikToAd', () => {
             operator: OPERATORS_MAP.IS_NOT_NULL,
           },
         ],
+        detectionInterval: randomDetector.detectionInterval.period.interval,
+        windowDelay: randomDetector.windowDelay.period.interval,
       },
       {} as Detector
     );
@@ -95,6 +114,18 @@ describe('formikToAd', () => {
         ],
       },
       timeField: randomDetector.timeField,
+      detectionInterval: {
+        period: {
+          interval: randomDetector.detectionInterval.period.interval,
+          unit: UNITS.MINUTES,
+        },
+      },
+      windowDelay: {
+        period: {
+          interval: randomDetector.windowDelay.period.interval,
+          unit: UNITS.MINUTES,
+        },
+      },
     });
   });
 });

--- a/public/pages/createDetector/containers/utils/constant.ts
+++ b/public/pages/createDetector/containers/utils/constant.ts
@@ -25,6 +25,8 @@ export const INITIAL_VALUES: ADFormikValues = {
   index: [],
   filterType: FILTER_TYPES.SIMPLE,
   filterQuery: JSON.stringify({ query: { bool: { filter: [] } } }, null, 4),
+  detectionInterval: 10,
+  windowDelay: 0,
 };
 
 export const EMPTY_UI_FILTER: UIFilter = {

--- a/public/pages/createDetector/containers/utils/detectorToFormik.ts
+++ b/public/pages/createDetector/containers/utils/detectorToFormik.ts
@@ -38,5 +38,7 @@ export function detectorToFormik(ad: Detector): ADFormikValues {
     filterQuery,
     index: [{ label: ad.indices[0] }], // Currently we support only one index
     timeField: ad.timeField,
+    detectionInterval: get(ad, 'detectionInterval.period.interval', 10),
+    windowDelay: get(ad, 'windowDelay.period.interval', 0),
   };
 }

--- a/public/pages/createDetector/containers/utils/formikToDetector.ts
+++ b/public/pages/createDetector/containers/utils/formikToDetector.ts
@@ -17,6 +17,7 @@ import {
   Detector,
   UIFilter,
   FILTER_TYPES,
+  UNITS,
 } from '../../../../models/interfaces';
 import { ADFormikValues } from '../models/interfaces';
 import { OPERATORS_QUERY_MAP } from './whereFilters';
@@ -48,6 +49,12 @@ export function formikToDetector(
       ...filterQuery,
     },
     uiMetadata: uiMetaData,
+    detectionInterval: {
+      period: { interval: values.detectionInterval, unit: UNITS.MINUTES },
+    },
+    windowDelay: {
+      period: { interval: values.windowDelay, unit: UNITS.MINUTES },
+    },
   } as Detector;
 
   return apiRequest;

--- a/public/pages/createDetector/index.scss
+++ b/public/pages/createDetector/index.scss
@@ -14,3 +14,4 @@
  */
 
 @import 'components/DataFilters/dataFilter.scss';
+@import 'components/createDetector.scss';

--- a/public/redux/reducers/__tests__/utils.ts
+++ b/public/redux/reducers/__tests__/utils.ts
@@ -82,6 +82,7 @@ export const getRandomDetector = (isCreate: boolean = true): Detector => {
     indices: ['logstash-*'],
     featureAttributes: features,
     filterQuery: randomQuery(),
+    uiMetadata: getUIMetadata(features),
     detectionInterval: {
       period: {
         interval: detectorFaker.integer({ min: 1, max: 10 }),
@@ -94,6 +95,5 @@ export const getRandomDetector = (isCreate: boolean = true): Detector => {
         unit: UNITS.MINUTES,
       },
     },
-    uiMetadata: getUIMetadata(features),
   };
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
![create_1](https://user-images.githubusercontent.com/5303417/78061864-b4686e00-7342-11ea-8b3d-8a15758de835.png)
![create_2](https://user-images.githubusercontent.com/5303417/78061879-b7635e80-7342-11ea-9eba-78094e9fb454.png)



This PR modifies previous create/update detector page:
First, have instruction text above the form field according to Polaris guidance.
Second, update instruction, placeholder, and button’s content.
Third, reformat text and define the new format in a new scss file.
Fourth, move the data filter as part of the data source.
Fifth, add detector operation settings, including the detector interval and window delay.
Sixth, make detector description optional.
Eighth, update test snapshot and fix outdated tests.

Testing n the done:
*unit tests pass.
*manually verified that I could create and update detector

Note: The newly added unit tests and some other 16 test suites fail after the recent commit adds @babel/transform-runtime. Without that commit, all tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
