### PR TITLE
Fix dark mode readability on detector list page

### DIFF
--- a/public/pages/DetectorsList/List/List.tsx
+++ b/public/pages/DetectorsList/List/List.tsx
@@ -63,6 +63,7 @@ import {
   getDetectorsToDisplay,
 } from '../../utils/helpers';
 import { staticColumn } from '../utils/tableUtils';
+import { darkModeEnabled } from '../../../utils/kibanaUtils';
 
 export interface ListRouterParams {
   from: string;
@@ -260,6 +261,7 @@ export const DetectorList = (props: ListProps) => {
     pageSizeOptions: [5, 10, 20, 50],
   };
 
+  const detectorCountFontColor = darkModeEnabled() ? '#98A2B3' : '#535966';
   const pageTitle = (
     <EuiTitle size={'s'} className={''}>
       <h3
@@ -269,7 +271,9 @@ export const DetectorList = (props: ListProps) => {
         }}
       >
         <p>{'Detectors'}&nbsp;</p>
-        <p style={{ color: '#535966' }}>{`(${selectedDetectors.length})`}</p>
+        <p
+          style={{ color: detectorCountFontColor }}
+        >{`(${selectedDetectors.length})`}</p>
       </h3>
     </EuiTitle>
   );

--- a/public/pages/DetectorsList/utils/tableUtils.tsx
+++ b/public/pages/DetectorsList/utils/tableUtils.tsx
@@ -21,8 +21,10 @@ import React from 'react';
 import { Detector } from '../../../../server/models/types';
 import { PLUGIN_NAME, DETECTOR_STATE } from '../../../utils/constants';
 import { stateToColorMap } from '../../utils/constants';
+import { darkModeEnabled } from '../../../utils/kibanaUtils';
 
 export const DEFAULT_EMPTY_DATA = '-';
+const hintColor = darkModeEnabled() ? '#98A2B3' : '#535966';
 
 const renderTime = (time: number) => {
   const momentTime = moment(time);
@@ -51,7 +53,7 @@ export const staticColumn = [
           Detector{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />
@@ -76,7 +78,7 @@ export const staticColumn = [
           Indices{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />
@@ -97,7 +99,7 @@ export const staticColumn = [
           Detector state{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />
@@ -118,7 +120,7 @@ export const staticColumn = [
           Anomalies last 24 hours{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />
@@ -138,7 +140,7 @@ export const staticColumn = [
           Last anomaly occurrence{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />
@@ -159,7 +161,7 @@ export const staticColumn = [
           Last updated{' '}
           <EuiIcon
             size="s"
-            color="subdued"
+            color={hintColor}
             type="questionInCircle"
             className="eui-alignTop"
           />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a few small readability issues on the detector list page when dark mode is enabled. Specific changes:
1. The detector count font in the title
2. The hint icons above the table column headers

Before:
![Screen Shot 2020-04-21 at 10 11 30 AM](https://user-images.githubusercontent.com/62119629/79893842-77c7e980-83b9-11ea-8601-722f071d0cef.png)

After:
![Screen Shot 2020-04-21 at 10 12 07 AM](https://user-images.githubusercontent.com/62119629/79893956-a1811080-83b9-11ea-959c-19191487f882.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
