### PR TITLE
Do not show link label for sunburst to avoid label cut off

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -228,6 +228,9 @@ export const AnomaliesDistributionChart = (
                     fillLabel: {
                       textInvertible: true,
                     },
+                    linkLabel: {
+                      maxCount: 0,
+                    },
                     // TODO: Given only 1 detector exists, the inside Index circle will have issue in following scenarios:
                     // 1: if Linked Label is configured for identifying index, label of Index circle will be invisible;
                     // 2: if Fill Label is configured for identifying index, label of it will be overlapped with outer Detector circle


### PR DESCRIPTION
Known bug: https://github.com/elastic/elastic-charts/issues/633

*Issue #, if available:*
https://github.com/elastic/elastic-charts/issues/633
*Description of changes:*
Do not show link label for sunburst to avoid label cut off

Before:
![Screen Shot 2020-05-01 at 12 44 34 AM](https://user-images.githubusercontent.com/59710443/80791076-6911cd00-8b45-11ea-8c42-4abed69cc119.png)

After:
![Screen Shot 2020-05-01 at 12 43 37 AM](https://user-images.githubusercontent.com/59710443/80791085-70d17180-8b45-11ea-8cca-04611a0bbf07.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
