### PR TITLE
Make breadcrumbs consistent on home pages

### DIFF
--- a/public/pages/Dashboard/Container/Dashboard.tsx
+++ b/public/pages/Dashboard/Container/Dashboard.tsx
@@ -22,8 +22,19 @@ import { EmptyDashboard } from '../Components/EmptyDashboard/EmptyDashboard';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { DashboardHeader } from '../Components/utils/DashboardHeader';
 import { DashboardOverview } from './DashboardOverview';
+//@ts-ignore
+import chrome from 'ui/chrome';
+import { BREADCRUMBS } from '../../../utils/constants';
 
 export const Dashboard = () => {
+  // Set breadcrumbs on page initialization
+  useEffect(() => {
+    chrome.breadcrumbs.set([
+      BREADCRUMBS.ANOMALY_DETECTOR,
+      BREADCRUMBS.DASHBOARD,
+    ]);
+  }, []);
+
   const dispatch = useDispatch();
 
   const [isLoading, setIsLoading] = useState(true);

--- a/public/pages/DetectorsList/List/List.tsx
+++ b/public/pages/DetectorsList/List/List.tsx
@@ -57,6 +57,7 @@ import {
   ALL_DETECTOR_STATES,
   ALL_INDICES,
 } from '../../utils/constants';
+import { BREADCRUMBS } from '../../../utils/constants';
 import { getURLQueryParams } from '../utils/helpers';
 import {
   filterAndSortDetectors,
@@ -111,9 +112,12 @@ export const DetectorList = (props: ListProps) => {
     selectedIndices: ALL_INDICES,
   });
 
-  // Remove breadcrumbs on page initialization
+  // Set breadcrumbs on page initialization
   useEffect(() => {
-    chrome.breadcrumbs.set(['']);
+    chrome.breadcrumbs.set([
+      BREADCRUMBS.ANOMALY_DETECTOR,
+      BREADCRUMBS.DETECTORS,
+    ]);
   }, []);
 
   // Refresh data if user change any parameters / filter / sort


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes the inconsistencies for the breadcrumb navigation on the home pages (the dashboard and detector list pages).

Specifically:
- Dashboard page: refreshes the breadcrumbs and sets to 'Anomaly detection / Dashboard'
- Detector list page: instead of showing no breadcrumbs, set to 'Anomaly detection / Detectors'

![Screen Shot 2020-04-22 at 10 06 26 AM](https://user-images.githubusercontent.com/62119629/80012382-1c156300-8482-11ea-8641-afa55059543d.png)

![Screen Shot 2020-04-22 at 10 06 14 AM](https://user-images.githubusercontent.com/62119629/80012387-20418080-8482-11ea-999d-f9258abf4dd8.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
