### PR TITLE
type delete when delete detector; enhance confirm modal

### DIFF
--- a/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
+++ b/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
@@ -30,10 +30,11 @@ import {
 
 interface ConfirmModalProps {
   title: string;
-  description: string;
+  description: string | React.ReactNode;
   callout?: any;
   confirmButtonText: string;
   confirmButtonColor: ButtonColor;
+  confirmButtonDisabled?: boolean;
   onClose(): void;
   onCancel(): void;
   onConfirm(): void;
@@ -45,15 +46,19 @@ export const ConfirmModal = (props: ConfirmModalProps) => {
       <EuiModalHeader>
         <EuiModalHeaderTitle>{props.title}</EuiModalHeaderTitle>
       </EuiModalHeader>
-      <EuiModalBody style={{ paddingLeft: '24px', paddingRight: '24px' }}>
+      <EuiModalBody>
         <EuiFlexGroup direction="column">
           {props.callout ? (
             <EuiFlexItem grow={false}>{props.callout}</EuiFlexItem>
           ) : null}
           <EuiFlexItem grow={false}>
-            <EuiText>
-              <p>{props.description}</p>
-            </EuiText>
+            {typeof props.description === 'string' ? (
+              <EuiText>
+                <p>{props.description}</p>
+              </EuiText>
+            ) : (
+              <React.Fragment>{props.description}</React.Fragment>
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiModalBody>
@@ -65,6 +70,7 @@ export const ConfirmModal = (props: ConfirmModalProps) => {
           color={props.confirmButtonColor}
           fill
           onClick={props.onConfirm}
+          disabled={!!props.confirmButtonDisabled}
         >
           {props.confirmButtonText}
         </EuiButton>

--- a/public/pages/DetectorDetail/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/public/pages/DetectorDetail/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`<ConfirmModal /> spec Confirm Modal renders component with callout 1`] 
         </div>
         <div
           class="euiModalBody"
-          style="padding-left: 24px; padding-right: 24px;"
         >
           <div
             class="euiModalBody__overflow"
@@ -164,7 +163,6 @@ exports[`<ConfirmModal /> spec Confirm Modal renders component with empty callou
         </div>
         <div
           class="euiModalBody"
-          style="padding-left: 24px; padding-right: 24px;"
         >
           <div
             class="euiModalBody__overflow"

--- a/public/pages/DetectorDetail/components/DetectorControls/DetectorControls.tsx
+++ b/public/pages/DetectorDetail/components/DetectorControls/DetectorControls.tsx
@@ -36,7 +36,7 @@ export const DetectorControls = (props: DetectorControls) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={{ marginRight: '16px' }}>
         <EuiPopover
           id="actionsPopover"
           button={
@@ -56,7 +56,7 @@ export const DetectorControls = (props: DetectorControls) => {
         >
           <EuiContextMenuPanel>
             <EuiContextMenuItem
-              key="edit"
+              key="editDetector"
               data-test-subj="editDetector"
               onClick={props.onEditDetector}
             >
@@ -64,7 +64,7 @@ export const DetectorControls = (props: DetectorControls) => {
             </EuiContextMenuItem>
 
             <EuiContextMenuItem
-              key="edit"
+              key="editFeatures"
               data-test-subj="editFeature"
               onClick={props.onEditFeatures}
             >
@@ -81,7 +81,7 @@ export const DetectorControls = (props: DetectorControls) => {
           </EuiContextMenuPanel>
         </EuiPopover>
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={{ marginLeft: '0px' }}>
         <EuiButton
           data-test-subj="stopDetectorButton"
           onClick={

--- a/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
+++ b/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-right: 16px;"
     >
       <div
         class="euiPopover euiPopover--anchorDownLeft"
@@ -44,6 +45,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-left: 0px;"
     >
       <button
         class="euiButton euiButton--primary"
@@ -82,6 +84,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-right: 16px;"
     >
       <div
         class="euiPopover euiPopover--anchorDownLeft"
@@ -119,6 +122,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-left: 0px;"
     >
       <button
         class="euiButton euiButton--primary"
@@ -156,6 +160,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-right: 16px;"
     >
       <div
         class="euiPopover euiPopover--anchorDownLeft"
@@ -193,6 +198,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-left: 0px;"
     >
       <button
         class="euiButton euiButton--primary"
@@ -231,6 +237,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-right: 16px;"
     >
       <div
         class="euiPopover euiPopover--anchorDownLeft"
@@ -268,6 +275,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="margin-left: 0px;"
     >
       <button
         class="euiButton euiButton--primary"

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -95,7 +95,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
 
-  const [detecorDetailModel, setDetecorDetailModel] = useState<
+  const [detecorDetailModel, setDetectorDetailModel] = useState<
     DetectorDetailModel
   >({
     selectedTab: getSelectedTabId(
@@ -127,7 +127,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   }, [detector]);
 
   const handleSwitchToConfigurationTab = useCallback(() => {
-    setDetecorDetailModel({
+    setDetectorDetailModel({
       ...detecorDetailModel,
       selectedTab: DETECTOR_DETAIL_TABS.CONFIGURATIONS,
     });
@@ -135,7 +135,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   }, []);
 
   const handleTabChange = (route: DETECTOR_DETAIL_TABS) => {
-    setDetecorDetailModel({
+    setDetectorDetailModel({
       ...detecorDetailModel,
       selectedTab: route,
     });
@@ -143,21 +143,21 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   };
 
   const hideMonitorCalloutModal = () => {
-    setDetecorDetailModel({
+    setDetectorDetailModel({
       ...detecorDetailModel,
       showMonitorCalloutModal: false,
     });
   };
 
   const hideStopDetectorModal = () => {
-    setDetecorDetailModel({
+    setDetectorDetailModel({
       ...detecorDetailModel,
       showStopDetectorModalFor: undefined,
     });
   };
 
   const hideDeleteDetectorModal = () => {
-    setDetecorDetailModel({
+    setDetectorDetailModel({
       ...detecorDetailModel,
       showDeleteDetectorModal: false,
     });
@@ -222,7 +222,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
 
   const handleEditDetector = () => {
     detector.enabled
-      ? setDetecorDetailModel({
+      ? setDetectorDetailModel({
           ...detecorDetailModel,
           showStopDetectorModalFor: 'detector',
         })
@@ -231,7 +231,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
 
   const handleEditFeature = () => {
     detector.enabled
-      ? setDetecorDetailModel({
+      ? setDetectorDetailModel({
           ...detecorDetailModel,
           showStopDetectorModalFor: 'features',
         })
@@ -303,7 +303,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
             <DetectorControls
               onEditDetector={handleEditDetector}
               onDelete={() =>
-                setDetecorDetailModel({
+                setDetectorDetailModel({
                   ...detecorDetailModel,
                   showDeleteDetectorModal: true,
                 })
@@ -311,7 +311,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
               onStartDetector={() => handleStartAdJob(detectorId)}
               onStopDetector={() =>
                 monitor
-                  ? setDetecorDetailModel({
+                  ? setDetectorDetailModel({
                       ...detecorDetailModel,
                       showMonitorCalloutModal: true,
                     })
@@ -362,12 +362,12 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                     placeholder="delete"
                     onChange={e => {
                       if (e.target.value === 'delete') {
-                        setDetecorDetailModel({
+                        setDetectorDetailModel({
                           ...detecorDetailModel,
                           deleteTyped: true,
                         });
                       } else {
-                        setDetecorDetailModel({
+                        setDetectorDetailModel({
                           ...detecorDetailModel,
                           deleteTyped: false,
                         });

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, Fragment } from 'react';
 import {
   EuiTabs,
   EuiTab,
@@ -22,6 +22,10 @@ import {
   EuiTitle,
   EuiHealth,
   EuiOverlayMask,
+  EuiCallOut,
+  EuiSpacer,
+  EuiText,
+  EuiFieldText,
 } from '@elastic/eui';
 // @ts-ignore
 import { toastNotifications } from 'ui/notify';
@@ -39,13 +43,15 @@ import { getErrorMessage, Listener } from '../../../utils/utils';
 //@ts-ignore
 import chrome from 'ui/chrome';
 import { darkModeEnabled } from '../../../utils/kibanaUtils';
-import { BREADCRUMBS } from '../../../utils/constants';
+import { BREADCRUMBS, DETECTOR_STATE } from '../../../utils/constants';
 import { DetectorControls } from '../components/DetectorControls';
 import moment from 'moment';
 import { ConfirmModal } from '../components/ConfirmModal/ConfirmModal';
 import { useFetchMonitorInfo } from '../hooks/useFetchMonitorInfo';
 import { MonitorCallout } from '../components/MonitorCallout/MonitorCallout';
 import { DETECTOR_DETAIL_TABS } from '../utils/constants';
+import { DetectorConfig } from '../../DetectorConfig/containers/DetectorConfig';
+import { AnomalyResults } from '../../DetectorResults/containers/AnomalyResults';
 
 export interface DetectorRouterProps {
   detectorId?: string;
@@ -77,6 +83,7 @@ interface DetectorDetailModel {
   showDeleteDetectorModal: boolean;
   showStopDetectorModalFor: string | undefined;
   showMonitorCalloutModal: boolean;
+  deleteTyped: boolean;
 }
 
 export const DetectorDetail = (props: DetectorDetailProps) => {
@@ -84,6 +91,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   const detectorId = get(props, 'match.params.detectorId', '') as string;
   const { monitor, fetchMonitorError } = useFetchMonitorInfo(detectorId);
   const { detector, hasError } = useFetchDetectorInfo(detectorId);
+
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
 
@@ -96,6 +104,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     showDeleteDetectorModal: false,
     showStopDetectorModalFor: undefined,
     showMonitorCalloutModal: false,
+    deleteTyped: false,
   });
 
   useHideSideNavBar(true, false);
@@ -116,6 +125,14 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
       ]);
     }
   }, [detector]);
+
+  const handleSwitchToConfigurationTab = useCallback(() => {
+    setDetecorDetailModel({
+      ...detecorDetailModel,
+      selectedTab: DETECTOR_DETAIL_TABS.CONFIGURATIONS,
+    });
+    props.history.push(`/detectors/${detectorId}/configurations`);
+  }, []);
 
   const handleTabChange = (route: DETECTOR_DETAIL_TABS) => {
     setDetecorDetailModel({
@@ -178,7 +195,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     try {
       await dispatch(stopDetector(detectorId));
       toastNotifications.addSuccess(
-        'Detector job has been stoped successfully'
+        'Detector job has been stopped successfully'
       );
       if (listener) listener.onSuccess();
     } catch (err) {
@@ -189,7 +206,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     }
   };
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = useCallback(async (detectorId: string) => {
     try {
       await dispatch(deleteDetector(detectorId));
       toastNotifications.addSuccess(`Detector has been deleted successfully`);
@@ -203,11 +220,37 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     }
   }, []);
 
+  const handleEditDetector = () => {
+    detector.enabled
+      ? setDetecorDetailModel({
+          ...detecorDetailModel,
+          showStopDetectorModalFor: 'detector',
+        })
+      : props.history.push(`/detectors/${detectorId}/edit`);
+  };
+
+  const handleEditFeature = () => {
+    detector.enabled
+      ? setDetecorDetailModel({
+          ...detecorDetailModel,
+          showStopDetectorModalFor: 'features',
+        })
+      : props.history.push(`/detectors/${detectorId}/features`);
+  };
+
   const lightStyles = {
     backgroundColor: '#FFF',
   };
   const monitorCallout = monitor ? (
     <MonitorCallout monitorId={monitor.id} monitorName={monitor.name} />
+  ) : null;
+
+  const deleteDetectorCallout = detector.enabled ? (
+    <EuiCallOut
+      title="The detector is running. Are you sure you want to proceed?"
+      color="warning"
+      iconType="alert"
+    ></EuiCallOut>
   ) : null;
 
   return (
@@ -225,20 +268,28 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
             <EuiTitle size="l">
               <h1>
                 {detector && detector.name}{' '}
-                {detector && detector.enabled ? (
+                {detector &&
+                detector.enabled &&
+                detector.curState === DETECTOR_STATE.RUNNING ? (
                   <EuiHealth color="success">
                     Running since{' '}
                     {detector.enabledTime
-                      ? moment(detector.enabledTime).format('MM/DD/YY h:mm a')
+                      ? moment(detector.enabledTime).format('MM/DD/YY h:mm A')
                       : '?'}
                   </EuiHealth>
+                ) : detector.enabled &&
+                  detector.curState === DETECTOR_STATE.INIT ? (
+                  <EuiHealth color="primary">Initializing</EuiHealth>
+                ) : detector.curState === DETECTOR_STATE.INIT_FAILURE ||
+                  detector.curState === DETECTOR_STATE.UNEXPECTED_FAILURE ? (
+                  <EuiHealth color="danger">Initialization failure</EuiHealth>
                 ) : (
                   <EuiHealth color="subdued">
                     {detector.featureAttributes &&
                     detector.featureAttributes.length
                       ? detector.disabledTime
                         ? `Stopped at ${moment(detector.disabledTime).format(
-                            'MM/DD/YY h:mm a'
+                            'MM/DD/YY h:mm A'
                           )}`
                         : 'Detector is not started'
                       : 'Feature required to start the detector'}
@@ -250,14 +301,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
 
           <EuiFlexItem grow={false}>
             <DetectorControls
-              onEditDetector={() => {
-                detector.enabled
-                  ? setDetecorDetailModel({
-                      ...detecorDetailModel,
-                      showStopDetectorModalFor: 'detector',
-                    })
-                  : props.history.push(`/detectors/${detectorId}/edit`);
-              }}
+              onEditDetector={handleEditDetector}
               onDelete={() =>
                 setDetecorDetailModel({
                   ...detecorDetailModel,
@@ -273,14 +317,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                     })
                   : handleStopAdJob(detectorId)
               }
-              onEditFeatures={() => {
-                detector.enabled
-                  ? setDetecorDetailModel({
-                      ...detecorDetailModel,
-                      showStopDetectorModalFor: 'features',
-                    })
-                  : props.history.push(`/detectors/${detectorId}/features`);
-              }}
+              onEditFeatures={handleEditFeature}
               detector={detector}
             />
           </EuiFlexItem>
@@ -308,13 +345,63 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         <EuiOverlayMask>
           <ConfirmModal
             title="Delete detector?"
-            description="Detector and feature configuration will be removed and the deletion is irreversible and you can’t review anomaly result of this detector on Kibana. To confirm deletion, click the delete button."
-            callout={monitorCallout}
+            description={
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <EuiText>
+                    <p>
+                      Detector and feature configuration will be permanently
+                      removed. This action is irreversible. To confirm deletion,
+                      type <i>delete</i> in the field.
+                    </p>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={true}>
+                  <EuiFieldText
+                    fullWidth={true}
+                    placeholder="delete"
+                    onChange={e => {
+                      if (e.target.value === 'delete') {
+                        setDetecorDetailModel({
+                          ...detecorDetailModel,
+                          deleteTyped: true,
+                        });
+                      } else {
+                        setDetecorDetailModel({
+                          ...detecorDetailModel,
+                          deleteTyped: false,
+                        });
+                      }
+                    }}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            }
+            callout={
+              <Fragment>
+                {deleteDetectorCallout}
+                {monitorCallout ? <EuiSpacer size="s" /> : null}
+                {monitorCallout}
+              </Fragment>
+            }
             confirmButtonText="Delete"
             confirmButtonColor="danger"
+            confirmButtonDisabled={!detecorDetailModel.deleteTyped}
             onClose={hideDeleteDetectorModal}
             onCancel={hideDeleteDetectorModal}
-            onConfirm={handleDelete}
+            onConfirm={() => {
+              if (detector.enabled) {
+                const listener: Listener = {
+                  onSuccess: () => {
+                    handleDelete(detectorId);
+                  },
+                  onException: hideDeleteDetectorModal,
+                };
+                handleStopAdJob(detectorId, listener);
+              } else {
+                handleDelete(detectorId);
+              }
+            }}
           />
         </EuiOverlayMask>
       ) : null}
@@ -324,8 +411,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           <ConfirmModal
             title="Stop detector to proceed?"
             description="Stop the detector before you can edit any detector
-                      configuration. Reconfiguration requires a restart and
-                      reinitialization."
+                      configuration. After you change the detector, make sure to restart and reinitialize the detector."
             callout={monitorCallout}
             confirmButtonText="Stop and proceed to edit"
             confirmButtonColor="primary"
@@ -359,26 +445,25 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           exact
           path="/detectors/:detectorId/results"
           render={props => (
-            // placeholder for AnomalyResults page, will change to
-            // <AnomalyResults
-            //   {...props}
-            //   detectorId={detectorId}
-            //   onSwitchToConfiguration={handleSwitchToConfigurationTab}
-            // />
-            <div style={{ paddingTop: '20px' }}>AnomalyResults page</div>
+            <AnomalyResults
+              {...props}
+              detectorId={detectorId}
+              onStartDetector={() => handleStartAdJob(detectorId)}
+              onSwitchToConfiguration={handleSwitchToConfigurationTab}
+            />
           )}
         />
         <Route
           exact
           path="/detectors/:detectorId/configurations"
           render={props => (
-            // placeholder for DetectorConfig page, will change to
-            // <DetectorConfig
-            //   {...props}
-            //   detectorId={detectorId}
-            //   detector={detector}
-            // />
-            <div style={{ paddingTop: '20px' }}>DetectorConfig page</div>
+            <DetectorConfig
+              {...props}
+              detectorId={detectorId}
+              detector={detector}
+              onEditFeatures={handleEditFeature}
+              onEditDetector={handleEditDetector}
+            />
           )}
         />
         <Redirect to="/detectors/:detectorId/results" />

--- a/public/pages/DetectorDetail/containers/__tests__/__snapshots__/DetectorDetail.test.tsx.snap
+++ b/public/pages/DetectorDetail/containers/__tests__/__snapshots__/DetectorDetail.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <svg
-                  class="euiIcon euiIcon--medium euiIcon--success euiIcon-isLoading"
+                  class="euiIcon euiIcon--medium euiIcon--subdued euiIcon-isLoading"
                   focusable="false"
                   height="16"
                   viewBox="0 0 16 16"
@@ -39,9 +39,7 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
               <div
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                Running since
-                 
-                04/13/20 5:13 pm
+                Stopped at 04/12/20 5:13 PM
               </div>
             </div>
           </div>
@@ -55,6 +53,7 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
         >
           <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
+            style="margin-right: 16px;"
           >
             <div
               class="euiPopover euiPopover--anchorDownLeft"
@@ -92,6 +91,7 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
           </div>
           <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
+            style="margin-left: 0px;"
           >
             <button
               class="euiButton euiButton--primary"
@@ -160,9 +160,16 @@ exports[`<DetectorDetail /> spec detector detail renders detector detail compone
     </div>
   </div>
   <div
-    style="padding-top: 20px;"
+    class="euiPage"
+    style="margin-top: 16px; padding-top: 0px;"
   >
-    AnomalyResults page
+    <div
+      class="euiPageBody"
+    >
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 
* Ask user to type `delete` before delete detector
* Enhance confirm modal to support saving edit features


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
