### PR TITLE
Fix stats minWidth on Dashboard live chart to make sure text doesn’t wrap

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -241,14 +241,14 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         // regardless of whether anomaly grade is 0 or larger.
         [
           <EuiFlexGroup>
-            <EuiFlexItem>
+            <EuiFlexItem style={{ minWidth: '200px' }}>
               <EuiStat
                 description={'Last updated time'}
                 title={liveTimeRange.endDateTime.format('MM/DD/YYYY hh:mm A')}
                 titleSize="s"
               />
             </EuiFlexItem>
-            <EuiFlexItem>
+            <EuiFlexItem style={{ minWidth: '310px' }}>
               <EuiStat
                 description={'Detector with most recent anomaly occurrence'}
                 title={
@@ -259,7 +259,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                 titleSize="s"
               />
             </EuiFlexItem>
-            <EuiFlexItem>
+            <EuiFlexItem style={{ minWidth: '185px' }}>
               <EuiStat
                 description={'Most recent anomaly grade'}
                 title={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix stats minWidth on Dashboard live chart to make sure text doesn’t wrap

Before fix:
![Screen Shot 2020-05-01 at 12 26 38 AM](https://user-images.githubusercontent.com/59710443/80789981-78dbe200-8b42-11ea-810e-cb1cf11f1b79.png)


After fix
![Screen Shot 2020-05-01 at 12 25 01 AM](https://user-images.githubusercontent.com/59710443/80789935-54800580-8b42-11ea-9df3-d64189807368.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
