### PR TITLE
Address couples of feedback. Issue: #26, #36, #37, #38

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -38,14 +38,16 @@ type ContentPanelProps = {
   titleContainerStyles?: React.CSSProperties;
   actions?: React.ReactNode | React.ReactNode[];
   children: React.ReactNode | React.ReactNode[];
+  contentPanelClassName?: string;
 };
 
 const ContentPanel = (props: ContentPanelProps) => (
   <EuiPanel
     style={{ paddingLeft: '0px', paddingRight: '0px', ...props.panelStyles }}
+    className={props.contentPanelClassName}
   >
     <EuiFlexGroup
-      style={{ padding: '0px 10px', ...props.titleContainerStyles }}
+      style={{ padding: '0px 20px', ...props.titleContainerStyles }}
       justifyContent="spaceBetween"
       alignItems="center"
     >
@@ -105,7 +107,7 @@ const ContentPanel = (props: ContentPanelProps) => (
         className={props.horizontalRuleClassName}
       />
     )}
-    <div style={{ padding: '0px 10px', ...props.bodyStyles }}>
+    <div style={{ padding: '0px 20px', ...props.bodyStyles }}>
       {props.children}
     </div>
   </EuiPanel>

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -14,8 +14,9 @@
  */
 
 import React from 'react';
-//@ts-ignore
+
 import {
+  //@ts-ignore
   EuiTitleSize,
   EuiFlexGroup,
   EuiFlexItem,
@@ -43,7 +44,10 @@ type ContentPanelProps = {
 
 const ContentPanel = (props: ContentPanelProps) => (
   <EuiPanel
-    style={{ paddingLeft: '0px', paddingRight: '0px', ...props.panelStyles }}
+    style={{
+      padding: '20px 0px',
+      ...props.panelStyles,
+    }}
     className={props.contentPanelClassName}
   >
     <EuiFlexGroup
@@ -55,7 +59,7 @@ const ContentPanel = (props: ContentPanelProps) => (
         {typeof props.title === 'string' ? (
           <EuiTitle
             size={props.titleSize || 'l'}
-            className={props.titleClassName || 'content-panel-title'}
+            className={props.titleClassName || ''}
           >
             <h3>{props.title}</h3>
           </EuiTitle>
@@ -107,7 +111,14 @@ const ContentPanel = (props: ContentPanelProps) => (
         className={props.horizontalRuleClassName}
       />
     )}
-    <div style={{ padding: '0px 20px', ...props.bodyStyles }}>
+    <div
+      style={{
+        paddingTop: '12px',
+        paddingLeft: '20px',
+        paddingRight: '20px',
+        ...props.bodyStyles,
+      }}
+    >
       {props.children}
     </div>
   </EuiPanel>

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
       class="euiFlexItem"
     >
       <h3
-        class="euiTitle euiTitle--large content-panel-title"
+        class="euiTitle euiTitle--large"
       >
         Testing
       </h3>

--- a/public/components/ContentPanel/index.scss
+++ b/public/components/ContentPanel/index.scss
@@ -14,12 +14,11 @@
  */
 
 .content-panel-title {
-  color: #3f3f3f;
+  color: #000;
 }
 
 .content-panel-subTitle {
   color: #879196;
-  font-family: 'Helvetica Neue';
   font-size: 12px;
   letter-spacing: 0;
 }

--- a/public/components/ContentPanel/index.scss
+++ b/public/components/ContentPanel/index.scss
@@ -13,10 +13,6 @@
  * permissions and limitations under the License.
  */
 
-.content-panel-title {
-  color: #000;
-}
-
 .content-panel-subTitle {
   color: #879196;
   font-size: 12px;

--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -34,9 +34,9 @@ import { useDispatch } from 'react-redux';
 import { Datum } from '@elastic/charts/dist/utils/commons';
 import React from 'react';
 import { TIME_RANGE_OPTIONS } from '../../Dashboard/utils/constants';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { searchES } from '../../../redux/reducers/elasticsearch';
-import { MAX_DETECTORS } from '../../../utils/constants';
+import { MAX_DETECTORS, MAX_ANOMALIES } from '../../../utils/constants';
 import { AD_DOC_FIELDS } from '../../../../server/utils/constants';
 export interface AnomaliesDistributionChartProps {
   allDetectorsSelected: boolean;
@@ -64,17 +64,23 @@ export const AnomaliesDistributionChart = (
   const [timeRange, setTimeRange] = useState(TIME_RANGE_OPTIONS[0].value);
 
   const getAnomalyResult = async (currentDetectors: DetectorListItem[]) => {
-    const finalAnomalyResult = await getLatestAnomalyResultsForDetectorsByTimeRange(
+    const latestAnomalyResult = await getLatestAnomalyResultsForDetectorsByTimeRange(
       searchES,
       props.selectedDetectors,
       timeRange,
-      MAX_DETECTORS,
-      dispatch
+      dispatch,
+      0,
+      MAX_ANOMALIES,
+      MAX_DETECTORS
     );
-    setAnomalyResults(finalAnomalyResult);
+
+    const nonZeroAnomalyResult = latestAnomalyResult.filter(
+      anomalyData => get(anomalyData, AD_DOC_FIELDS.ANOMALY_GRADE, 0) > 0
+    );
+    setAnomalyResults(nonZeroAnomalyResult);
 
     const resultDetectors = getFinalDetectors(
-      finalAnomalyResult,
+      nonZeroAnomalyResult,
       props.selectedDetectors
     );
     setIndicesNumber(getFinalIndices(resultDetectors).size);
@@ -123,9 +129,8 @@ export const AnomaliesDistributionChart = (
         <EuiFlexItem>
           <EuiText className={'anomaly-distribution-subtitle'}>
             <p>
-              {
-                'The inner circle shows the anomaly distribution by your indices. The outer circle shows the anomaly distribution by your detector'
-              }
+              {'The inner circle shows the anomaly distribution by your indices. ' +
+                'The outer circle shows the anomaly distribution by your detectors.'}
             </p>
           </EuiText>
         </EuiFlexItem>
@@ -141,13 +146,14 @@ export const AnomaliesDistributionChart = (
         />
       }
     >
-      <EuiFlexGroup style={{ padding: '10px' }}>
+      <EuiFlexGroup style={{ marginTop: '0px' }}>
         <EuiFlexItem>
           <EuiStat
             description={'Indices with anomalies'}
             title={indicesNumber}
             isLoading={anomalyResultsLoading}
             titleSize="s"
+            style={{ color: '#000' }}
           />
         </EuiFlexItem>
         <EuiFlexItem>
@@ -156,17 +162,12 @@ export const AnomaliesDistributionChart = (
             title={finalDetectors.length}
             isLoading={anomalyResultsLoading}
             titleSize="s"
+            style={{ color: '#000' }}
           />
         </EuiFlexItem>
       </EuiFlexGroup>
       {anomalyResultsLoading ? (
         <EuiFlexGroup justifyContent="center">
-          <EuiFlexItem grow={false}>
-            <EuiLoadingChart size="m" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiLoadingChart size="l" />
-          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiLoadingChart size="xl" />
           </EuiFlexItem>
@@ -174,67 +175,69 @@ export const AnomaliesDistributionChart = (
       ) : (
         <EuiFlexGroup justifyContent="center">
           <EuiFlexItem grow={false}>
-            <Chart className="anomalies-distribution-sunburst">
-              <Partition
-                id="Anomalies by index and detector"
-                data={visualizeAnomalyResultForSunburstChart(
-                  anomalyResults,
-                  finalDetectors
-                )}
-                valueAccessor={(d: Datum) => d.count as number}
-                valueFormatter={(d: number) => d.toString()}
-                layers={[
-                  {
-                    groupByRollup: (d: Datum) => d.indices,
-                    nodeLabel: (d: Datum) => {
-                      return d;
+            {isEmpty(anomalyResults) ? null : (
+              <Chart className="anomalies-distribution-sunburst">
+                <Partition
+                  id="Anomalies by index and detector"
+                  data={visualizeAnomalyResultForSunburstChart(
+                    anomalyResults,
+                    finalDetectors
+                  )}
+                  valueAccessor={(d: Datum) => d.count as number}
+                  valueFormatter={(d: number) => d.toString()}
+                  layers={[
+                    {
+                      groupByRollup: (d: Datum) => d.indices,
+                      nodeLabel: (d: Datum) => {
+                        return d;
+                      },
+                      fillLabel: {
+                        textInvertible: true,
+                      },
+                      shape: {
+                        fillColor: d => {
+                          return fillOutColors(
+                            d,
+                            (d.x0 + d.x1) / 2 / (2 * Math.PI),
+                            []
+                          );
+                        },
+                      },
                     },
+                    {
+                      groupByRollup: (d: Datum) => d.name,
+                      nodeLabel: (d: Datum) => {
+                        return d;
+                      },
+                      fillLabel: {
+                        textInvertible: true,
+                      },
+                      shape: {
+                        fillColor: d => {
+                          return fillOutColors(
+                            d,
+                            (d.x0 + d.x1) / 2 / (2 * Math.PI),
+                            []
+                          );
+                        },
+                      },
+                    },
+                  ]}
+                  config={{
+                    partitionLayout: PartitionLayout.sunburst,
+                    fontFamily: 'Arial',
+                    outerSizeRatio: 1,
                     fillLabel: {
                       textInvertible: true,
                     },
-                    shape: {
-                      fillColor: d => {
-                        return fillOutColors(
-                          d,
-                          (d.x0 + d.x1) / 2 / (2 * Math.PI),
-                          []
-                        );
-                      },
-                    },
-                  },
-                  {
-                    groupByRollup: (d: Datum) => d.name,
-                    nodeLabel: (d: Datum) => {
-                      return d;
-                    },
-                    fillLabel: {
-                      textInvertible: true,
-                    },
-                    shape: {
-                      fillColor: d => {
-                        return fillOutColors(
-                          d,
-                          (d.x0 + d.x1) / 2 / (2 * Math.PI),
-                          []
-                        );
-                      },
-                    },
-                  },
-                ]}
-                config={{
-                  partitionLayout: PartitionLayout.sunburst,
-                  fontFamily: 'Arial',
-                  outerSizeRatio: 1,
-                  fillLabel: {
-                    textInvertible: true,
-                  },
-                  // TODO: Given only 1 detector exists, the inside Index circle will have issue in following scenarios:
-                  // 1: if Linked Label is configured for identifying index, label of Index circle will be invisible;
-                  // 2: if Fill Label is configured for identifying index, label of it will be overlapped with outer Detector circle
-                  // Issue link: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/24
-                }}
-              />
-            </Chart>
+                    // TODO: Given only 1 detector exists, the inside Index circle will have issue in following scenarios:
+                    // 1: if Linked Label is configured for identifying index, label of Index circle will be invisible;
+                    // 2: if Fill Label is configured for identifying index, label of it will be overlapped with outer Detector circle
+                    // Issue link: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/24
+                  }}
+                />
+              </Chart>
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       )}

--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -146,14 +146,13 @@ export const AnomaliesDistributionChart = (
         />
       }
     >
-      <EuiFlexGroup style={{ marginTop: '0px' }}>
+      <EuiFlexGroup>
         <EuiFlexItem>
           <EuiStat
             description={'Indices with anomalies'}
             title={indicesNumber}
             isLoading={anomalyResultsLoading}
             titleSize="s"
-            style={{ color: '#000' }}
           />
         </EuiFlexItem>
         <EuiFlexItem>
@@ -162,7 +161,6 @@ export const AnomaliesDistributionChart = (
             title={finalDetectors.length}
             isLoading={anomalyResultsLoading}
             titleSize="s"
-            style={{ color: '#000' }}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -191,7 +191,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   return (
     <ContentPanel
       title={
-        <EuiTitle size="s" className="content-panel-title">
+        <EuiTitle size="s">
           <h3>
             Live anomalies{' '}
             <EuiBadge color={hasLatestAnomalyData ? '#DB1374' : '#DDD'}>
@@ -206,7 +206,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
             <p>
               {'Live anomaly results across detectors for the last 30 minutes. ' +
                 'The results refresh every 1 minute. ' +
-                'For each detector, if an anomaly occurence is detected at the end of the detector interval, ' +
+                'For each detector, if an anomaly occurrence is detected at the end of the detector interval, ' +
                 'you will see a bar representing its anomaly grade.'}
             </p>
           </EuiText>
@@ -238,13 +238,12 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         // show below content as long as there exists anomaly data,
         // regardless of whether anomaly grade is 0 or larger.
         [
-          <EuiFlexGroup style={{ marginTop: '0px' }}>
+          <EuiFlexGroup>
             <EuiFlexItem>
               <EuiStat
                 description={'Last updated time'}
                 title={liveTimeRange.endDateTime.format('MM/DD/YYYY hh:mm A')}
                 titleSize="s"
-                style={{ color: '#000' }}
               />
             </EuiFlexItem>
             <EuiFlexItem>
@@ -256,7 +255,6 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                     : get(lastAnomalyResult, AD_DOC_FIELDS.DETECTOR_NAME, '')
                 }
                 titleSize="s"
-                style={{ color: '#000' }}
               />
             </EuiFlexItem>
             <EuiFlexItem>
@@ -268,7 +266,6 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                     : get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
                 }
                 titleSize="s"
-                style={{ color: '#000' }}
               />
             </EuiFlexItem>
           </EuiFlexGroup>,
@@ -286,9 +283,9 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                   }}
                 >
                   <p>
-                    10 detectors with the most recent anomalies are shown on the
+                    {`${MAX_LIVE_DETECTORS} detectors with the most recent anomalies are shown on the
                     chart. Adjust filters if there are specific detectors you
-                    would like to monitor.
+                    would like to monitor.`}
                   </p>
                 </EuiCallOut>
               ) : anomalousDetectorCount === 0 ? (

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -72,7 +72,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   const dispatch = useDispatch();
 
   const [liveTimeRange, setLiveTimeRange] = useState<LiveTimeRangeState>({
-    startDateTime: moment().subtract(30, 'minutes'),
+    startDateTime: moment().subtract(31, 'minutes'),
     endDateTime: moment(),
   });
 
@@ -121,7 +121,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
       setAnomalousDetectorCount(0);
     }
     setLiveTimeRange({
-      startDateTime: moment().subtract(30, 'minutes'),
+      startDateTime: moment().subtract(31, 'minutes'),
       endDateTime: moment(),
     });
   };

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -21,6 +21,8 @@ import {
 } from '../../../../server/utils/constants';
 import {
   EuiBadge,
+  EuiButton,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingChart,
@@ -52,6 +54,7 @@ import {
   getLatestAnomalyResultsForDetectorsByTimeRange,
 } from '../utils/utils';
 import { AppState } from '../../../redux/reducers';
+import { MAX_ANOMALIES } from '../../../utils/constants';
 
 export interface AnomaliesLiveChartProps {
   allDetectorsSelected: boolean;
@@ -81,20 +84,41 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
 
   const [liveAnomalyData, setLiveAnomalyData] = useState([] as object[]);
 
+  const [anomalousDetectorCount, setAnomalousDetectorCount] = useState(0);
+
+  const [hasLatestAnomalyData, setHasLatestAnomalyData] = useState(false);
+
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
   const getLiveAnomalyResults = async () => {
-    const finalLiveAnomalyResult = await getLatestAnomalyResultsForDetectorsByTimeRange(
+    const latestLiveAnomalyResult = await getLatestAnomalyResultsForDetectorsByTimeRange(
       searchES,
       props.selectedDetectors,
       '30m',
-      MAX_LIVE_DETECTORS,
-      dispatch
+      dispatch,
+      -1,
+      MAX_ANOMALIES,
+      MAX_LIVE_DETECTORS
     );
 
-    setLiveAnomalyData(finalLiveAnomalyResult);
-    if (!isEmpty(finalLiveAnomalyResult)) {
-      setLastAnomalyResult(finalLiveAnomalyResult[0]);
+    setHasLatestAnomalyData(!isEmpty(latestLiveAnomalyResult));
+
+    const nonZeroAnomalyResult = latestLiveAnomalyResult.filter(
+      anomalyData => get(anomalyData, AD_DOC_FIELDS.ANOMALY_GRADE, 0) > 0
+    );
+    setLiveAnomalyData(nonZeroAnomalyResult);
+
+    if (!isEmpty(nonZeroAnomalyResult)) {
+      setLastAnomalyResult(nonZeroAnomalyResult[0]);
+      const uniqueIds = new Set(
+        nonZeroAnomalyResult.map(anomalyData =>
+          get(anomalyData, AD_DOC_FIELDS.DETECTOR_ID, '')
+        )
+      );
+      setAnomalousDetectorCount(uniqueIds.size);
     } else {
       setLastAnomalyResult(undefined);
+      setAnomalousDetectorCount(0);
     }
     setLiveTimeRange({
       startDateTime: moment().subtract(30, 'minutes'),
@@ -121,46 +145,47 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   const prepareVisualizedAnomalies = (
     liveVisualizedAnomalies: object[]
   ): object[] => {
-    // add data point placeholder at every minute,
-    // to ensure chart evenly distrubted
-    const existingPlotTimes = liveVisualizedAnomalies.map(anomaly =>
-      getFloorPlotTime(get(anomaly, AD_DOC_FIELDS.PLOT_TIME, 0))
-    );
     const result = [...liveVisualizedAnomalies];
 
-    for (
-      let currentTime = getFloorPlotTime(liveTimeRange.startDateTime.valueOf());
-      currentTime <= liveTimeRange.endDateTime.valueOf();
-      currentTime += MIN_IN_MILLI_SECS
-    ) {
-      if (existingPlotTimes.includes(currentTime)) {
-        continue;
-      }
-      result.push({
-        [AD_DOC_FIELDS.DETECTOR_NAME]: '',
-        [AD_DOC_FIELDS.PLOT_TIME]: currentTime,
-        [AD_DOC_FIELDS.ANOMALY_GRADE]: null,
-      });
-    }
+    // add placeholder data point to make sure chart exists
+    result.push({
+      [AD_DOC_FIELDS.DETECTOR_NAME]: null,
+      [AD_DOC_FIELDS.PLOT_TIME]: getFloorPlotTime(
+        liveTimeRange.startDateTime.valueOf()
+      ),
+      [AD_DOC_FIELDS.ANOMALY_GRADE]: null,
+    });
+
     return result;
   };
 
   const timeNowAnnotation = {
     dataValue: getFloorPlotTime(liveTimeRange.endDateTime.valueOf()),
     header: 'Now',
-    details: liveTimeRange.endDateTime.format('MM/DD/YY h:mm a'),
+    details: liveTimeRange.endDateTime.format('MM/DD/YY h:mm A'),
   } as LineAnnotationDatum;
 
   const annotations = [timeNowAnnotation];
 
-  // Add View full screen button
-  // Issue link: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/26
+  const fullScreenButton = () => (
+    <EuiButton
+      onClick={() => setIsFullScreen(isFullScreen => !isFullScreen)}
+      iconType={isFullScreen ? 'exit' : 'fullScreen'}
+      aria-label="View full screen"
+    >
+      {isFullScreen ? 'Exit full screen' : 'View full screen'}
+    </EuiButton>
+  );
+
   return (
     <ContentPanel
       title={
         <EuiTitle size="s" className="content-panel-title">
           <h3>
-            Live anomalies <EuiBadge color={'#DB1374'}>Live</EuiBadge>
+            Live anomalies{' '}
+            <EuiBadge color={hasLatestAnomalyData ? '#DB1374' : '#DDD'}>
+              Live
+            </EuiBadge>
           </h3>
         </EuiTitle>
       }
@@ -168,101 +193,161 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         <EuiFlexItem>
           <EuiText className={'live-anomaly-results-subtile'}>
             <p>
-              {'Live anomaly results across detectors for the last 30 minutes'}
+              {'Live anomaly results across detectors for the last 30 minutes. ' +
+                'The results refresh every 1 minute. ' +
+                'For each detector, if an anomaly occurence is detected at the end of the detector interval, ' +
+                'you will see a bar representing its anomaly grade.'}
             </p>
           </EuiText>
         </EuiFlexItem>
       }
+      actions={[fullScreenButton()]}
+      contentPanelClassName={isFullScreen ? 'full-screen' : undefined}
     >
-      <EuiFlexGroup style={{ padding: '10px' }}>
-        <EuiFlexItem>
-          <EuiStat
-            description={'Detector with most recent anomaly occurrence'}
-            title={
-              lastAnomalyResult === undefined
-                ? '-'
-                : get(lastAnomalyResult, AD_DOC_FIELDS.DETECTOR_NAME, '')
-            }
-            titleSize="s"
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiStat
-            description={'Most recent anomaly grade'}
-            title={
-              lastAnomalyResult === undefined
-                ? '-'
-                : get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
-            }
-            titleSize="s"
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiStat
-            description={'Last updated time'}
-            title={liveTimeRange.endDateTime.format('MM/DD/YYYY hh:mm a')}
-            titleSize="s"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <div
-        style={{
-          height: '200px',
-          width: '100%',
-          opacity: 1,
-        }}
-      >
-        {elasticsearchState.requesting ? (
-          <EuiFlexGroup justifyContent="center">
-            <EuiFlexItem grow={false}>
-              <EuiLoadingChart size="m" />
+      {elasticsearchState.requesting ? (
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false}>
+            <EuiLoadingChart size="xl" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : !hasLatestAnomalyData ? (
+        <EuiText
+          style={{
+            color: '#666666',
+            paddingTop: '12px',
+            paddingBottom: '4px',
+          }}
+        >
+          <p>
+            All matching detectors are under initialization or stopped for the
+            last 30 minutes. Please adjust filters or come back later.
+          </p>
+        </EuiText>
+      ) : (
+        // show below content as long as there exists anomaly data,
+        // regardless of whether anomaly grade is 0 or larger.
+        [
+          <EuiFlexGroup style={{ marginTop: '0px' }}>
+            <EuiFlexItem>
+              <EuiStat
+                description={'Last updated time'}
+                title={liveTimeRange.endDateTime.format('MM/DD/YYYY hh:mm A')}
+                titleSize="s"
+                style={{ color: '#000' }}
+              />
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiLoadingChart size="l" />
+            <EuiFlexItem>
+              <EuiStat
+                description={'Detector with most recent anomaly occurrence'}
+                title={
+                  lastAnomalyResult === undefined
+                    ? '-'
+                    : get(lastAnomalyResult, AD_DOC_FIELDS.DETECTOR_NAME, '')
+                }
+                titleSize="s"
+                style={{ color: '#000' }}
+              />
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiLoadingChart size="xl" />
+            <EuiFlexItem>
+              <EuiStat
+                description={'Most recent anomaly grade'}
+                title={
+                  lastAnomalyResult === undefined
+                    ? '-'
+                    : get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
+                }
+                titleSize="s"
+                style={{ color: '#000' }}
+              />
             </EuiFlexItem>
-          </EuiFlexGroup>
-        ) : (
-          [
-            <EuiText size="s" style={{ marginLeft: '10px' }}>
-              <p>10 detectors with the most recent anomaly occurrence</p>
-            </EuiText>,
-            <Chart>
-              <Settings showLegend legendPosition={Position.Right} />
-              <LineAnnotation
-                domainType={AnnotationDomainTypes.XDomain}
-                dataValues={annotations}
-                style={TIME_NOW_LINE_STYLE}
-                marker={'Now'}
-              />
-              <Axis
-                id={'bottom'}
-                position={Position.Bottom}
-                tickFormat={timeFormatter}
-                showOverlappingTicks={false}
-              />
-              <Axis
-                id={'left'}
-                title={'Anomaly grade'}
-                position={Position.Left}
-                domain={{ min: 0, max: 1 }}
-              />
-              <BarSeries
-                id={'Detectors Anomaly grade'}
-                xScaleType={ScaleType.Time}
-                timeZone="local"
-                yScaleType="linear"
-                xAccessor={AD_DOC_FIELDS.PLOT_TIME}
-                yAccessors={[AD_DOC_FIELDS.ANOMALY_GRADE]}
-                splitSeriesAccessors={[AD_DOC_FIELDS.DETECTOR_NAME]}
-                data={prepareVisualizedAnomalies(visualizedAnomalies)}
-              />
-            </Chart>,
-          ]
-        )}
-      </div>
+          </EuiFlexGroup>,
+          <div>
+            {[
+              // only show below message when anomalousDetectorCount >= MAX_LIVE_DETECTORS
+              anomalousDetectorCount >= MAX_LIVE_DETECTORS ? (
+                <EuiCallOut
+                  size="s"
+                  title={`You are viewing ${MAX_LIVE_DETECTORS} detectors with the most recent anomaly occurrences.`}
+                  style={{
+                    width: '86%', // ensure width reaches NOW annotation line
+                    marginTop: '20px',
+                    marginBottom: '20px',
+                  }}
+                >
+                  <p>
+                    10 detectors with the most recent anomalies are shown on the
+                    chart. Adjust filters if there are specific detectors you
+                    would like to monitor.
+                  </p>
+                </EuiCallOut>
+              ) : anomalousDetectorCount === 0 ? (
+                // all the data points have anomaly grade as 0
+                <EuiCallOut
+                  color="success"
+                  size="s"
+                  title="No anomalies found during the last 30 minutes across all matching detectors."
+                  style={{
+                    width: '96%', // ensure width reaches NOW line
+                    marginTop: '20px',
+                    marginBottom: '20px',
+                  }}
+                />
+              ) : null,
+              <div
+                style={{
+                  height: '200px',
+                  width: '100%',
+                  opacity: 1,
+                }}
+              >
+                <Chart>
+                  <Settings
+                    // hide legend if there only exists anomalies with 0 anomaly grade
+                    showLegend={!isEmpty(liveAnomalyData)}
+                    legendPosition={Position.Right}
+                    xDomain={{
+                      min: liveTimeRange.startDateTime.valueOf(),
+                      max: liveTimeRange.endDateTime.valueOf(),
+                      // minInterval: MIN_IN_MILLI_SECS,
+                    }}
+                  />
+                  <LineAnnotation
+                    domainType={AnnotationDomainTypes.XDomain}
+                    dataValues={annotations}
+                    style={TIME_NOW_LINE_STYLE}
+                    marker={'Now'}
+                  />
+                  <Axis
+                    id={'bottom'}
+                    position={Position.Bottom}
+                    tickFormat={timeFormatter}
+                    showOverlappingTicks={false}
+                  />
+                  <Axis
+                    id={'left'}
+                    title={'Anomaly grade'}
+                    position={Position.Left}
+                    domain={{ min: 0, max: 1 }}
+                  />
+                  <BarSeries
+                    // `id` for placeholder data point introduced by `prepareVisualizedAnomalies` shows as legend,
+                    // When there exists anomalies with anomaly grade > 0
+                    // we make `id` to blank string to hide the legend of placeholder data point
+                    id={!isEmpty(liveAnomalyData) ? '' : ' '}
+                    xScaleType={ScaleType.Time}
+                    timeZone="local"
+                    yScaleType="linear"
+                    xAccessor={AD_DOC_FIELDS.PLOT_TIME}
+                    yAccessors={[AD_DOC_FIELDS.ANOMALY_GRADE]}
+                    splitSeriesAccessors={[AD_DOC_FIELDS.DETECTOR_NAME]}
+                    data={prepareVisualizedAnomalies(visualizedAnomalies)}
+                  />
+                </Chart>
+              </div>,
+            ]}
+          </div>,
+        ]
+      )}
     </ContentPanel>
   );
 };

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -161,7 +161,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         continue;
       }
       result.push({
-        [AD_DOC_FIELDS.DETECTOR_NAME]: null,
+        [AD_DOC_FIELDS.DETECTOR_NAME]: !isEmpty(liveAnomalyData) ? '' : null,
         [AD_DOC_FIELDS.PLOT_TIME]: currentTime,
         [AD_DOC_FIELDS.ANOMALY_GRADE]: null,
       });
@@ -303,7 +303,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
               ) : null,
               <div
                 style={{
-                  height: '200px',
+                  height: isFullScreen ? '400px' : '200px',
                   width: '100%',
                   opacity: 1,
                 }}
@@ -337,10 +337,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                     domain={{ min: 0, max: 1 }}
                   />
                   <BarSeries
-                    // `id` for placeholder data point introduced by `prepareVisualizedAnomalies` shows as legend,
-                    // When there exists anomalies with anomaly grade > 0
-                    // we make `id` to blank string to hide the legend of placeholder data point
-                    id={!isEmpty(liveAnomalyData) ? '' : ' '}
+                    id={'Detector Anomaly grade'}
                     xScaleType={ScaleType.Time}
                     timeZone="local"
                     yScaleType="linear"

--- a/public/pages/Dashboard/Components/AnomalousDetectorsList.tsx
+++ b/public/pages/Dashboard/Components/AnomalousDetectorsList.tsx
@@ -76,22 +76,24 @@ export const AnomalousDetectorsList = (props: AnomalousDetectorsListProps) => {
   };
 
   return (
-    <ContentPanel title="Detectors and features" titleSize="s">
-      <EuiBasicTable
-        items={getOrderedDetectorsForPage(
-          props.selectedDetectors,
-          indexOfPage,
-          sizeOfPage,
-          sortDirection,
-          fieldForSort
-        )}
-        columns={anomalousDetectorsStaticColumn}
-        tableLayout={'auto'}
-        onChange={handleTableChange}
-        sorting={sorting}
-        pagination={pagination}
-        compressed
-      />
-    </ContentPanel>
+    <div style={{ height: 'auto' }}>
+      <ContentPanel title="Detectors and features" titleSize="s">
+        <EuiBasicTable
+          items={getOrderedDetectorsForPage(
+            props.selectedDetectors,
+            indexOfPage,
+            sizeOfPage,
+            sortDirection,
+            fieldForSort
+          )}
+          columns={anomalousDetectorsStaticColumn}
+          tableLayout={'auto'}
+          onChange={handleTableChange}
+          sorting={sorting}
+          pagination={pagination}
+          compressed
+        />
+      </ContentPanel>
+    </div>
   );
 };

--- a/public/pages/Dashboard/Container/Dashboard.tsx
+++ b/public/pages/Dashboard/Container/Dashboard.tsx
@@ -29,16 +29,21 @@ export const Dashboard = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const onRefreshPage = async () => {
-    await dispatch(
-      getDetectorList({
-        from: 0,
-        size: 1,
-        search: '',
-        sortDirection: SORT_DIRECTION.DESC,
-        sortField: 'name',
-      })
-    );
-    setIsLoading(false);
+    try {
+      await dispatch(
+        getDetectorList({
+          from: 0,
+          size: 1,
+          search: '',
+          sortDirection: SORT_DIRECTION.DESC,
+          sortField: 'name',
+        })
+      );
+    } catch (error) {
+      console.log('Error is found during getting detector list', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const totalDetectors = useSelector(

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -187,8 +187,8 @@ export function DashboardOverview() {
 
   return (
     <Fragment>
-      <EuiFlexGroup justifyContent="flexStart">
-        <EuiFlexItem grow={1}>
+      <EuiFlexGroup justifyContent="flexStart" gutterSize="s">
+        <EuiFlexItem>
           <EuiComboBox
             id="detectorFilter"
             placeholder={ALL_DETECTORS_MESSAGE}
@@ -196,9 +196,10 @@ export function DashboardOverview() {
             onChange={handleDetectorsFilterChange}
             selectedOptions={selectedDetectorsName.map(buildItemOption)}
             isClearable={true}
+            fullWidth
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={1}>
+        <EuiFlexItem>
           <EuiComboBox
             id="detectorStateFilter"
             placeholder={ALL_DETECTOR_STATES_MESSAGE}
@@ -206,9 +207,10 @@ export function DashboardOverview() {
             onChange={handleDetectorStateFilterChange}
             selectedOptions={selectedDetectorStates.map(buildItemOption)}
             isClearable={true}
+            fullWidth
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem>
           <EuiComboBox
             id="indicesFilter"
             placeholder={ALL_INDICES_MESSAGE}
@@ -216,6 +218,7 @@ export function DashboardOverview() {
             onChange={handleIndicesFilterChange}
             selectedOptions={selectedIndices.map(buildItemOption)}
             isClearable={true}
+            fullWidth
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -23,7 +23,6 @@ import { DetectorListItem } from '../../../models/interfaces';
 import { getIndices, getAliases } from '../../../redux/reducers/elasticsearch';
 import { getDetectorList } from '../../../redux/reducers/ad';
 import {
-  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiComboBox,
@@ -40,11 +39,7 @@ import {
 import { AppState } from '../../../redux/reducers';
 import { CatIndex, IndexAlias } from '../../../../server/models/types';
 import { getVisibleOptions } from '../../utils/helpers';
-import {
-  DETECTOR_STATE,
-  PLUGIN_NAME,
-  APP_PATH,
-} from '../../../utils/constants';
+import { DETECTOR_STATE } from '../../../utils/constants';
 import { getDetectorStateOptions } from '../../DetectorsList/utils/helpers';
 
 export function DashboardOverview() {

--- a/public/pages/Dashboard/index.scss
+++ b/public/pages/Dashboard/index.scss
@@ -14,23 +14,29 @@
  */
 
 .live-anomaly-results-subtile {
-  height: 14px;
-  width: 376px;
   color: #879196;
-  font-family: 'Helvetica Neue';
   font-size: 12px;
   letter-spacing: 0;
-  line-height: 14px;
+  line-height: 16px;
 }
 
 .anomaly-distribution-subtitle {
   color: #879196;
-  font-family: 'Helvetica Neue';
   font-size: 12px;
   letter-spacing: 0;
+  line-height: 16px;
 }
 
 .anomalies-distribution-sunburst {
-  height: 500px;
-  width: 500px;
+  height: 400px;
+  width: 400px;
+}
+
+.full-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
 }

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -436,7 +436,7 @@ export const buildGetAnomalyResultQueryByRange = (
   timeRange: string,
   from: number,
   size: number,
-  threadhold: number
+  threshold: number
 ) => {
   return {
     index: `${ANOMALY_RESULT_INDEX}*`,
@@ -448,7 +448,7 @@ export const buildGetAnomalyResultQueryByRange = (
           {
             range: {
               [AD_DOC_FIELDS.ANOMALY_GRADE]: {
-                gt: threadhold,
+                gt: threshold,
               },
             },
           },
@@ -480,7 +480,7 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
   selectedDetectors: DetectorListItem[],
   timeRange: string,
   dispatch: Dispatch<any>,
-  threadhold: number,
+  threshold: number,
   anomalySize: number,
   detectorNum: number
 ): Promise<object[]> => {
@@ -495,7 +495,7 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
           timeRange,
           from,
           anomalySize,
-          threadhold
+          threshold
         )
       )
     );
@@ -539,7 +539,7 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
     SORT_DIRECTION.DESC
   );
 
-  const latestDetetorIds = selectLatestDetetorIds(
+  const latestDetetorIds = selectLatestDetectorIds(
     orderedLiveAnomalyData,
     detectorNum
   );
@@ -562,7 +562,7 @@ const buildDetectorAndIdMap = (
   return detectorAndIdMap;
 };
 
-const selectLatestDetetorIds = (
+const selectLatestDetectorIds = (
   orderedAnomalyData: object[],
   neededDetectorNum: number
 ): Set<string> => {
@@ -571,16 +571,6 @@ const selectLatestDetetorIds = (
       get(anomalyData, AD_DOC_FIELDS.DETECTOR_ID, '')
     )
   );
-  if (uniqueIds.size <= neededDetectorNum) {
-    return uniqueIds;
-  }
-  const latestDetectorIds = new Set<string>();
-  for (let anomalyData of orderedAnomalyData) {
-    const detectorId = get(anomalyData, AD_DOC_FIELDS.DETECTOR_ID, '');
-    latestDetectorIds.add(detectorId);
-    if (latestDetectorIds.size === neededDetectorNum) {
-      return latestDetectorIds;
-    }
-  }
-  return latestDetectorIds;
+
+  return new Set(Array.from(uniqueIds).slice(0, neededDetectorNum));
 };

--- a/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
+++ b/public/pages/createDetector/components/DetectorInfo/__tests__/__snapshots__/DetectorInfo.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<DetectorInfo /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <h3
-          class="euiTitle euiTitle--small content-panel-title"
+          class="euiTitle euiTitle--small"
         >
           Name and description
         </h3>

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           class="euiFlexItem"
         >
           <h3
-            class="euiTitle euiTitle--small content-panel-title"
+            class="euiTitle euiTitle--small"
           >
             Name and description
           </h3>
@@ -164,7 +164,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           class="euiFlexItem"
         >
           <h3
-            class="euiTitle euiTitle--small content-panel-title"
+            class="euiTitle euiTitle--small"
           >
             Data Source
           </h3>
@@ -525,7 +525,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
           class="euiFlexItem"
         >
           <h3
-            class="euiTitle euiTitle--small content-panel-title"
+            class="euiTitle euiTitle--small"
           >
             Detector operation settings
           </h3>


### PR DESCRIPTION
*Issue #, if available:*
Address couples of feedback. Issue: #26, #36, #37, #38
*Description of changes:*
1. change the detector link on dashboard detector list table should redirect to AD result page
1. add Fullscreen of dashboard live chart
1. Fix issue that: for a new domain which has no AD plugin running, dashboard will always show loading status as we can’t get detectors (detector index not found). We need to show empty dashboard page
1. Decrease line height for subtitle of Distribution Sunburst Chart on Dashboard
1. Increase margin Live Anomalies title to 20px, make all the text/wording is aligned/consistent with other components
1. Filter boxes can use full-width, margin between filter boxes is too wide(decrease to 8px), we can make filter boxes take the all whole row. The goal is to make all boxes long enough to avoid stacked multi-selections as much as possible
1. Use dynamic height for Detector&Feature list, its height is not necessary to be same as Distribution Sunburst chart.
1. Decrease size of Distribution Sunburst chart to 400px/360px
1. Change style of subtitle of Live Anomaly chart.
1. Keep XL loading chart only.
1.  Couples of style changes required by UX designer. 
1. Change anomaly live chart in cases of 1) no anomaly result; 2) there exists anomaly data; 3) only anomaly grade 0 data like below

![Screen Shot 2020-04-23 at 9 45 19 PM](https://user-images.githubusercontent.com/59710443/80257989-05643d00-8637-11ea-9544-11f06dbaac5e.png)
![Screen Shot 2020-04-23 at 10 42 38 PM](https://user-images.githubusercontent.com/59710443/80257975-fed5c580-8636-11ea-9e2e-8f1816fe8b0e.png)
![Screen Shot 2020-04-23 at 11 09 48 PM](https://user-images.githubusercontent.com/59710443/80258041-1b71fd80-8637-11ea-96de-372af3c9752e.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
