### PR TITLE
Address detector list page feedback

### DIFF
--- a/public/pages/DetectorsList/Components/ListControls/ListControls.tsx
+++ b/public/pages/DetectorsList/Components/ListControls/ListControls.tsx
@@ -39,7 +39,7 @@ interface ListControlsProps {
   onPageClick: (pageNumber: number) => void;
 }
 export const ListControls = (props: ListControlsProps) => (
-  <EuiFlexGroup>
+  <EuiFlexGroup gutterSize="s">
     <EuiFlexItem grow={false} style={{ width: '40%' }}>
       <EuiFieldSearch
         fullWidth={true}

--- a/public/pages/DetectorsList/Components/ListControls/__tests__/__snapshots__/ListControls.test.tsx.snap
+++ b/public/pages/DetectorsList/Components/ListControls/__tests__/__snapshots__/ListControls.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ListControls /> spec Empty results renders component with empty message 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/DetectorsList/utils/tableUtils.tsx
+++ b/public/pages/DetectorsList/utils/tableUtils.tsx
@@ -109,6 +109,7 @@ export const staticColumn = [
     sortable: true,
     dataType: 'string',
     align: 'left',
+    width: '12%',
     truncateText: false,
     render: renderState,
   },
@@ -130,6 +131,7 @@ export const staticColumn = [
     sortable: true,
     dataType: 'number',
     align: 'right',
+    width: '16%',
     truncateText: false,
   },
   {

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -48,7 +48,7 @@ export const MAX_DETECTORS = 1000;
 export const MAX_ANOMALIES = 10000;
 
 export enum DETECTOR_STATE {
-  DISABLED = 'Disabled',
+  DISABLED = 'Stopped',
   INIT = 'Initializing',
   RUNNING = 'Running',
   INIT_FAILURE = 'Initialization failure',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Addresses some small feedback changes to the detector list page.
- Renames `Disabled` detector state to `Stopped` (affects detector list and dashboard pages)
- Decreases spacing between the search bar and filters to 8px
- Decreases spacing between the `Detector state` and `Anomalies last 24 hours` table cols

Before:
<img width="1156" alt="Screen Shot 2020-04-24 at 10 05 01 AM" src="https://user-images.githubusercontent.com/62119629/80238345-1f8c2400-8613-11ea-9ec0-fc370c1b8eff.png">

After:
<img width="1168" alt="Screen Shot 2020-04-24 at 10 00 41 AM" src="https://user-images.githubusercontent.com/62119629/80238063-9c6ace00-8612-11ea-8be0-5af76a5e464c.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
