### PR TITLE
Change default build artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/opendistro-anomaly-detection-1.6.1.0.zip`
+Example output: `./build/opendistro-anomaly-detection-kibana-1.6.1.0.zip`
 
 ## Run
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opendistro-anomaly-detection",
+  "name": "opendistro-anomaly-detection-kibana",
   "version": "1.6.1.0",
   "description": "Open Distro for Elasticsearch Anomaly Detection Kibana plugin",
   "main": "index.js",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes project name and build artifact name from `opendistro-anomaly-detection-1.6.1.0` to `opendistro-anomaly-detection-kibana-1.6.1.0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
