### PR TITLE
home page and side nav bar hook

### DIFF
--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -15,50 +15,106 @@
 
 import { Switch, Route, RouteComponentProps, Redirect } from 'react-router-dom';
 import React from 'react';
+import { AppState } from '../../redux/reducers';
 import { CreateDetector } from '../createDetector';
-
 import { DetectorList } from '../DetectorsList';
 import { ListRouterParams } from '../DetectorsList/List/List';
-import { PreviewDetector } from '../PreviewDetector/containers/PreviewDetector';
-import { Dashboard } from '../Dashboard/Container/Dashboard';
-import { APP_PATH } from '../../utils/constants';
+// @ts-ignore
+import { EuiSideNav, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
+import { useSelector } from 'react-redux';
 
-interface MainProps {}
+enum Navigation {
+  AnomalyDetection = 'Anomaly detection',
+  Dashboard = 'Dashboard',
+  Detectors = 'Detectors',
+}
 
-export function Main(mainProps: MainProps) {
+enum Pathname {
+  Dashboard = '/dashboard',
+  Detectors = '/detectors',
+}
+
+interface MainProps extends RouteComponentProps {}
+
+export function Main(props: MainProps) {
+  const hideSideNavBar = useSelector(
+    (state: AppState) => state.adApp.hideSideNavBar
+  );
+  const sideNav = [
+    {
+      name: Navigation.AnomalyDetection,
+      id: 0,
+      href: `#${Pathname.Dashboard}`,
+      items: [
+        {
+          name: Navigation.Dashboard,
+          id: 1,
+          href: `#${Pathname.Dashboard}`,
+          isSelected: props.location.pathname === Pathname.Dashboard,
+        },
+        {
+          name: Navigation.Detectors,
+          id: 2,
+          href: `#${Pathname.Detectors}`,
+          isSelected: props.location.pathname === Pathname.Detectors,
+        },
+      ],
+    },
+  ];
+
   return (
-    <Switch>
-      <Route
-        exact
-        path="/detectors"
-        render={(props: RouteComponentProps<ListRouterParams>) => (
-          <DetectorList {...props} />
-        )}
-      />
-      <Route
-        exact
-        path="/create-ad/"
-        render={(props: RouteComponentProps) => (
-          <CreateDetector {...props} isEdit={false} />
-        )}
-      />
-      <Route
-        exact
-        path="/detectors/:detectorId/edit"
-        render={(props: RouteComponentProps) => (
-          <CreateDetector {...props} isEdit={true} />
-        )}
-      />
-      <Route
-        path="/detectors/:detectorId/features/"
-        render={(props: RouteComponentProps) => <PreviewDetector {...props} />}
-      />
-      <Route
-        exact
-        path={APP_PATH.DASHBOARD}
-        render={(props: RouteComponentProps) => <Dashboard />}
-      />
-      <Redirect to="/dashboard" />
-    </Switch>
+    <EuiPage>
+      <EuiPageSideBar style={{ minWidth: 150 }} hidden={hideSideNavBar}>
+        <EuiSideNav style={{ width: 150 }} items={sideNav} />
+      </EuiPageSideBar>
+      <EuiPageBody>
+        <Switch>
+          <Route
+            path="/dashboard"
+            render={(props: RouteComponentProps) => (
+              // place holder for DashboardOverview, please replace with your page
+              <div>place holder for DashboardOverview</div>
+            )}
+          />
+          <Route
+            exact
+            path="/detectors"
+            render={(props: RouteComponentProps<ListRouterParams>) => (
+              <DetectorList {...props} />
+            )}
+          />
+          <Route
+            exact
+            path="/create-ad/"
+            render={(props: RouteComponentProps) => (
+              <CreateDetector {...props} isEdit={false} />
+            )}
+          />
+          <Route
+            exact
+            path="/detectors/:detectorId/edit"
+            render={(props: RouteComponentProps) => (
+              <CreateDetector {...props} isEdit={true} />
+            )}
+          />
+          <Route
+            exact
+            path="/detectors/:detectorId/features/"
+            render={(props: RouteComponentProps) => (
+              // place holder for EditFeatures, please replace with your page
+              <div>place holder for EditFeatures</div>
+            )}
+          />
+          <Route
+            path="/detectors/:detectorId/"
+            render={(props: RouteComponentProps) => (
+              // place holder for DetectorDetail, please replace with your page
+              <div>place holder for DetectorDetail</div>
+            )}
+          />
+          <Redirect from="/" to="/dashboard" />
+        </Switch>
+      </EuiPageBody>
+    </EuiPage>
   );
 }

--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -22,6 +22,7 @@ import { ListRouterParams } from '../DetectorsList/List/List';
 // @ts-ignore
 import { EuiSideNav, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
 import { useSelector } from 'react-redux';
+import { APP_PATH } from '../../utils/constants';
 
 enum Navigation {
   AnomalyDetection = 'Anomaly detection',
@@ -70,7 +71,7 @@ export function Main(props: MainProps) {
       <EuiPageBody>
         <Switch>
           <Route
-            path="/dashboard"
+            path={APP_PATH.DASHBOARD}
             render={(props: RouteComponentProps) => (
               // place holder for DashboardOverview, please replace with your page
               <div>place holder for DashboardOverview</div>
@@ -78,35 +79,35 @@ export function Main(props: MainProps) {
           />
           <Route
             exact
-            path="/detectors"
+            path={APP_PATH.LIST_DETECTORS}
             render={(props: RouteComponentProps<ListRouterParams>) => (
               <DetectorList {...props} />
             )}
           />
           <Route
             exact
-            path="/create-ad/"
+            path={APP_PATH.CREATE_DETECTOR}
             render={(props: RouteComponentProps) => (
               <CreateDetector {...props} isEdit={false} />
             )}
           />
           <Route
             exact
-            path="/detectors/:detectorId/edit"
+            path={APP_PATH.EDIT_DETECTOR}
             render={(props: RouteComponentProps) => (
               <CreateDetector {...props} isEdit={true} />
             )}
           />
           <Route
             exact
-            path="/detectors/:detectorId/features/"
+            path={APP_PATH.EDIT_FEATURES}
             render={(props: RouteComponentProps) => (
               // place holder for EditFeatures, please replace with your page
               <div>place holder for EditFeatures</div>
             )}
           />
           <Route
-            path="/detectors/:detectorId/"
+            path={APP_PATH.DETECTOR_DETAIL}
             render={(props: RouteComponentProps) => (
               // place holder for DetectorDetail, please replace with your page
               <div>place holder for DetectorDetail</div>

--- a/public/pages/main/hooks/useHideSideNavBar.ts
+++ b/public/pages/main/hooks/useHideSideNavBar.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { useEffect } from 'react';
+import { SET_HIDE_SIDE_NAV_BAR_STATE } from '../../../redux/reducers/adAppReducer';
+import { useDispatch } from 'react-redux';
+
+//A hook which hide side nav bar
+export const useHideSideNavBar = (hidden: boolean, hiddenAfterClear: boolean) => {
+    const dispatch = useDispatch();
+    useEffect(
+        () => {
+            dispatch({ type: SET_HIDE_SIDE_NAV_BAR_STATE, payload: hidden })
+            return () => {
+                dispatch({ type: SET_HIDE_SIDE_NAV_BAR_STATE, payload: hiddenAfterClear })
+            }
+        },
+        []
+    );
+};

--- a/public/redux/reducers/adAppReducer.ts
+++ b/public/redux/reducers/adAppReducer.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { Action } from 'redux';
+
+
+export const SET_HIDE_SIDE_NAV_BAR_STATE = 'adApp/SET_HIDE_SIDE_NAV_BAR_STATE';
+
+const initialAdAppState = {
+  hideSideNavBar: false
+};
+
+export interface AdAppState {
+  hideSideNavBar: boolean;
+}
+
+const reducer = (state = initialAdAppState, action: Action) => {
+  switch (action.type) {
+    case SET_HIDE_SIDE_NAV_BAR_STATE: {
+      // @ts-ignore
+      const hideNaveBar = action.payload;
+      return {
+        ...state,
+        hideSideNavBar: hideNaveBar,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export default reducer;

--- a/public/redux/reducers/index.ts
+++ b/public/redux/reducers/index.ts
@@ -18,12 +18,14 @@ import indicesReducer from './elasticsearch';
 import adReducer from './ad';
 import anomalies from './anomalies';
 import anomalyResults from './anomalyResults';
+import adAppReducer from './adAppReducer';
 
 const rootReducer = combineReducers({
   elasticsearch: indicesReducer,
   anomalies: anomalies,
   anomalyResults: anomalyResults,
   ad: adReducer,
+  adApp: adAppReducer,
 });
 
 export default rootReducer;

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -31,9 +31,12 @@ export const BREADCRUMBS = Object.freeze({
 });
 
 export const APP_PATH = {
-  CREATE_DETECTOR: '/create-ad',
   DASHBOARD: '/dashboard',
-  LIST_DETECTORS: '/list-detectors',
+  LIST_DETECTORS: '/detectors',
+  CREATE_DETECTOR: '/create-ad/',
+  EDIT_DETECTOR: '/detectors/:detectorId/edit',
+  EDIT_FEATURES: '/detectors/:detectorId/features/',
+  DETECTOR_DETAIL: '/detectors/:detectorId/',
 };
 export const PLUGIN_NAME = 'opendistro-anomaly-detection';
 


### PR DESCRIPTION
*Issue #, if available:*

* add side nav bar to home page
* control show/hide side bar through AD app hook, sample code to use it
```
...
import { useHideSideNavBar } from '../../DetectorDetail/hooks/useHideSideNavBar';
...

export function EditFeatures(props: EditFeaturesProps) {
  // the first boolean of useHideSideNavBar is true, means hide side nav bar on this page
 // the second boolean of useHideSideNavBar is false means show side nav bar after exit this page
  useHideSideNavBar(true, false);
  ...
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
