### PR TITLE
Add detector state page

### DIFF
--- a/public/pages/DetectorDetail/utils/constants.ts
+++ b/public/pages/DetectorDetail/utils/constants.ts
@@ -18,7 +18,7 @@ export enum DETECTOR_DETAIL_TABS {
   CONFIGURATIONS = 'configurations',
 }
 
-export const DEFAULT_ACTION_ITEM = 'Please restart this detector to retry.';
+const DEFAULT_ACTION_ITEM = 'Please restart this detector to retry.';
 // Known causes:
 // https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L174-L185
 export const DETECTOR_INIT_FAILURES = Object.freeze({
@@ -47,7 +47,7 @@ export const DETECTOR_INIT_FAILURES = Object.freeze({
     keyword: 'Exceeded memory limit',
     cause: 'lack of memory',
     actionItem:
-      "Try deleting or stop other detectors that you don't actively use, increase your cluster size, or reduce the number of features in this detector.",
+      "Try deleting or stop other detectors that you don't actively use, increase your cluster size, reduce the number of features in this detector, or scale up with an instance type of more memory.",
   },
   DATA_INDEX_NOT_FOUND: {
     //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L366
@@ -68,5 +68,11 @@ export const DETECTOR_INIT_FAILURES = Object.freeze({
     keyword: 'AnomalyDetector is not available',
     cause: 'your detector is not defined',
     actionItem: 'Please make sure your detector is defined.',
+  },
+  UNKNOWN_EXCEPTION: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L438
+    keyword: 'We might have bug',
+    cause: 'unknown error',
+    actionItem: DEFAULT_ACTION_ITEM,
   },
 });

--- a/public/pages/DetectorDetail/utils/constants.ts
+++ b/public/pages/DetectorDetail/utils/constants.ts
@@ -16,4 +16,57 @@
 export enum DETECTOR_DETAIL_TABS {
   RESULTS = 'results',
   CONFIGURATIONS = 'configurations',
-};
+}
+
+export const DEFAULT_ACTION_ITEM = 'Please restart this detector to retry.';
+// Known causes:
+// https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L174-L185
+export const DETECTOR_INIT_FAILURES = Object.freeze({
+  NO_TRAINING_DATA: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L801
+    keyword: 'Cannot get training data',
+    cause: 'lack of data ingestion',
+    actionItem:
+      'Please make sure your data ingestion is working. Or increase your detector time interval if data source has infrequent ingestion.',
+  },
+  COLD_START_ERROR: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L811
+    keyword: 'Error while cold start',
+    cause: 'error is found while model initialization',
+    actionItem: DEFAULT_ACTION_ITEM,
+  },
+  AD_MODEL_MEMORY_REACH_LIMIT: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java#L272
+    keyword: 'AD models memory usage exceeds our limit',
+    cause: 'lack of memory for detector models',
+    actionItem:
+      'Model of this detector is too large, please reduce the number of features in this detector.',
+  },
+  DETECTOR_MEMORY_REACH_LIMIT: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java#L783
+    keyword: 'Exceeded memory limit',
+    cause: 'lack of memory',
+    actionItem:
+      "Try deleting or stop other detectors that you don't actively use, increase your cluster size, or reduce the number of features in this detector.",
+  },
+  DATA_INDEX_NOT_FOUND: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L366
+    keyword: 'Having trouble querying data: ',
+    cause: 'data index not found',
+    actionItem: 'Please make sure your data index does exist.',
+  },
+  ALL_FEATURES_DISABLED: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L368
+    keyword:
+      'Having trouble querying data because all of your features have been disabled',
+    cause: 'all features in this detector are disabled',
+    actionItem:
+      'Please enable some of your features and re-start your detector.',
+  },
+  DETECTOR_UNDEFINED: {
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L230
+    keyword: 'AnomalyDetector is not available',
+    cause: 'your detector is not defined',
+    actionItem: 'Please make sure your detector is defined.',
+  },
+});

--- a/public/pages/DetectorDetail/utils/helpers.ts
+++ b/public/pages/DetectorDetail/utils/helpers.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { DETECTOR_INIT_FAILURES, DEFAULT_ACTION_ITEM } from './constants';
+
+export const getInitFailureMessageAndActionItem = (error: string): object => {
+  const failureDetails = Object.values(DETECTOR_INIT_FAILURES);
+  const failureDetail = failureDetails.find(failure =>
+    error.includes(failure.keyword)
+  );
+  if (!failureDetail) {
+    return {
+      cause: 'unknown error',
+      actionItem: DEFAULT_ACTION_ITEM,
+    };
+  }
+  return failureDetail;
+};

--- a/public/pages/DetectorDetail/utils/helpers.ts
+++ b/public/pages/DetectorDetail/utils/helpers.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import { DETECTOR_INIT_FAILURES, DEFAULT_ACTION_ITEM } from './constants';
+import { DETECTOR_INIT_FAILURES } from './constants';
 
 export const getInitFailureMessageAndActionItem = (error: string): object => {
   const failureDetails = Object.values(DETECTOR_INIT_FAILURES);
@@ -21,10 +21,7 @@ export const getInitFailureMessageAndActionItem = (error: string): object => {
     error.includes(failure.keyword)
   );
   if (!failureDetail) {
-    return {
-      cause: 'unknown error',
-      actionItem: DEFAULT_ACTION_ITEM,
-    };
+    return DETECTOR_INIT_FAILURES.UNKNOWN_EXCEPTION;
   }
   return failureDetail;
 };

--- a/public/pages/DetectorResults/components/DetectorState/DetectorFeatureRequired.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorFeatureRequired.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { Fragment } from 'react';
+import { Detector } from '../../../../models/interfaces';
+
+export interface DetectorFeatureRequiredProps {
+  detector: Detector;
+}
+
+export const DetectorFeatureRequired = (
+  props: DetectorFeatureRequiredProps
+) => {
+  return (
+    <EuiEmptyPrompt
+      style={{ maxWidth: '75%' }}
+      title={<h2>Features are required to run a detector</h2>}
+      body={
+        <Fragment>
+          <p>
+            Specify index fields that you want to find anomalies for by defining
+            features. Once you define the features, you can preview your
+            anomalies from a sample feature output.
+          </p>
+        </Fragment>
+      }
+      actions={[
+        <EuiButton
+          color="primary"
+          fill
+          href={`#/detectors/${props.detector.id}/features`}
+          style={{ width: '250px' }}
+        >
+          View detector configuration
+        </EuiButton>,
+      ]}
+    />
+  );
+};

--- a/public/pages/DetectorResults/components/DetectorState/DetectorInitializationFailure.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorInitializationFailure.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { EuiButton, EuiEmptyPrompt, EuiIcon } from '@elastic/eui';
+import { Fragment } from 'react';
+import { Detector } from '../../../../models/interfaces';
+
+export interface DetectorInitializationFailureProps {
+  detector: Detector;
+  onStartDetector(): void;
+  failureDetail: any;
+  onSwitchToConfiguration(): void;
+}
+
+export const DetectorInitializationFailure = (
+  props: DetectorInitializationFailureProps
+) => {
+  return (
+    <EuiEmptyPrompt
+      style={{ maxWidth: '75%' }}
+      title={
+        <div>
+          <EuiIcon type="alert" size="l" color="danger" />
+
+          <h2>
+            {`The detector cannot be initialized due to ${props.failureDetail.cause}`}
+          </h2>
+        </div>
+      }
+      body={
+        <Fragment>
+          <p>{`${props.failureDetail.actionItem}`}</p>
+        </Fragment>
+      }
+      actions={[
+        <EuiButton
+          onClick={props.onSwitchToConfiguration}
+          style={{ width: '250px' }}
+        >
+          View detector configuration
+        </EuiButton>,
+        <EuiButton
+          onClick={props.onStartDetector}
+          iconType={'play'}
+          style={{ width: '250px' }}
+        >
+          Restart detector
+        </EuiButton>,
+      ]}
+    />
+  );
+};

--- a/public/pages/DetectorResults/components/DetectorState/DetectorInitializing.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorInitializing.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { EuiButton, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+import { Fragment } from 'react';
+import { Detector } from '../../../../models/interfaces';
+
+export interface DetectorInitializingProps {
+  detector: Detector;
+  onSwitchToConfiguration(): void;
+}
+
+export const DetectorInitializing = (props: DetectorInitializingProps) => {
+  return (
+    <EuiEmptyPrompt
+      style={{ maxWidth: '75%' }}
+      title={
+        <div>
+          <EuiLoadingSpinner size="l" />
+          <h2>The detector is initializing...</h2>
+        </div>
+      }
+      body={
+        <Fragment>
+          <p>
+            Based on your latest update to the detector configuration, the
+            detector is collecting sufficient data to generate accurate
+            real-time anomalies.
+          </p>
+          <p>
+            The longer the detector interval is, the longer the initialization
+            will take.
+          </p>
+        </Fragment>
+      }
+      actions={
+        <EuiButton
+          onClick={props.onSwitchToConfiguration}
+          style={{ width: '250px' }}
+        >
+          View detector configuration
+        </EuiButton>
+      }
+    />
+  );
+};

--- a/public/pages/DetectorResults/components/DetectorState/DetectorStopped.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorStopped.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { Fragment } from 'react';
+import { Detector } from '../../../../models/interfaces';
+
+export interface DetectorStoppedProps {
+  detector: Detector;
+  onStartDetector(): void;
+  onSwitchToConfiguration(): void;
+}
+
+export const DetectorStopped = (props: DetectorStoppedProps) => {
+  return (
+    <EuiEmptyPrompt
+      style={{ maxWidth: '75%' }}
+      title={<h2>The detector is stopped</h2>}
+      body={
+        <Fragment>
+          {props.detector.enabledTime ? (
+            <p>
+              The detector is stopped due to your latest update to the detector
+              configuration. Run the detector to see anomalies.
+            </p>
+          ) : (
+            <p>
+              The detector is never started. Please start the detector to see
+              anomalies.
+            </p>
+          )}
+        </Fragment>
+      }
+      actions={[
+        <EuiButton
+          onClick={props.onSwitchToConfiguration}
+          style={{ width: '250px' }}
+        >
+          View detector configuration
+        </EuiButton>,
+        <EuiButton
+          fill={!props.detector.enabledTime}
+          onClick={props.onStartDetector}
+          iconType={'play'}
+          style={{ width: '250px' }}
+        >
+          {props.detector.enabledTime ? 'Restart detector' : 'Start detector'}
+        </EuiButton>,
+      ]}
+    />
+  );
+};

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -62,7 +62,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       <EuiPage style={{ marginTop: '16px', paddingTop: '0px' }}>
         <EuiPageBody>
           <EuiSpacer size="l" />
-          {detector && isEmpty(detector.featureAttributes) ? (
+          {detector && detector.curState === DETECTOR_STATE.FEATURE_REQUIRED ? (
             <EuiEmptyPrompt
               title={<h2>Features are required to run a detector</h2>}
               body={

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -62,29 +62,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       <EuiPage style={{ marginTop: '16px', paddingTop: '0px' }}>
         <EuiPageBody>
           <EuiSpacer size="l" />
-          {detector && detector.curState === DETECTOR_STATE.FEATURE_REQUIRED ? (
-            <EuiEmptyPrompt
-              title={<h2>Features are required to run a detector</h2>}
-              body={
-                <Fragment>
-                  <p>
-                    Specify index fields that you want to find anomalies for by
-                    defining features. Once you define the features, you can
-                    preview your anomalies from a sample feature output.
-                  </p>
-                </Fragment>
-              }
-              actions={
-                <EuiButton
-                  color="primary"
-                  fill
-                  href={`#/detectors/${detectorId}/features`}
-                >
-                  Add features
-                </EuiButton>
-              }
-            />
-          ) : (
+          {
             <Fragment>
               {detector && detector.curState === DETECTOR_STATE.RUNNING ? (
                 <Fragment>
@@ -128,7 +106,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                 </Fragment>
               ) : null}
             </Fragment>
-          )}
+          }
         </EuiPageBody>
       </EuiPage>
     </Fragment>

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -30,12 +30,14 @@ import { RouteComponentProps } from 'react-router';
 //@ts-ignore
 import chrome from 'ui/chrome';
 import { AppState } from '../../../redux/reducers';
-import { BREADCRUMBS } from '../../../utils/constants';
+import { BREADCRUMBS, DETECTOR_STATE } from '../../../utils/constants';
 import { AnomalyResultsLiveChart } from './AnomalyResultsLiveChart';
 import { AnomalyHistory } from './AnomalyHistory';
+import { DetectorStateDetails } from './DetectorStateDetails';
 
 interface AnomalyResultsProps extends RouteComponentProps {
   detectorId: string;
+  onStartDetector(): void;
   onSwitchToConfiguration(): void;
 }
 
@@ -84,7 +86,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
             />
           ) : (
             <Fragment>
-              {detector ? (
+              {detector && detector.curState === DETECTOR_STATE.RUNNING ? (
                 <Fragment>
                   {!detector.enabled &&
                   detector.disabledTime &&
@@ -106,9 +108,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                       </EuiButton>
                     </EuiCallOut>
                   ) : null}
-                  <AnomalyResultsLiveChart
-                    detector={detector}
-                  />
+                  <AnomalyResultsLiveChart detector={detector} />
                   <EuiSpacer size="l" />
                   <AnomalyHistory
                     detector={detector}
@@ -116,6 +116,14 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                     createFeature={() =>
                       props.history.push(`/detectors/${detectorId}/features`)
                     }
+                  />
+                </Fragment>
+              ) : detector && detector.curState !== DETECTOR_STATE.RUNNING ? (
+                <Fragment>
+                  <DetectorStateDetails
+                    detector={detector}
+                    onStartDetector={props.onStartDetector}
+                    onSwitchToConfiguration={props.onSwitchToConfiguration}
                   />
                 </Fragment>
               ) : null}

--- a/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
+++ b/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { Detector } from '../../../models/interfaces';
+import { getInitFailureMessageAndActionItem } from '../../DetectorDetail/utils/helpers';
+import { DETECTOR_STATE } from '../../../utils/constants';
+import { DetectorStopped } from '../components/DetectorState/DetectorStopped';
+import { DetectorInitializing } from '../components/DetectorState/DetectorInitializing';
+import { DetectorInitializationFailure } from '../components/DetectorState/DetectorInitializationFailure';
+
+export interface DetectorStateDetailsProp {
+  detector: Detector;
+  onStartDetector(): void;
+  onSwitchToConfiguration(): void;
+}
+
+export const DetectorStateDetails = (props: DetectorStateDetailsProp) => {
+  const currentState = props.detector.curState;
+
+  switch (currentState) {
+    case DETECTOR_STATE.DISABLED:
+      return (
+        <DetectorStopped
+          detector={props.detector}
+          onStartDetector={props.onStartDetector}
+          onSwitchToConfiguration={props.onSwitchToConfiguration}
+        />
+      );
+    case DETECTOR_STATE.INIT:
+      return (
+        <DetectorInitializing
+          detector={props.detector}
+          onSwitchToConfiguration={props.onSwitchToConfiguration}
+        />
+      );
+    case DETECTOR_STATE.INIT_FAILURE:
+      const failureDetail = getInitFailureMessageAndActionItem(
+        props.detector.initializationError
+      );
+      return (
+        <DetectorInitializationFailure
+          detector={props.detector}
+          onStartDetector={props.onStartDetector}
+          failureDetail={failureDetail}
+          onSwitchToConfiguration={props.onSwitchToConfiguration}
+        />
+      );
+    default:
+      console.log('Unknown detector state', currentState);
+      return null;
+  }
+};

--- a/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
+++ b/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
@@ -19,6 +19,7 @@ import { DETECTOR_STATE } from '../../../utils/constants';
 import { DetectorStopped } from '../components/DetectorState/DetectorStopped';
 import { DetectorInitializing } from '../components/DetectorState/DetectorInitializing';
 import { DetectorInitializationFailure } from '../components/DetectorState/DetectorInitializationFailure';
+import { DetectorFeatureRequired } from '../components/DetectorState/DetectorFeatureRequired';
 
 export interface DetectorStateDetailsProp {
   detector: Detector;
@@ -57,6 +58,8 @@ export const DetectorStateDetails = (props: DetectorStateDetailsProp) => {
           onSwitchToConfiguration={props.onSwitchToConfiguration}
         />
       );
+    case DETECTOR_STATE.FEATURE_REQUIRED:
+      return <DetectorFeatureRequired detector={props.detector} />;
     default:
       console.log('Unknown detector state', currentState);
       return null;

--- a/public/pages/DetectorResults/utils/tableUtils.ts
+++ b/public/pages/DetectorResults/utils/tableUtils.ts
@@ -18,7 +18,7 @@ import moment from 'moment';
 
 export const DEFAULT_EMPTY_DATA = '-';
 
-export const renderTime = (time: number) => {
+const renderTime = (time: number) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm A');
   return DEFAULT_EMPTY_DATA;

--- a/public/pages/DetectorResults/utils/tableUtils.ts
+++ b/public/pages/DetectorResults/utils/tableUtils.ts
@@ -18,7 +18,7 @@ import moment from 'moment';
 
 export const DEFAULT_EMPTY_DATA = '-';
 
-const renderTime = (time: number) => {
+export const renderTime = (time: number) => {
   const momentTime = moment(time);
   if (time && momentTime.isValid()) return momentTime.format('MM/DD/YY h:mm A');
   return DEFAULT_EMPTY_DATA;


### PR DESCRIPTION
*Issue #, if available:*
#46 
*Description of changes:*
Add detector state page; fix minor issue that renderTime is not exported

**Detector stopped:** 
Detector never started:
![Screen Shot 2020-04-29 at 8 24 52 PM](https://user-images.githubusercontent.com/59710443/80668812-af88fe00-8a57-11ea-89fb-64696ea5edcb.png)
Detector is manually stopped:
![Screen Shot 2020-04-29 at 8 24 19 PM](https://user-images.githubusercontent.com/59710443/80668852-c16aa100-8a57-11ea-8b36-a3985dcaaa23.png)

**Detector is initializing:**
![Screen Shot 2020-04-29 at 8 25 18 PM](https://user-images.githubusercontent.com/59710443/80668879-d0e9ea00-8a57-11ea-8768-f67011f56435.png)

**Detector initialization failure:**
![Screen Shot 2020-04-29 at 8 23 43 PM](https://user-images.githubusercontent.com/59710443/80668895-e0693300-8a57-11ea-9509-614073ba44e8.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
