### PR TITLE
Correct the create detector button/detector link on Dashboard to avoid creating new tab

### DIFF
--- a/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
+++ b/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
@@ -40,7 +40,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
             <EuiButton
               fill
               href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}
-              target="_blank"
               data-test-subj="add_detector"
             >
               Create detector

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -343,10 +343,7 @@ export const anomalousDetectorsStaticColumn = [
     truncateText: false,
     textOnly: true,
     render: (name: string, detector: Detector) => (
-      <EuiLink
-        href={`${PLUGIN_NAME}#/detectors/${detector.id}/results`}
-        target="_blank"
-      >
+      <EuiLink href={`${PLUGIN_NAME}#/detectors/${detector.id}/results`}>
         {name}
       </EuiLink>
     ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Correct the create detector button/detector link on Dashboard to avoid creating new tab

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
