### PR TITLE
Make titles with counts consistent

### DIFF
--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -30,6 +30,7 @@ import { get, sortBy } from 'lodash';
 import { PLUGIN_NAME } from '../../../utils/constants';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import { CodeModal } from '../components/CodeModal/CodeModal';
+import { getTitleWithCount } from '../../../utils/utils';
 
 interface FeaturesProps {
   detectorId: string;
@@ -183,7 +184,7 @@ export class Features extends Component<FeaturesProps, FeaturesState> {
 
     return (
       <ContentPanel
-        title={`Features (${featureNum})`}
+        title={getTitleWithCount('Features', featureNum)}
         titleSize="s"
         subTitle={
           <EuiText className="anomaly-distribution-subtitle">

--- a/public/pages/DetectorConfig/containers/__tests__/DetectorConfig.test.tsx
+++ b/public/pages/DetectorConfig/containers/__tests__/DetectorConfig.test.tsx
@@ -154,7 +154,7 @@ describe('<DetectorConfig /> spec', () => {
       getByText(
         'Specify index fields that you want to find anomalies for by defining features. Once you define the features, you can preview your anomalies from a sample feature output.'
       );
-      getByText('Features (0)');
+      getByText('Features');
       getByText(randomDetector.name);
       getByText(randomDetector.indices[0]);
       getByText(toString(randomDetector.detectionInterval));

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -357,11 +357,28 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h3
-            class="euiTitle euiTitle--small"
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            Features (2)
-          </h3>
+            <div
+              class="euiFlexItem"
+            >
+              <h3
+                class="euiTitle euiTitle--small"
+                style="display: flex;"
+              >
+                <p>
+                  Features
+                   
+                </p>
+                <p
+                  style="color: rgb(83, 89, 102);"
+                >
+                  (2)
+                </p>
+              </h3>
+            </div>
+          </div>
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
@@ -1074,11 +1091,28 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
         <div
           class="euiFlexItem"
         >
-          <h3
-            class="euiTitle euiTitle--small"
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            Features (3)
-          </h3>
+            <div
+              class="euiFlexItem"
+            >
+              <h3
+                class="euiTitle euiTitle--small"
+                style="display: flex;"
+              >
+                <p>
+                  Features
+                   
+                </p>
+                <p
+                  style="color: rgb(83, 89, 102);"
+                >
+                  (3)
+                </p>
+              </h3>
+            </div>
+          </div>
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
           >

--- a/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
@@ -29,6 +29,7 @@ import { staticColumn } from '../utils/tableUtils';
 import { ListControls } from '../components/ListControls/ListControls';
 import { DetectorResultsQueryParams } from 'server/models/types';
 import { AnomalyData } from '../../../models/interfaces';
+import { getTitleWithCount } from '../../../utils/utils';
 
 interface AnomalyResultsTableProps {
   anomalies: AnomalyData[];
@@ -119,7 +120,7 @@ export function AnomalyResultsTable(props: AnomalyResultsTableProps) {
   };
   return (
     <ContentPanel
-      title={`Anomaly occurrences(${totalAnomalies.length})`}
+      title={getTitleWithCount('Anomaly occurrences', totalAnomalies.length)}
       titleSize="xs"
       titleClassName="preview-title"
     >

--- a/public/pages/DetectorsList/List/List.tsx
+++ b/public/pages/DetectorsList/List/List.tsx
@@ -20,7 +20,6 @@ import {
   EuiHorizontalRule,
   EuiPage,
   EuiPageBody,
-  EuiTitle,
 } from '@elastic/eui';
 import { debounce, get, isEmpty } from 'lodash';
 import queryString from 'query-string';
@@ -64,7 +63,7 @@ import {
   getDetectorsToDisplay,
 } from '../../utils/helpers';
 import { staticColumn } from '../utils/tableUtils';
-import { darkModeEnabled } from '../../../utils/kibanaUtils';
+import { getTitleWithCount } from '../../../utils/utils';
 
 export interface ListRouterParams {
   from: string;
@@ -265,28 +264,11 @@ export const DetectorList = (props: ListProps) => {
     pageSizeOptions: [5, 10, 20, 50],
   };
 
-  const detectorCountFontColor = darkModeEnabled() ? '#98A2B3' : '#535966';
-  const pageTitle = (
-    <EuiTitle size={'s'} className={''}>
-      <h3
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-        }}
-      >
-        <p>{'Detectors'}&nbsp;</p>
-        <p
-          style={{ color: detectorCountFontColor }}
-        >{`(${selectedDetectors.length})`}</p>
-      </h3>
-    </EuiTitle>
-  );
-
   return (
     <EuiPage>
       <EuiPageBody>
         <ContentPanel
-          title={pageTitle}
+          title={getTitleWithCount('Detectors', selectedDetectors.length)}
           actions={[
             <EuiButton fill href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}>
               Create detector

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -14,10 +14,13 @@
  */
 
 import { get, isEmpty } from 'lodash';
+import React from 'react';
+import { EuiTitle } from '@elastic/eui';
 //@ts-ignore
 import { isAngularHttpError } from 'ui/notify/lib/format_angular_http_error';
 //@ts-ignore
 import { npStart } from 'ui/new_platform';
+import { darkModeEnabled } from '../utils/kibanaUtils';
 import { ALERTING_PLUGIN_NAME, NAME_REGEX } from './constants';
 import { MAX_FEATURE_NAME_SIZE } from './constants';
 
@@ -108,4 +111,24 @@ export const getAlertingMonitorListLink = (): string => {
 export interface Listener {
   onSuccess(): void;
   onException(): void;
+};
+
+const detectorCountFontColor = darkModeEnabled() ? '#98A2B3' : '#535966';
+
+export const getTitleWithCount = (title: string, count: number) => {
+  return (
+    <EuiTitle size={'s'} className={''}>
+      <h3
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+        }}
+      >
+        <p>{title}&nbsp;</p>
+        <p
+          style={{ color: detectorCountFontColor }}
+        >{`(${count})`}</p>
+      </h3>
+    </EuiTitle>
+  );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR makes all titles with counts to be consistent and have the count be a lighter color. Also handles readability if user has dark mode enabled.
- Fixes title for feature list table
- Fixes title for anomaly results list table

All will look like this:
![Screen Shot 2020-04-30 at 5 50 26 PM](https://user-images.githubusercontent.com/62119629/80772403-84f87d00-8b0b-11ea-8a34-11b7cb18b522.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
