### PR TITLE
Add detector configuration page

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 
-import React from 'react';
-
+import React, { ReactElement } from 'react';
+//@ts-ignore
 import {
   //@ts-ignore
   EuiTitleSize,
@@ -105,6 +105,7 @@ const ContentPanel = (props: ContentPanelProps) => (
         </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>
+
     {props.title != '' && (
       <EuiHorizontalRule
         margin="xs"

--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/Dashboard/Container/__tests__/Dashboard.test.tsx
+++ b/public/pages/Dashboard/Container/__tests__/Dashboard.test.tsx
@@ -20,7 +20,6 @@ import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route, Switch } from 'react-router-dom';
 import configureStore from '../../../../redux/configureStore';
 import { httpClientMock } from '../../../../../test/mocks';
-import moment from 'moment';
 
 const renderWithRouter = () => ({
   ...render(

--- a/public/pages/DetectorConfig/DetectorConfig.scss
+++ b/public/pages/DetectorConfig/DetectorConfig.scss
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+.enabled {
+  height: 14.3px;
+  width: 267.91px;
+  color: #454545;
+  font-family: 'Helvetica Neue';
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 14px;
+}
+
+.modelSubtitle {
+  height: 17px;
+  width: 162px;
+  color: #3f3f3f;
+  font-family: 'Helvetica Neue';
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0;
+  line-height: 17px;
+}
+
+.featureText {
+  color: #3f3f3f;
+  font-family: 'SF Pro Text';
+  font-size: 14px;
+  letter-spacing: 0;
+  line-height: 21px;
+}
+
+.fieldsSubtitle {
+  height: 32px;
+  width: 692px;
+  color: #69707d;
+  //font-family: Helvetica;
+  font-size: 12px;
+  letter-spacing: -0.06px;
+  line-height: 16px;
+}
+
+.configTitle {
+  height: 15px;
+  width: 80px;
+  color: #454545;
+  font-family: 'Helvetica Neue';
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0;
+  line-height: 15px;
+}
+
+.emptyFeatureTitle {
+  height: 40px;
+  width: 834px;
+  color: #1a1c21;
+  font-family: Helvetica;
+  font-size: 28px;
+  letter-spacing: -1.2px;
+  line-height: 40px;
+  text-align: center;
+}
+
+.emptyFeatureBody {
+  color: #69707d;
+  font-family: Helvetica;
+  font-size: 16px;
+  letter-spacing: -0.08px;
+  line-height: 24px;
+  text-align: center;
+}

--- a/public/pages/DetectorConfig/components/CodeModal/CodeModal.tsx
+++ b/public/pages/DetectorConfig/components/CodeModal/CodeModal.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Component } from 'react';
+
+import {
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+  EuiCodeBlock,
+} from '@elastic/eui';
+
+interface CodeModalProps {
+  code: string;
+  title: string;
+  subtitle?: string;
+  getModalVisibilityChange: () => boolean;
+  closeModal: () => void;
+}
+
+export class CodeModal extends Component<CodeModalProps, {}> {
+  constructor(props: CodeModalProps) {
+    super(props);
+  }
+
+  render() {
+    let modal;
+
+    if (this.props.getModalVisibilityChange()) {
+      modal = (
+        <EuiOverlayMask>
+          <EuiModal onClose={this.props.closeModal}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <div>
+                  <p>{this.props.title}</p>
+                  {this.props.subtitle ? (
+                    <p className="modelSubtitle">{this.props.subtitle}</p>
+                  ) : (
+                    {}
+                  )}
+                </div>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiCodeBlock
+                language="json"
+                paddingSize="s"
+                overflowHeight={300}
+                isCopyable
+              >
+                {this.props.code}
+              </EuiCodeBlock>
+            </EuiModalBody>
+          </EuiModal>
+        </EuiOverlayMask>
+      );
+    }
+    return <div>{modal}</div>;
+  }
+}

--- a/public/pages/DetectorConfig/components/CodeModal/__tests__/CodeModal.test.tsx
+++ b/public/pages/DetectorConfig/components/CodeModal/__tests__/CodeModal.test.tsx
@@ -13,7 +13,24 @@
  * permissions and limitations under the License.
  */
 
-@import 'components/ContentPanel/index.scss';
-@import 'pages/createDetector/index.scss';
-@import 'pages/Dashboard/index.scss';
-@import 'pages/DetectorConfig/index.scss';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CodeModal } from '../CodeModal';
+
+describe('CodeMOdal spec', () => {
+  const onVisibilityChange = jest.fn(() => true);
+  const onCloseModal = jest.fn();
+
+  test('renders the component', () => {
+    const { container } = render(
+      <CodeModal
+        code="xyz"
+        title="123"
+        subtitle="abc"
+        getModalVisibilityChange={onVisibilityChange}
+        closeModal={onCloseModal}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/public/pages/DetectorConfig/components/CodeModal/__tests__/__snapshots__/CodeModal.test.tsx.snap
+++ b/public/pages/DetectorConfig/components/CodeModal/__tests__/__snapshots__/CodeModal.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CodeMOdal spec renders the component 1`] = `
+<div>
+  <div />
+</div>
+`;

--- a/public/pages/DetectorConfig/containers/DetectorConfig.tsx
+++ b/public/pages/DetectorConfig/containers/DetectorConfig.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { Detector } from '../../../models/interfaces';
+import React from 'react';
+import { MetaData } from './MetaData';
+import { Features } from './Features';
+import { EuiSpacer, EuiPage, EuiPageBody } from '@elastic/eui';
+import { RouteComponentProps } from 'react-router';
+
+interface DetectorConfigProps extends RouteComponentProps {
+  detectorId: string;
+  detector: Detector;
+  onEditFeatures(): void;
+  onEditDetector(): void;
+}
+
+export const DetectorConfig = (props: DetectorConfigProps) => {
+  return (
+    <div>
+      <EuiPage>
+        <EuiPageBody>
+          <EuiSpacer size="l" />
+          <MetaData
+            detectorId={props.detectorId}
+            detector={props.detector}
+            onEditDetector={props.onEditDetector}
+          />
+          <EuiSpacer />
+          <Features
+            detectorId={props.detectorId}
+            detector={props.detector}
+            onEditFeatures={props.onEditFeatures}
+          />
+        </EuiPageBody>
+      </EuiPage>
+    </div>
+  );
+};

--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React, { Component } from 'react';
+import {
+  EuiBasicTable,
+  EuiText,
+  EuiLink,
+  EuiIcon,
+  EuiButton,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import {
+  Detector,
+  FEATURE_TYPE,
+  FeatureAttributes,
+} from '../../../models/interfaces';
+import { get, sortBy } from 'lodash';
+import { PLUGIN_NAME } from '../../../utils/constants';
+import ContentPanel from '../../../components/ContentPanel/ContentPanel';
+import { CodeModal } from '../components/CodeModal/CodeModal';
+
+interface FeaturesProps {
+  detectorId: string;
+  detector: Detector;
+  onEditFeatures(): void;
+}
+
+interface FeaturesState {
+  showCodeModel: boolean[];
+  sortField: string;
+  sortDirection: 'asc' | 'desc';
+}
+
+export class Features extends Component<FeaturesProps, FeaturesState> {
+  constructor(props: FeaturesProps) {
+    super(props);
+    this.state = {
+      showCodeModel: get(props.detector, 'featureAttributes', []).map(
+        () => false
+      ),
+      sortField: 'name',
+      sortDirection: 'desc',
+    };
+  }
+
+  private closeModal(index: number) {
+    const cloneShowCodeModal = [...this.state.showCodeModel];
+    cloneShowCodeModal[index] = false;
+    this.setState({
+      showCodeModel: cloneShowCodeModal,
+    });
+  }
+
+  private showModal(index: number) {
+    const cloneShowCodeModal = [...this.state.showCodeModel];
+    cloneShowCodeModal[index] = true;
+    this.setState({
+      showCodeModel: cloneShowCodeModal,
+    });
+  }
+
+  private getModalVisibilityChange = (index: number) => {
+    return this.state.showCodeModel[index];
+  };
+
+  private handleTableChange = (props: any) => {
+    this.setState({
+      sortField: props.sort.field,
+      sortDirection: props.sort.direction,
+    });
+  };
+
+  private sortedItems(items: Array<any>) {
+    let sorted = sortBy(items, this.state.sortField);
+    if (this.state.sortDirection == 'desc') {
+      sorted = sorted.reverse();
+    }
+    return sorted;
+  }
+
+  public render() {
+    const featureAttributes = get(this.props.detector, 'featureAttributes', []);
+
+    const sorting = {
+      sort: {
+        field: this.state.sortField,
+        direction: this.state.sortDirection,
+      },
+    };
+
+    const items = featureAttributes.map(
+      (feature: FeatureAttributes, index: number) => ({
+        name: feature.featureName,
+        definition: index,
+        state: feature.featureEnabled ? 'Enabled' : 'Disabled',
+      })
+    );
+
+    const sortedItems = this.sortedItems(items);
+
+    const columns = [
+      {
+        field: 'name',
+        name: 'Feature name',
+        sortable: true,
+      },
+      {
+        field: 'definition',
+        name: 'Feature definition',
+        render: (featureIndex: number) => {
+          const feature = featureAttributes[featureIndex];
+
+          const metaData = get(
+            this.props.detector,
+            `uiMetadata.features.${feature.featureName}`,
+            {}
+          );
+
+          if (
+            Object.keys(metaData).length === 0 ||
+            metaData.featureType == FEATURE_TYPE.CUSTOM
+          ) {
+            return (
+              <div>
+                <p>
+                  Custom expression:{' '}
+                  <EuiLink
+                    data-test-subj={`viewFeature-${featureIndex}`}
+                    onClick={() => this.showModal(featureIndex)}
+                  >
+                    View code
+                  </EuiLink>
+                </p>
+
+                {!this.getModalVisibilityChange(featureIndex) ? null : (
+                  <CodeModal
+                    code={JSON.stringify(feature.aggregationQuery, null, 4)}
+                    title={feature.featureName}
+                    subtitle="Custom expression"
+                    closeModal={() => this.closeModal(featureIndex)}
+                    getModalVisibilityChange={() =>
+                      this.getModalVisibilityChange(featureIndex)
+                    }
+                  />
+                )}
+              </div>
+            );
+          } else {
+            return (
+              <div>
+                <p>Field: {metaData.aggregationOf || ''}</p>
+                <p>Aggregation method: {metaData.aggregationBy || ''}</p>
+              </div>
+            );
+          }
+        },
+      },
+      {
+        field: 'state',
+        name: 'State',
+      },
+    ];
+
+    const getCellProps = () => {
+      return {
+        className: 'featureText',
+        textOnly: true,
+      };
+    };
+
+    const featureNum = Object.keys(featureAttributes).length;
+
+    return (
+      <ContentPanel
+        title={`Features (${featureNum})`}
+        titleSize="s"
+        subTitle={
+          <EuiText style={{ padding: '0px 10px' }} className="fieldsSubtitle">
+            Specify index fields that you want to find anomalies for by defining
+            features. A detector can discover anomalies across up to 5 features.
+            Once you define the features, you can preview your anomalies from a
+            sample feature output.{' '}
+            <EuiLink
+              href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+              target="_blank"
+            >
+              Learn more &nbsp;
+              <EuiIcon size="s" type="popout" />
+            </EuiLink>
+          </EuiText>
+        }
+        actions={[
+          <EuiButton onClick={this.props.onEditFeatures}>Edit</EuiButton>,
+        ]}
+        panelStyles={{
+          left: '10px',
+          width: '1120px',
+        }}
+      >
+        {featureNum == 0 ? (
+          <EuiEmptyPrompt
+            title={
+              <span className="emptyFeatureTitle">
+                Features are required to run a detector
+              </span>
+            }
+            body={
+              <EuiText className="emptyFeatureBody">
+                Specify index fields that you want to find anomalies for by
+                defining features. Once you define the features, you can preview
+                your anomalies from a sample feature output.
+              </EuiText>
+            }
+            actions={[
+              <EuiButton
+                data-test-subj="createButton"
+                href={`${PLUGIN_NAME}#/detectors/${this.props.detectorId}/features`}
+                fill
+              >
+                Add feature
+              </EuiButton>,
+            ]}
+          />
+        ) : (
+          <EuiBasicTable
+            items={sortedItems}
+            columns={columns}
+            cellProps={getCellProps}
+            sorting={sorting}
+            onChange={this.handleTableChange}
+          />
+        )}
+      </ContentPanel>
+    );
+  }
+}

--- a/public/pages/DetectorConfig/containers/MetaData.tsx
+++ b/public/pages/DetectorConfig/containers/MetaData.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import ContentPanel from '../../../components/ContentPanel/ContentPanel';
+import {
+  //@ts-ignore
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiText,
+  EuiFormRow,
+  EuiLink,
+  EuiButton,
+  EuiFormRowProps,
+} from '@elastic/eui';
+import { PLUGIN_NAME } from '../../../utils/constants';
+import {
+  Detector,
+  Schedule,
+  UiMetaData,
+  FILTER_TYPES,
+  UIFilter,
+} from '../../../models/interfaces';
+import React, { Component, FunctionComponent } from 'react';
+import { displayText } from '../../createDetector/components/DataFilters/utils/helpers';
+import { CodeModal } from '../components/CodeModal/CodeModal';
+import { renderTime } from '../../DetectorResults/utils/tableUtils';
+import { render } from 'enzyme';
+
+interface MetaDataProps {
+  detectorId: string;
+  detector: Detector;
+  onEditDetector(): void;
+}
+
+const FixedWidthRow = (props: EuiFormRowProps) => (
+  <EuiFormRow {...props} style={{ width: '250px' }} />
+);
+
+interface ConfigCellProps {
+  title: string;
+  description: string | string[];
+}
+
+const ConfigCell: FunctionComponent<ConfigCellProps> = (
+  props: ConfigCellProps
+) => {
+  return (
+    <FixedWidthRow label={props.title}>
+      <EuiText>
+        <p className="enabled">{props.description}</p>
+      </EuiText>
+    </FixedWidthRow>
+  );
+};
+
+export function toString(obj: any): string {
+  // render calls this method.  During different lifecylces, obj can be undefined
+  if (typeof obj != 'undefined') {
+    if (obj.hasOwnProperty('period')) {
+      let period = obj.period;
+      return period.interval + ' ' + period.unit;
+    } else if (typeof obj == 'number') {
+      // epoch
+      return renderTime(obj);
+    }
+  }
+  return '-';
+}
+
+interface FilterDisplayProps {
+  filterInputs: Detector;
+}
+
+interface FilterDisplayState {
+  showCodeModel: boolean;
+}
+
+export class FilterDisplay extends Component<
+  FilterDisplayProps,
+  FilterDisplayState
+> {
+  constructor(props: FilterDisplayProps) {
+    super(props);
+
+    this.closeModal = this.closeModal.bind(this);
+    this.showModal = this.showModal.bind(this);
+    this.getModalVisibilityChange = this.getModalVisibilityChange.bind(this);
+    this.state = {
+      showCodeModel: false,
+    };
+  }
+
+  private closeModal() {
+    this.setState({
+      showCodeModel: false,
+    });
+  }
+
+  private showModal() {
+    this.setState({
+      showCodeModel: true,
+    });
+  }
+
+  private getModalVisibilityChange = () => {
+    return this.state.showCodeModel;
+  };
+
+  public render() {
+    let filter = this.props.filterInputs.uiMetadata;
+
+    if (filter == undefined || filter.filterType == undefined) {
+      return (
+        <EuiText>
+          <p className="enabled">-</p>
+        </EuiText>
+      );
+    }
+    if (filter.filterType == FILTER_TYPES.SIMPLE) {
+      let filters = filter.filters;
+      let n = filters.length;
+      let content;
+
+      if (n == 0) {
+        content = <p className="enabled">-</p>;
+      } else if (n == 1) {
+        content = <p className="enabled">{displayText(filters[0])}</p>;
+      } else {
+        content = (
+          <ol>
+            {filters.map((filter: UIFilter, index: number) => {
+              return (
+                <li className="enabled" key={index}>
+                  {displayText(filter)}
+                </li>
+              );
+            })}
+          </ol>
+        );
+      }
+      return <EuiText>{content}</EuiText>;
+    } else {
+      return (
+        <div>
+          <EuiText>
+            <p className="enabled">
+              Custom expression:{' '}
+              <EuiLink data-test-subj="viewFilter" onClick={this.showModal}>
+                View code
+              </EuiLink>
+            </p>
+          </EuiText>
+          {!this.getModalVisibilityChange() ? null : (
+            <CodeModal
+              code={JSON.stringify(
+                this.props.filterInputs.filterQuery || {},
+                null,
+                4
+              )}
+              title="Filter query"
+              subtitle="Custom expression"
+              getModalVisibilityChange={this.getModalVisibilityChange}
+              closeModal={this.closeModal}
+            />
+          )}
+        </div>
+      );
+    }
+  }
+}
+
+export const MetaData = (props: MetaDataProps) => {
+  let detector = props.detector;
+
+  return (
+    <ContentPanel
+      title="Detector configuration"
+      titleSize="s"
+      actions={[<EuiButton onClick={props.onEditDetector}>Edit</EuiButton>]}
+      panelStyles={{
+        left: '10px',
+        width: '1120px',
+      }}
+    >
+      <EuiFlexGrid columns={4} gutterSize="l" style={{ border: 'none' }}>
+        <EuiFlexItem>
+          <ConfigCell title="Name" description={detector.name} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell
+            title="Data source index"
+            description={detector.indices}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell
+            title="Detector interval"
+            description={toString(detector.detectionInterval)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell
+            title="Last Updated"
+            description={toString(detector.lastUpdateTime)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell title="ID" description={detector.id} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell
+            title="Window delay"
+            description={toString(detector.windowDelay)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ConfigCell title="Description" description={detector.description} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <FixedWidthRow label="Data filter">
+            <FilterDisplay filterInputs={detector} />
+          </FixedWidthRow>
+        </EuiFlexItem>
+      </EuiFlexGrid>
+    </ContentPanel>
+  );
+};

--- a/public/pages/DetectorConfig/containers/__tests__/DetectorConfig.test.tsx
+++ b/public/pages/DetectorConfig/containers/__tests__/DetectorConfig.test.tsx
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import {
+  HashRouter as Router,
+  RouteComponentProps,
+  Route,
+  Switch,
+} from 'react-router-dom';
+import {
+  render,
+  fireEvent,
+  wait,
+  waitForElement,
+} from '@testing-library/react';
+// @ts-ignore
+import { toastNotifications } from 'ui/notify';
+import { DetectorConfig } from '../DetectorConfig';
+import {
+  Detector,
+  UiMetaData,
+  FILTER_TYPES,
+  UIFilter,
+  FEATURE_TYPE,
+  UiFeature,
+  FeatureAttributes,
+} from '../../../../models/interfaces';
+import {
+  getRandomDetector,
+  getRandomFeature,
+} from '../../../../redux/reducers/__tests__/utils';
+import configureStore from '../../../../redux/configureStore';
+import { httpClientMock } from '../../../../../test/mocks';
+import userEvent from '@testing-library/user-event';
+import { toString } from '../MetaData';
+import { DATA_TYPES } from '../../../../utils/constants';
+import { OPERATORS_MAP } from '../../../createDetector/components/DataFilters/utils/constant';
+import { displayText } from '../../../createDetector/components/DataFilters/utils/helpers';
+
+const renderWithRouter = (detector: Detector) => ({
+  ...render(
+    <Router>
+      <Switch>
+        <Route
+          render={(props: RouteComponentProps) => (
+            <DetectorConfig
+              detector={detector}
+              detectorId={detector.id}
+              {...props}
+            />
+          )}
+        />
+      </Switch>
+    </Router>
+  ),
+});
+
+const fieldInFilter = 'age';
+const filters = [
+  {
+    fieldInfo: [{ label: fieldInFilter, type: DATA_TYPES.NUMBER }],
+    operator: OPERATORS_MAP.IN_RANGE,
+    fieldRangeStart: 20,
+    fieldRangeEnd: 40,
+  },
+  {
+    fieldInfo: [{ label: fieldInFilter, type: DATA_TYPES.NUMBER }],
+    operator: OPERATORS_MAP.IS_NOT_NULL,
+  },
+] as UIFilter[];
+
+const featureQuery1 = {
+  featureName: 'value',
+  featureEnabled: true,
+  aggregationQuery: {
+    size: 0,
+    query: {
+      bool: {
+        must: {
+          terms: {
+            detector_id: ['detector_1', 'detector_2'],
+          },
+        },
+      },
+    },
+    aggs: {
+      unique_detectors: {
+        terms: {
+          field: 'detector_id',
+          size: 20,
+          order: {
+            total_anomalies_in_24hr: 'asc',
+          },
+        },
+        aggs: {
+          total_anomalies_in_24hr: {
+            filter: {
+              range: {
+                data_start_time: { gte: 'now-24h', lte: 'now' },
+              },
+            },
+          },
+          latest_anomaly_time: { max: { field: 'data_start_time' } },
+        },
+      },
+    },
+  },
+} as { [key: string]: any };
+
+const featureQuery2 = {
+  featureName: 'value2',
+  featureEnabled: true,
+  aggregationQuery: {
+    aggregation_name: {
+      max: {
+        field: 'value2',
+      },
+    },
+  },
+} as { [key: string]: any };
+
+describe('<DetectorConfig /> spec', () => {
+  test('renders the component', () => {
+    const randomDetector = {
+      ...getRandomDetector(false),
+    };
+    const { container } = renderWithRouter(randomDetector);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('renders empty features and filters', async () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      uiMetadata: {} as UiMetaData,
+      featureAttributes: [],
+    };
+    const { getByText } = renderWithRouter(randomDetector);
+    await wait(() => {
+      getByText('Features are required to run a detector');
+      getByText(
+        'Specify index fields that you want to find anomalies for by defining features. Once you define the features, you can preview your anomalies from a sample feature output.'
+      );
+      getByText('Features (0)');
+      getByText(randomDetector.name);
+      getByText(randomDetector.indices[0]);
+      getByText(toString(randomDetector.detectionInterval));
+      getByText(toString(randomDetector.lastUpdateTime));
+      getByText(randomDetector.id);
+      getByText(toString(randomDetector.windowDelay));
+      getByText(randomDetector.description);
+      // filter should be -
+      getByText('-');
+      getByText(
+        'Specify index fields that you want to find anomalies for by defining features. A detector can discover anomalies across up to 5 features. Once you define the features, you can preview your anomalies from a sample feature output.'
+      );
+    });
+  });
+
+  test('renders empty features and one simple filter', async () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      uiMetadata: {
+        filterType: FILTER_TYPES.SIMPLE,
+        filters: [filters[0]],
+      } as UiMetaData,
+      featureAttributes: [],
+    };
+    const { getByText } = renderWithRouter(randomDetector);
+    await wait(() => {
+      getByText(displayText(filters[0]));
+    });
+  });
+
+  test('renders empty features and two simple filters', async () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      uiMetadata: {
+        filterType: FILTER_TYPES.SIMPLE,
+        filters: filters,
+      } as UiMetaData,
+      featureAttributes: [],
+    };
+    const { getByText } = renderWithRouter(randomDetector);
+    await wait(() => {
+      // filter should be -
+      getByText(displayText(filters[0]));
+      getByText(displayText(filters[1]));
+    });
+  });
+
+  test('renders empty features and a custom filter', async () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      uiMetadata: {
+        filterType: FILTER_TYPES.CUSTOM,
+        filters: [filters[0]],
+      } as UiMetaData,
+      featureAttributes: [],
+    };
+    const { getByTestId, getByText, queryByText } = renderWithRouter(
+      randomDetector
+    );
+    await wait(() => {
+      // filter should be -
+      getByText('Custom expression:');
+      expect(queryByText(fieldInFilter)).toBeNull();
+      expect(queryByText('filter')).toBeNull();
+    });
+
+    fireEvent.click(getByTestId('viewFilter'));
+    await wait(() => {
+      queryByText(fieldInFilter);
+      queryByText('filter');
+    });
+  });
+
+  describe('test 1 simple feature enabled/disabled', () => {
+    test.each([[true, 'Enabled'], [false, 'Disabled']])(
+      'renders 1 simple feature enabled/disabled',
+      async (enabledInDef, enabledInRender) => {
+        const randomDetector = {
+          ...getRandomDetector(true),
+          featureAttributes: [
+            {
+              featureName: 'value',
+              featureEnabled: enabledInDef,
+            },
+          ] as FeatureAttributes[],
+          uiMetadata: {
+            filterType: FILTER_TYPES.SIMPLE,
+            filters: [],
+            features: {
+              value: {
+                featureType: FEATURE_TYPE.SIMPLE,
+                aggregationOf: 'value',
+                aggregationBy: 'avg',
+              } as UiFeature,
+            },
+          } as UiMetaData,
+        };
+        const { getByText } = renderWithRouter(randomDetector);
+        await wait(() => {
+          getByText('Field: value');
+          getByText('Aggregation method: avg');
+          getByText(enabledInRender);
+        });
+      }
+    );
+  });
+
+  test('renders one custom feature', async () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      featureAttributes: [
+        {
+          featureName: 'value',
+          featureEnabled: true,
+          aggregationQuery: featureQuery1,
+        },
+      ] as FeatureAttributes[],
+      uiMetadata: {
+        filterType: FILTER_TYPES.SIMPLE,
+        filters: [],
+        features: {
+          value: {
+            featureType: FEATURE_TYPE.CUSTOM,
+          } as UiFeature,
+        },
+      } as UiMetaData,
+    };
+    const { getByTestId, getByText, queryByText } = renderWithRouter(
+      randomDetector
+    );
+    await wait(() => {
+      getByText('Custom expression:');
+      expect(queryByText('detector_1')).toBeNull();
+      expect(queryByText('detector_2')).toBeNull();
+    });
+
+    fireEvent.click(getByTestId('viewFeature-0'));
+    await wait(() => {
+      queryByText('detector_1');
+      queryByText('detector_2');
+    });
+  });
+
+  describe('renders two custom features', () => {
+    test.each([
+      [
+        'viewFeature-0',
+        ['detector_1', 'detector_2'],
+        ['max', 'aggregation_name'],
+      ],
+      [
+        'viewFeature-1',
+        ['max', 'aggregation_name'],
+        ['detector_1', 'detector_2'],
+      ],
+    ])(
+      'renders two custom features',
+      async (toClick, notExpected, expected) => {
+        const randomDetector = {
+          ...getRandomDetector(true),
+          featureAttributes: [
+            {
+              featureName: 'value',
+              featureEnabled: true,
+              aggregationQuery: featureQuery1,
+            },
+            {
+              featureName: 'value2',
+              featureEnabled: true,
+              aggregationQuery: featureQuery2,
+            },
+          ] as FeatureAttributes[],
+          uiMetadata: {
+            filterType: FILTER_TYPES.SIMPLE,
+            filters: [],
+            features: {
+              value: {
+                featureType: FEATURE_TYPE.CUSTOM,
+              } as UiFeature,
+              value2: {
+                featureType: FEATURE_TYPE.CUSTOM,
+              } as UiFeature,
+            },
+          } as UiMetaData,
+        };
+        const { getByTestId, getAllByText, queryByText } = renderWithRouter(
+          randomDetector
+        );
+        await wait(() => {
+          getAllByText('Custom expression:');
+          expect(queryByText('detector_1')).toBeNull();
+          expect(queryByText('detector_2')).toBeNull();
+          expect(queryByText('max')).toBeNull();
+          expect(queryByText('aggregation_name')).toBeNull();
+        });
+
+        fireEvent.click(getByTestId(toClick));
+        await wait(() => {
+          notExpected.forEach((obj, index) => {
+            expect(queryByText(notExpected[index])).toBeNull();
+          });
+          expected.forEach((obj, index) => {
+            queryByText(expected[index]);
+          });
+        });
+      }
+    );
+  });
+
+  test('renders the component with 2 custom and 1 simple features', () => {
+    const randomDetector = {
+      ...getRandomDetector(true),
+      featureAttributes: [
+        {
+          featureName: 'value',
+          featureEnabled: true,
+          aggregationQuery: featureQuery1,
+        },
+        {
+          featureName: 'value2',
+          featureEnabled: true,
+          aggregationQuery: featureQuery2,
+        },
+        {
+          featureName: 'value',
+          featureEnabled: false,
+        },
+      ] as FeatureAttributes[],
+      uiMetadata: {
+        filterType: FILTER_TYPES.SIMPLE,
+        filters: [],
+        features: {
+          value: {
+            featureType: FEATURE_TYPE.CUSTOM,
+          } as UiFeature,
+          value2: {
+            featureType: FEATURE_TYPE.CUSTOM,
+          } as UiFeature,
+          value3: {
+            featureType: FEATURE_TYPE.SIMPLE,
+            aggregationOf: 'value3',
+            aggregationBy: 'avg',
+          } as UiFeature,
+        },
+      } as UiMetaData,
+    };
+    const { container } = renderWithRouter(randomDetector);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -1,0 +1,1399 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DetectorConfig /> spec renders the component 1`] = `
+<div>
+  <div
+    class="euiPage"
+  >
+    <div
+      class="euiPageBody"
+    >
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiPanel euiPanel--paddingMedium"
+        style="padding-left: 0px; padding-right: 0px; left: 10px; width: 1120px;"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3
+              class="euiTitle euiTitle--small content-panel-title"
+            >
+              Detector configuration
+            </h3>
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <button
+                  class="euiButton euiButton--primary"
+                  type="button"
+                >
+                  <span
+                    class="euiButton__content"
+                  >
+                    <span
+                      class="euiButton__text"
+                    >
+                      Edit
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+        />
+        <div
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexGrid euiFlexGrid--gutterLarge euiFlexGrid--fourths euiFlexGrid--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Name
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    niihduhifi
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Data source index
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    logstash-*
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Detector interval
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    6 MINUTES
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Last Updated
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    Mon Apr 13 2020 17:13:38 GMT-0700 (Pacific Daylight Time)
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    ID
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Window delay
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    5 MINUTES
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Description
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    Gegni fe sokvuhi luwegja evumemu dajnidu dangap id baj vejmil linsumi leem.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Data filter
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    -
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiPanel euiPanel--paddingMedium"
+        style="padding-left: 0px; padding-right: 0px; left: 10px; width: 1120px;"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3
+              class="euiTitle euiTitle--small content-panel-title"
+            >
+              Features (2)
+            </h3>
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <p>
+                  Specify index fields that you want to find anomalies for by defining features. A detector can discover anomalies across up to 5 features. Once you define the features, you can preview your anomalies from a sample feature output.
+                   
+                  <a
+                    class="euiLink euiLink--primary"
+                    href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more  
+                    <svg
+                      class="euiIcon euiIcon--small euiIcon-isLoading"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <button
+                  class="euiButton euiButton--primary"
+                  type="button"
+                >
+                  <span
+                    class="euiButton__content"
+                  >
+                    <span
+                      class="euiButton__text"
+                    >
+                      Edit
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+        />
+        <div
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiBasicTable"
+          >
+            <div>
+              <div
+                class="euiTableHeaderMobile"
+              >
+                <div
+                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                >
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  />
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <div
+                      class="euiTableSortMobile"
+                    >
+                      <div
+                        class="euiPopover euiPopover--anchorDownRight"
+                        id="sortPopover"
+                      >
+                        <div
+                          class="euiPopover__anchor"
+                        >
+                          <button
+                            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
+                            type="button"
+                          >
+                            <span
+                              class="euiButtonEmpty__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+                                focusable="false"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                              <span
+                                class="euiButtonEmpty__text"
+                              >
+                                Sorting
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="euiTable euiTable--responsive"
+              >
+                <caption
+                  aria-live="polite"
+                  aria-relevant="text"
+                  class="euiScreenReaderOnly"
+                  role="status"
+                />
+                <thead>
+                  <tr>
+                    <th
+                      aria-live="polite"
+                      aria-sort="descending"
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_name_0"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <button
+                        class="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                        data-test-subj="tableHeaderSortButton"
+                        type="button"
+                      >
+                        <span
+                          class="euiTableCellContent"
+                        >
+                          <span
+                            class="euiTableCellContent__text"
+                          >
+                            Feature name
+                          </span>
+                          <svg
+                            aria-label="Sorted in descending order"
+                            class="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                            focusable="false"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <span
+                            class="euiScreenReaderOnly"
+                          >
+                            Click to sort in ascending order
+                          </span>
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_definition_1"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Feature definition
+                        </span>
+                      </div>
+                    </th>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_state_2"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          State
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature name
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          SR
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature definition
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          <div>
+                            <p>
+                              Field: 
+                              SR
+                            </p>
+                            <p>
+                              Aggregation method: 
+                              min
+                            </p>
+                          </div>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        State
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Disabled
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature name
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          HN
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature definition
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          <div>
+                            <p>
+                              Field: 
+                              HN
+                            </p>
+                            <p>
+                              Aggregation method: 
+                              max
+                            </p>
+                          </div>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        State
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Disabled
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simple features 1`] = `
+<div>
+  <div
+    class="euiPage"
+  >
+    <div
+      class="euiPageBody"
+    >
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiPanel euiPanel--paddingMedium"
+        style="padding-left: 0px; padding-right: 0px; left: 10px; width: 1120px;"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3
+              class="euiTitle euiTitle--small content-panel-title"
+            >
+              Detector configuration
+            </h3>
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              />
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <button
+                  class="euiButton euiButton--primary"
+                  type="button"
+                >
+                  <span
+                    class="euiButton__content"
+                  >
+                    <span
+                      class="euiButton__text"
+                    >
+                      Edit
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+        />
+        <div
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexGrid euiFlexGrid--gutterLarge euiFlexGrid--fourths euiFlexGrid--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Name
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    vibivubuko
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Data source index
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    logstash-*
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Detector interval
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    5 MINUTES
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Last Updated
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    Mon Apr 13 2020 17:13:38 GMT-0700 (Pacific Daylight Time)
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    ID
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    b480ad31-134b-5f8b-9
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Window delay
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    1 MINUTES
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Description
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                  id="random_id"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    Cuzolale omuranot barpul ete wal zuclujzor ponopzel opo cosmicbov zezido viwwojci akgime.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFormRow"
+                id="random_id-row"
+                style="width: 250px;"
+              >
+                <div>
+                  <label
+                    class="euiFormLabel"
+                    for="random_id"
+                  >
+                    Data filter
+                  </label>
+                </div>
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <p
+                    class="enabled"
+                  >
+                    -
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiPanel euiPanel--paddingMedium"
+        style="padding-left: 0px; padding-right: 0px; left: 10px; width: 1120px;"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3
+              class="euiTitle euiTitle--small content-panel-title"
+            >
+              Features (3)
+            </h3>
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <p>
+                  Specify index fields that you want to find anomalies for by defining features. A detector can discover anomalies across up to 5 features. Once you define the features, you can preview your anomalies from a sample feature output.
+                   
+                  <a
+                    class="euiLink euiLink--primary"
+                    href="https://github.com/opendistro-for-elasticsearch/anomaly-detection"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more  
+                    <svg
+                      class="euiIcon euiIcon--small euiIcon-isLoading"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <button
+                  class="euiButton euiButton--primary"
+                  type="button"
+                >
+                  <span
+                    class="euiButton__content"
+                  >
+                    <span
+                      class="euiButton__text"
+                    >
+                      Edit
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+        />
+        <div
+          style="padding: 0px 10px;"
+        >
+          <div
+            class="euiBasicTable"
+          >
+            <div>
+              <div
+                class="euiTableHeaderMobile"
+              >
+                <div
+                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                >
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  />
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <div
+                      class="euiTableSortMobile"
+                    >
+                      <div
+                        class="euiPopover euiPopover--anchorDownRight"
+                        id="sortPopover"
+                      >
+                        <div
+                          class="euiPopover__anchor"
+                        >
+                          <button
+                            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
+                            type="button"
+                          >
+                            <span
+                              class="euiButtonEmpty__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+                                focusable="false"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                              <span
+                                class="euiButtonEmpty__text"
+                              >
+                                Sorting
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="euiTable euiTable--responsive"
+              >
+                <caption
+                  aria-live="polite"
+                  aria-relevant="text"
+                  class="euiScreenReaderOnly"
+                  role="status"
+                />
+                <thead>
+                  <tr>
+                    <th
+                      aria-live="polite"
+                      aria-sort="descending"
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_name_0"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <button
+                        class="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                        data-test-subj="tableHeaderSortButton"
+                        type="button"
+                      >
+                        <span
+                          class="euiTableCellContent"
+                        >
+                          <span
+                            class="euiTableCellContent__text"
+                          >
+                            Feature name
+                          </span>
+                          <svg
+                            aria-label="Sorted in descending order"
+                            class="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                            focusable="false"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <span
+                            class="euiScreenReaderOnly"
+                          >
+                            Click to sort in ascending order
+                          </span>
+                        </span>
+                      </button>
+                    </th>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_definition_1"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Feature definition
+                        </span>
+                      </div>
+                    </th>
+                    <th
+                      class="euiTableHeaderCell"
+                      data-test-subj="tableHeaderCell_state_2"
+                      role="columnheader"
+                      scope="col"
+                    >
+                      <div
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          State
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature name
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          value2
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature definition
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          <div>
+                            <p>
+                              Custom expression:
+                               
+                              <button
+                                class="euiLink euiLink--primary"
+                                data-test-subj="viewFeature-1"
+                                type="button"
+                              >
+                                View code
+                              </button>
+                            </p>
+                          </div>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        State
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Enabled
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature name
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          value
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature definition
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          <div>
+                            <p>
+                              Custom expression:
+                               
+                              <button
+                                class="euiLink euiLink--primary"
+                                data-test-subj="viewFeature-2"
+                                type="button"
+                              >
+                                View code
+                              </button>
+                            </p>
+                          </div>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        State
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Disabled
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="euiTableRow"
+                  >
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature name
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          value
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        Feature definition
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          <div>
+                            <p>
+                              Custom expression:
+                               
+                              <button
+                                class="euiLink euiLink--primary"
+                                data-test-subj="viewFeature-0"
+                                type="button"
+                              >
+                                View code
+                              </button>
+                            </p>
+                          </div>
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="euiTableRowCell"
+                    >
+                      <div
+                        class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                      >
+                        State
+                      </div>
+                      <div
+                        class="euiTableCellContent featureText"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                        >
+                          Enabled
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/DetectorConfig/index.scss
+++ b/public/pages/DetectorConfig/index.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -13,7 +13,4 @@
  * permissions and limitations under the License.
  */
 
-@import 'components/ContentPanel/index.scss';
-@import 'pages/createDetector/index.scss';
-@import 'pages/Dashboard/index.scss';
-@import 'pages/DetectorConfig/index.scss';
+@import './DetectorConfig.scss';

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -51,7 +51,7 @@ import { useFetchMonitorInfo } from '../hooks/useFetchMonitorInfo';
 import { MonitorCallout } from '../components/MonitorCallout/MonitorCallout';
 import { DETECTOR_DETAIL_TABS } from '../utils/constants';
 import { DetectorConfig } from '../../DetectorConfig/containers/DetectorConfig';
-import { AnomalyResults } from '../../DetectorResults/containers/AnomalyResults';
+//import { AnomalyResults } from '../../DetectorResults/containers/AnomalyResults';
 
 export interface DetectorRouterProps {
   detectorId?: string;
@@ -445,12 +445,14 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           exact
           path="/detectors/:detectorId/results"
           render={props => (
-            <AnomalyResults
-              {...props}
-              detectorId={detectorId}
-              onStartDetector={() => handleStartAdJob(detectorId)}
-              onSwitchToConfiguration={handleSwitchToConfigurationTab}
-            />
+            // TODO: add Yaliang's changes back when he checks in AnomalyResults
+            // <AnomalyResults
+            //   {...props}
+            //   detectorId={detectorId}
+            //   onStartDetector={() => handleStartAdJob(detectorId)}
+            //   onSwitchToConfiguration={handleSwitchToConfigurationTab}
+            // />
+            <div></div>
           )}
         />
         <Route

--- a/public/pages/DetectorDetail/containers/__tests__/__snapshots__/DetectorDetail.test.tsx.snap
+++ b/public/pages/DetectorDetail/containers/__tests__/__snapshots__/DetectorDetail.test.tsx.snap
@@ -159,17 +159,6 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
       </div>
     </div>
   </div>
-  <div
-    class="euiPage"
-    style="margin-top: 16px; padding-top: 0px;"
-  >
-    <div
-      class="euiPageBody"
-    >
-      <div
-        class="euiSpacer euiSpacer--l"
-      />
-    </div>
-  </div>
+  <div />
 </div>
 `;

--- a/public/pages/DetectorResults/utils/tableUtils.ts
+++ b/public/pages/DetectorResults/utils/tableUtils.ts
@@ -18,7 +18,7 @@ import moment from 'moment';
 
 export const DEFAULT_EMPTY_DATA = '-';
 
-const renderTime = (time: number) => {
+export const renderTime = (time: number) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm a');
   return DEFAULT_EMPTY_DATA;

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -51,6 +51,7 @@ import { detectorToFormik } from './utils/detectorToFormik';
 import { formikToDetector } from './utils/formikToDetector';
 import { Detector } from '../../../models/interfaces';
 import { Settings } from '../components/Settings/Settings';
+import { useHideSideNavBar } from '../../main/hooks/useHideSideNavBar';
 
 interface CreateRouterProps {
   detectorId?: string;
@@ -61,6 +62,7 @@ interface CreateADProps extends RouteComponentProps<CreateRouterProps> {
 }
 
 export function CreateDetector(props: CreateADProps) {
+  useHideSideNavBar(true, false);
   const dispatch = useDispatch<Dispatch<APIAction>>();
   const detectorId: string = get(props, 'match.params.detectorId', '');
   //In case user is refreshing Edit detector page, we'll lose existing detector state
@@ -91,7 +93,7 @@ export function CreateDetector(props: CreateADProps) {
       toastNotifications.addSuccess(
         `Detector updated: ${detectorToBeUpdated.name}`
       );
-      props.history.push(`/detectors/${detectorId}/features/`);
+      props.history.push(`/detectors/${detectorId}/configurations/`);
     } catch (err) {
       toastNotifications.addDanger(
         getErrorMessage(err, 'There was a problem updating detector')
@@ -105,7 +107,7 @@ export function CreateDetector(props: CreateADProps) {
         `Detector created: ${detectorResp.data.response.name}`
       );
       props.history.push(
-        `/detectors/${detectorResp.data.response.id}/features/`
+        `/detectors/${detectorResp.data.response.id}/configurations/`
       );
     } catch (err) {
       toastNotifications.addDanger(

--- a/public/pages/createDetector/containers/utils/formikToDetector.ts
+++ b/public/pages/createDetector/containers/utils/formikToDetector.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../../models/interfaces';
 import { ADFormikValues } from '../models/interfaces';
 import { OPERATORS_QUERY_MAP } from './whereFilters';
+import { get } from 'lodash';
 
 export function formikToDetector(
   values: ADFormikValues,
@@ -38,7 +39,8 @@ export function formikToDetector(
     }
   }
   const indices = formikToIndices(values.index);
-  const uiMetaData = formikToUIMetadata(values);
+  const uiMetaData = formikToUIMetadata(values, detector);
+
   let apiRequest = {
     ...detector,
     name: values.detectorName,
@@ -60,11 +62,14 @@ export function formikToDetector(
   return apiRequest;
 }
 
-export const formikToUIMetadata = (values: ADFormikValues) => {
+export const formikToUIMetadata = (
+  values: ADFormikValues,
+  detector: Detector
+) => {
   return {
     filterType: values.filterType,
     filters: formikFiltersToUiMetadata(values.filters),
-    features: {},
+    features: get(detector, 'uiMetadata.features', {}),
   };
 };
 

--- a/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
+++ b/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
@@ -39,22 +39,19 @@ export const useFetchDetectorInfo = (
     (state: AppState) => state.elasticsearch.requesting
   );
   const selectedIndices = get(detector, 'indices.0', '');
-  useEffect(
-    () => {
-      const fetchDetector = async () => {
-        if (!detector && !isDetectorRequesting) {
-          await dispatch(getDetector(detectorId));
-        }
-        if (selectedIndices && !isIndicesRequesting) {
-          await dispatch(getMappings(selectedIndices));
-        }
-      };
-      if (detectorId) {
-        fetchDetector();
+  useEffect(() => {
+    const fetchDetector = async () => {
+      if (!detector && !isDetectorRequesting) {
+        await dispatch(getDetector(detectorId));
       }
-    },
-    [detectorId, selectedIndices]
-  );
+      if (selectedIndices && !isIndicesRequesting) {
+        await dispatch(getMappings(selectedIndices));
+      }
+    };
+    if (detectorId) {
+      fetchDetector();
+    }
+  }, [detectorId, selectedIndices]);
   return {
     detector: detector || {},
     hasError: !isEmpty(hasError) && isEmpty(detector),

--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds detector configuration page.

Empty feature:
![empty_feature](https://user-images.githubusercontent.com/5303417/79365884-1b1f8700-7f00-11ea-9b50-9d0817eb410d.png)

With feature:
![with_feature](https://user-images.githubusercontent.com/5303417/79365895-207cd180-7f00-11ea-9090-b7c0a34bf316.png)

View code:
![view_code](https://user-images.githubusercontent.com/5303417/79365901-22df2b80-7f00-11ea-9615-e7d8cacae577.png)


This PR also removes fixed eui dependency and use Kibana's eui instead because  EuiCodeBlock with the old eui has no copy and full screen options.  This PR updates test snapshots due to the changes.

Testing done:
- added unit tests and also done end-to-end testing including the following scenarios:
*renders empty features and filters
*renders empty features and one simple filter
*renders empty features and two simple filters
*renders empty features and a custom filter
*renders one simple feature enabled or disabled
*renders one custom feature
*renders two custom features
*renders the component with 2 custom and 1 simple features
*checks if sorting by feature names works.
- other jest tests pass

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
