### PR TITLE
Fix sunburst import

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -29,7 +29,7 @@ import {
   //@ts-ignore
   EuiStat,
 } from '@elastic/eui';
-import { Chart, Partition, PartitionLayout } from '@elastic/charts/dist/index';
+import { Chart, Partition, PartitionLayout } from '@elastic/charts';
 import { useDispatch } from 'react-redux';
 import { Datum } from '@elastic/charts/dist/utils/commons';
 import React from 'react';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes the import statement for the sunburst chart that's needed for 1.6.X. Leftover when cherry-picking to 1.4. Was part of this commit: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/73/files#diff-474a5fc2dba872f006bdc3342074dd77R32

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
