### PR TITLE
Fix issue that blank ad results page after detector/feature creation

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -99,7 +99,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               ) : detector && detector.curState !== DETECTOR_STATE.RUNNING ? (
                 <Fragment>
                   <DetectorStateDetails
-                    detector={detector}
+                    detectorId={detector.id}
                     onStartDetector={props.onStartDetector}
                     onSwitchToConfiguration={props.onSwitchToConfiguration}
                   />

--- a/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
+++ b/public/pages/DetectorResults/containers/DetectorStateDetails.tsx
@@ -12,29 +12,39 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-import React from 'react';
-import { Detector } from '../../../models/interfaces';
+import React, { useEffect } from 'react';
 import { getInitFailureMessageAndActionItem } from '../../DetectorDetail/utils/helpers';
 import { DETECTOR_STATE } from '../../../utils/constants';
 import { DetectorStopped } from '../components/DetectorState/DetectorStopped';
 import { DetectorInitializing } from '../components/DetectorState/DetectorInitializing';
 import { DetectorInitializationFailure } from '../components/DetectorState/DetectorInitializationFailure';
 import { DetectorFeatureRequired } from '../components/DetectorState/DetectorFeatureRequired';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppState } from '../../../redux/reducers';
+import { getDetector } from '../../../redux/reducers/ad';
 
 export interface DetectorStateDetailsProp {
-  detector: Detector;
+  detectorId: string;
   onStartDetector(): void;
   onSwitchToConfiguration(): void;
 }
 
 export const DetectorStateDetails = (props: DetectorStateDetailsProp) => {
-  const currentState = props.detector.curState;
+  const dispatch = useDispatch();
+  const detector = useSelector(
+    (state: AppState) => state.ad.detectors[props.detectorId]
+  );
+  const currentState = detector.curState;
+
+  useEffect(() => {
+    dispatch(getDetector(props.detectorId));
+  }, []);
 
   switch (currentState) {
     case DETECTOR_STATE.DISABLED:
       return (
         <DetectorStopped
-          detector={props.detector}
+          detector={detector}
           onStartDetector={props.onStartDetector}
           onSwitchToConfiguration={props.onSwitchToConfiguration}
         />
@@ -42,24 +52,24 @@ export const DetectorStateDetails = (props: DetectorStateDetailsProp) => {
     case DETECTOR_STATE.INIT:
       return (
         <DetectorInitializing
-          detector={props.detector}
+          detector={detector}
           onSwitchToConfiguration={props.onSwitchToConfiguration}
         />
       );
     case DETECTOR_STATE.INIT_FAILURE:
       const failureDetail = getInitFailureMessageAndActionItem(
-        props.detector.initializationError
+        detector.initializationError
       );
       return (
         <DetectorInitializationFailure
-          detector={props.detector}
+          detector={detector}
           onStartDetector={props.onStartDetector}
           failureDetail={failureDetail}
           onSwitchToConfiguration={props.onSwitchToConfiguration}
         />
       );
     case DETECTOR_STATE.FEATURE_REQUIRED:
-      return <DetectorFeatureRequired detector={props.detector} />;
+      return <DetectorFeatureRequired detector={detector} />;
     default:
       console.log('Unknown detector state', currentState);
       return null;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issue that blank ad results page after detector/feature creation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
