### PR TITLE
Fix column truncation issue

### DIFF
--- a/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/FeatureBreakDown.test.tsx.snap
+++ b/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/FeatureBreakDown.test.tsx.snap
@@ -12,6 +12,9 @@ exports[`<FeatureBreakDown /> spec renders the component 1`] = `
     >
       test
     </h4>
+    <div
+      class="euiSpacer euiSpacer--s"
+    />
   </div>
 </div>
 `;

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -353,7 +353,7 @@ export const anomalousDetectorsStaticColumn = [
   },
   {
     field: 'featureAttributes',
-    name: 'features',
+    name: 'Features',
     sortable: false,
     truncateText: false,
     textOnly: true,

--- a/public/pages/DetectorsList/utils/tableUtils.tsx
+++ b/public/pages/DetectorsList/utils/tableUtils.tsx
@@ -25,6 +25,11 @@ import { darkModeEnabled } from '../../../utils/kibanaUtils';
 
 export const DEFAULT_EMPTY_DATA = '-';
 const hintColor = darkModeEnabled() ? '#98A2B3' : '#535966';
+const columnStyle = {
+  overflow: 'visible',
+  whiteSpace: 'normal',
+  wordBreak: 'break-word',
+} as React.CSSProperties;
 
 const renderTime = (time: number) => {
   const momentTime = moment(time);
@@ -49,8 +54,8 @@ export const staticColumn = [
     field: 'name',
     name: (
       <EuiToolTip content="The name of the detector">
-        <span>
-          Detector{' '}
+        <span style={columnStyle}>
+          Detector{''}
           <EuiIcon
             size="s"
             color={hintColor}
@@ -75,8 +80,8 @@ export const staticColumn = [
     field: 'indices',
     name: (
       <EuiToolTip content="The index or index pattern used for the detector">
-        <span>
-          Indices{' '}
+        <span style={columnStyle}>
+          Indices{''}
           <EuiIcon
             size="s"
             color={hintColor}
@@ -97,8 +102,8 @@ export const staticColumn = [
     field: 'curState',
     name: (
       <EuiToolTip content="The current state of the detector">
-        <span>
-          Detector state{' '}
+        <span style={columnStyle}>
+          Detector state{''}
           <EuiIcon
             size="s"
             color={hintColor}
@@ -119,8 +124,8 @@ export const staticColumn = [
     field: 'totalAnomalies',
     name: (
       <EuiToolTip content="Total anomalies with a grade > 0 in last 24 hours">
-        <span>
-          Anomalies last 24 hours{' '}
+        <span style={columnStyle}>
+          Anomalies last 24 hours{''}
           <EuiIcon
             size="s"
             color={hintColor}
@@ -140,8 +145,8 @@ export const staticColumn = [
     field: 'lastActiveAnomaly',
     name: (
       <EuiToolTip content="Time of the last active anomaly with a grade > 0">
-        <span>
-          Last anomaly occurrence{' '}
+        <span style={columnStyle}>
+          Last anomaly occurrence{''}
           <EuiIcon
             size="s"
             color={hintColor}
@@ -162,8 +167,8 @@ export const staticColumn = [
     field: 'lastUpdateTime',
     name: (
       <EuiToolTip content="The time the detector was last updated">
-        <span>
-          Last updated{' '}
+        <span style={columnStyle}>
+          Last updated{''}
           <EuiIcon
             size="s"
             color={hintColor}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes detector list column title truncation issue. Rather than displaying `...` and/or cutting text off, move to newline instead.
Also capitalizes feature list column title on dashboard page.
Updates one test snapshot.

Before:

![Screen Shot 2020-05-01 at 11 59 44 AM](https://user-images.githubusercontent.com/62119629/80833415-54642200-8ba3-11ea-96d4-6f92269c4b79.png)

After:

![Screen Shot 2020-05-01 at 11 59 19 AM](https://user-images.githubusercontent.com/62119629/80833421-58903f80-8ba3-11ea-8551-29fbc4b6e937.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
