### PR TITLE
Tune AD result charts: show more anomaly results

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -119,20 +119,22 @@ export type DetectorListItem = {
 
 export type AnomalyData = {
   anomalyGrade: number;
-  anomalyScore: number;
+  anomalyScore?: number;
   confidence: number;
-  detectorId: string;
+  detectorId?: string;
   endTime: number;
   startTime: number;
+  plotTime?: number;
 };
 
 export type FeatureAggregationData = {
   data: number;
   endTime: number;
   startTime: number;
+  plotTime?: number;
 };
 
-export type AnomalyPreview = {
+export type Anomalies = {
   anomalies: AnomalyData[];
   featureData: { [key: string]: FeatureAggregationData[] };
 };

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -84,7 +84,7 @@ interface AnomaliesChartProps {
   onZoomRangeChange(startDate: number, endDate: number): void;
   title: string;
   anomalies: any[];
-  atomicAnomalies: boolean;
+  bucketizedAnomalies: boolean;
   anomalySummary: any;
   annotations?: any[];
   dateRange: DateRange;
@@ -124,7 +124,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
     const anomalies = prepareDataForChart(props.anomalies, zoomRange);
     setZoomedAnomalies(anomalies);
     setAnomalySummary(
-      props.atomicAnomalies
+      !props.bucketizedAnomalies
         ? getAnomalySummary(
             filterWithDateRange(props.anomalies, zoomRange, 'plotTime')
           )
@@ -195,7 +195,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
         if (endTime) {
           if (
             !refresh &&
-            props.atomicAnomalies &&
+            !props.bucketizedAnomalies &&
             startTime.valueOf() >= props.dateRange.startDate &&
             endTime.valueOf() <= props.dateRange.endDate
           ) {
@@ -346,7 +346,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                       showLegendDisplayValue={false}
                       legendPosition={Position.Right}
                       onBrushEnd={(start: number, end: number) => {
-                        props.atomicAnomalies
+                        !props.bucketizedAnomalies
                           ? handleZoomRangeChange(start, end)
                           : handleDateRangeChange(start, end);
                         setDatePickerRange({

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -84,6 +84,8 @@ interface AnomaliesChartProps {
   onZoomRangeChange(startDate: number, endDate: number): void;
   title: string;
   anomalies: any[];
+  atomicAnomalies: boolean;
+  anomalySummary: any;
   annotations?: any[];
   dateRange: DateRange;
   isLoading: boolean;
@@ -122,9 +124,11 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
     const anomalies = prepareDataForChart(props.anomalies, zoomRange);
     setZoomedAnomalies(anomalies);
     setAnomalySummary(
-      getAnomalySummary(
-        filterWithDateRange(props.anomalies, zoomRange, 'plotTime')
-      )
+      props.atomicAnomalies
+        ? getAnomalySummary(
+            filterWithDateRange(props.anomalies, zoomRange, 'plotTime')
+          )
+        : props.anomalySummary
     );
     setTotalAlerts(filterWithDateRange(alerts, zoomRange, 'startTime').length);
   }, [props.anomalies, zoomRange]);
@@ -191,6 +195,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
         if (endTime) {
           if (
             !refresh &&
+            props.atomicAnomalies &&
             startTime.valueOf() >= props.dateRange.startDate &&
             endTime.valueOf() <= props.dateRange.endDate
           ) {
@@ -341,7 +346,9 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                       showLegendDisplayValue={false}
                       legendPosition={Position.Right}
                       onBrushEnd={(start: number, end: number) => {
-                        handleZoomRangeChange(start, end);
+                        props.atomicAnomalies
+                          ? handleZoomRangeChange(start, end)
+                          : handleDateRangeChange(start, end);
                         setDatePickerRange({
                           start: moment(start).format(),
                           end: moment(end).format(),
@@ -406,7 +413,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexGroup>
-        <div style={{ paddingTop: '10px', margin: '0px -20px -30px -20px'}}>
+        <div style={{ paddingTop: '10px', margin: '0px -20px -30px -20px' }}>
           {props.children}
         </div>
       </ContentPanel>

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -20,7 +20,7 @@ import { FeatureChart } from '../components/FeatureChart/FeatureChart';
 import {
   Detector,
   FeatureAttributes,
-  AnomalyPreview,
+  Anomalies,
   DateRange,
   FEATURE_TYPE,
 } from '../../../models/interfaces';
@@ -30,7 +30,7 @@ import { focusOnFeatureAccordion } from '../../EditFeatures/utils/helpers';
 interface FeatureBreakDownProps {
   title?: string;
   detector: Detector;
-  anomaliesResult: AnomalyPreview;
+  anomaliesResult: Anomalies;
   annotations: any[];
   isLoading: boolean;
   dateRange: DateRange;

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
@@ -46,7 +46,7 @@ const renderDataFilter = () => ({
           dataTypes: {
             keyword: ['cityName.keyword'],
             integer: ['age'],
-            text: ['cityName'],
+            text: ['cityName'], 
           },
         },
       })}
@@ -56,6 +56,8 @@ const renderDataFilter = () => ({
         onZoomRangeChange={jest.fn()}
         title="test"
         anomalies={anomalies}
+        atomicAnomalies={true}
+        anomalySummary={undefined}
         dateRange={dateRange}
         isLoading={false}
         anomalyGradeSeriesName="anoaly grade"

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
@@ -106,11 +106,12 @@ const findLatestAnomaly = (anomalies: any[]) => {
   return latestAnomaly;
 };
 
-export const getAnomalySummary = (anomalies: any[]): AnomalySummary => {
+export const getAnomalySummary = (totalAnomalies: any[]): AnomalySummary => {
   let minConfidence = 1.0,
     maxConfidence = 0.0;
   let minAnomalyGrade = 1.0,
     maxAnomalyGrade = 0.0;
+  const anomalies = totalAnomalies.filter(anomaly => anomaly.anomalyGrade>0)
   const targetAnomalies = anomalies.filter(anomaly => {
     if (anomaly.anomalyGrade < minAnomalyGrade) {
       minAnomalyGrade = anomaly.anomalyGrade;

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -29,10 +29,17 @@ import {
   Detector,
   Monitor,
   DateRange,
+  AnomalySummary,
+  Anomalies,
 } from '../../../models/interfaces';
 import {
   getAnomalyResultsWithDateRange,
   filterWithDateRange,
+  getAnomalySummaryQuery,
+  getAnomalyResultsQuery,
+  parseAnomalyResults,
+  parseAnomalySummary,
+  parsePureAnomalies,
 } from '../../utils/anomalyResultUtils';
 import { get } from 'lodash';
 import { AnomalyResultsTable } from './AnomalyResultsTable';
@@ -40,6 +47,10 @@ import { AnomaliesChart } from '../../AnomalyCharts/containers/AnomaliesChart';
 import { FeatureBreakDown } from '../../AnomalyCharts/containers/FeatureBreakDown';
 import { minuteDateFormatter } from '../../utils/helpers';
 import { ANOMALY_HISTORY_TABS } from '../utils/constants';
+import { searchES } from '../../../redux/reducers/elasticsearch';
+import { MIN_IN_MILLI_SECS } from '../../../../server/utils/constants';
+import { INITIAL_ANOMALY_SUMMARY } from '../../AnomalyCharts/utils/constants';
+import { MAX_ANOMALIES } from '../../../utils/constants';
 
 interface AnomalyHistoryProps {
   detector: Detector;
@@ -66,16 +77,78 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     ANOMALY_HISTORY_TABS.FEATURE_BREAKDOWN
   );
 
+  const [isLoadingAnomalyResults, setIsLoadingAnomalyResults] = useState<
+    boolean
+  >(false);
+  const [bucketizedAnomalyResults, setBucketizedAnomalyResults] = useState<
+    Anomalies
+  >();
+  const [pureAnomalies, setPureAnomalies] = useState<AnomalyData[]>([]);
+  const [bucketizedAnomalySummary, setBucketizedAnomalySummary] = useState<
+    AnomalySummary
+  >(INITIAL_ANOMALY_SUMMARY);
+
   useEffect(() => {
-    getAnomalyResultsWithDateRange(
-      dispatch,
-      dateRange.startDate,
-      dateRange.endDate,
-      props.detector.id
-    );
+    async function getAnomalyResults() {
+      try {
+        setIsLoadingAnomalyResults(true);
+        const anomalySummaryResult = await dispatch(
+          searchES(
+            getAnomalySummaryQuery(
+              dateRange.startDate,
+              dateRange.endDate,
+              props.detector.id
+            )
+          )
+        );
+        setPureAnomalies(parsePureAnomalies(anomalySummaryResult));
+        setBucketizedAnomalySummary(parseAnomalySummary(anomalySummaryResult));
+        const result = await dispatch(
+          searchES(
+            getAnomalyResultsQuery(
+              dateRange.startDate,
+              dateRange.endDate,
+              1,
+              props.detector.id
+            )
+          )
+        );
+        setBucketizedAnomalyResults(parseAnomalyResults(result));
+        setIsLoadingAnomalyResults(false);
+      } catch (err) {
+        setIsLoadingAnomalyResults(false);
+        console.error(
+          `Failed to get anomaly results for ${props.detector.id}`,
+          err
+        );
+      }
+    }
+
+    if (
+      dateRange.endDate - dateRange.startDate >
+      get(props.detector, 'detectionInterval.period.interval', 1) *
+        MIN_IN_MILLI_SECS *
+        MAX_ANOMALIES
+    ) {
+      getAnomalyResults();
+    } else {
+      setBucketizedAnomalyResults(undefined);
+      getAnomalyResultsWithDateRange(
+        dispatch,
+        dateRange.startDate,
+        dateRange.endDate,
+        props.detector.id
+      );
+    }
   }, [dateRange]);
 
-  const anomalyResults = useSelector((state: AppState) => state.anomalyResults);
+  const atomicAnomalyResults = useSelector(
+    (state: AppState) => state.anomalyResults
+  );
+
+  const anomalyResults = bucketizedAnomalyResults
+    ? bucketizedAnomalyResults
+    : atomicAnomalyResults;
 
   const handleDateRangeChange = useCallback(
     (startDate: number, endDate: number, dateRangeOption?: string) => {
@@ -94,20 +167,22 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     });
   }, []);
 
-  const annotations = get(anomalyResults, 'anomalies', [])
-    //@ts-ignore
-    .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
-    .map((anomaly: AnomalyData) => ({
-      coordinates: {
-        x0: anomaly.startTime,
-        x1: anomaly.endTime,
-      },
-      details: `There is an anomaly with confidence ${
-        anomaly.confidence
-      } between ${minuteDateFormatter(
-        anomaly.startTime
-      )} and ${minuteDateFormatter(anomaly.endTime)}`,
-    }));
+  const annotations = anomalyResults
+    ? get(anomalyResults, 'anomalies', [])
+        //@ts-ignore
+        .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
+        .map((anomaly: AnomalyData) => ({
+          coordinates: {
+            x0: anomaly.startTime,
+            x1: anomaly.endTime,
+          },
+          details: `There is an anomaly with confidence ${
+            anomaly.confidence
+          } between ${minuteDateFormatter(
+            anomaly.startTime
+          )} and ${minuteDateFormatter(anomaly.endTime)}`,
+        }))
+    : [];
 
   const tabs = [
     {
@@ -147,7 +222,9 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         onDateRangeChange={handleDateRangeChange}
         onZoomRangeChange={handleZoomChange}
         anomalies={anomalyResults.anomalies}
-        isLoading={isLoading}
+        atomicAnomalies={bucketizedAnomalyResults === undefined}
+        anomalySummary={bucketizedAnomalySummary}
+        isLoading={isLoading || isLoadingAnomalyResults}
         anomalyGradeSeriesName="Anomaly grade"
         confidenceSeriesName="Confidence"
         showAlerts={true}
@@ -163,7 +240,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       >
         <EuiTabs>{renderTabs()}</EuiTabs>
 
-        {isLoading ? (
+        {isLoading || isLoadingAnomalyResults ? (
           <EuiFlexGroup
             justifyContent="spaceAround"
             style={{ height: '200px', paddingTop: '100px' }}
@@ -186,11 +263,15 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
               />
             ) : (
               <AnomalyResultsTable
-                anomalies={filterWithDateRange(
-                  anomalyResults.anomalies,
-                  zoomRange,
-                  'plotTime'
-                )}
+                anomalies={
+                  bucketizedAnomalyResults === undefined
+                    ? filterWithDateRange(
+                        anomalyResults.anomalies,
+                        zoomRange,
+                        'plotTime'
+                      )
+                    : pureAnomalies
+                }
               />
             )}
           </div>

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -114,13 +114,13 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           )
         );
         setBucketizedAnomalyResults(parseAnomalyResults(result));
-        setIsLoadingAnomalyResults(false);
       } catch (err) {
-        setIsLoadingAnomalyResults(false);
         console.error(
           `Failed to get anomaly results for ${props.detector.id}`,
           err
         );
+      } finally {
+        setIsLoadingAnomalyResults(false);
       }
     }
 

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -21,9 +21,8 @@ import {
   EuiSpacer,
   EuiCallOut,
   EuiButton,
-  EuiEmptyPrompt,
 } from '@elastic/eui';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 import React, { useEffect, Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router';

--- a/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
@@ -30,6 +30,7 @@ import { ListControls } from '../components/ListControls/ListControls';
 import { DetectorResultsQueryParams } from 'server/models/types';
 import { AnomalyData } from '../../../models/interfaces';
 import { getTitleWithCount } from '../../../utils/utils';
+import { toFixedNumber } from '../../../../server/utils/helpers';
 
 interface AnomalyResultsTableProps {
   anomalies: AnomalyData[];
@@ -68,7 +69,13 @@ export function AnomalyResultsTable(props: AnomalyResultsTableProps) {
 
   useEffect(() => {
     const anomalies = props.anomalies
-      ? props.anomalies.filter(anomaly => anomaly.anomalyGrade > 0)
+      ? props.anomalies.filter(anomaly => anomaly.anomalyGrade > 0).map(anomaly => {
+        return {
+          ...anomaly,
+          anomalyGrade: toFixedNumber(anomaly.anomalyGrade),
+          confidence: toFixedNumber(anomaly.confidence),
+        }
+      })
       : [];
 
     anomalies.sort(

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -23,8 +23,16 @@ import { getDetectorLiveResults } from '../../redux/reducers/liveAnomalyResults'
 import moment from 'moment';
 import { Dispatch } from 'redux';
 import { get } from 'lodash';
-import { AnomalyData, DateRange } from '../../models/interfaces';
+import {
+  AnomalyData,
+  DateRange,
+  AnomalySummary,
+  FeatureAggregationData,
+  Anomalies,
+} from '../../models/interfaces';
 import { MAX_ANOMALIES } from '../../utils/constants';
+import { minuteDateFormatter } from './helpers';
+import { toFixedNumber } from '../../../server/utils/helpers';
 
 export const getLiveAnomalyResults = (
   dispatch: Dispatch<any>,
@@ -167,9 +175,272 @@ export const filterWithDateRange = (
   dateRange: DateRange,
   timeField: string
 ) => {
-  const anomalies = data.filter(item => {
-    const time = get(item, `${timeField}`);
-    return time && time >= dateRange.startDate && time <= dateRange.endDate;
+  const anomalies = data
+    ? data.filter(item => {
+        const time = get(item, `${timeField}`);
+        return time && time >= dateRange.startDate && time <= dateRange.endDate;
+      })
+    : [];
+  return anomalies;
+};
+
+export const RETURNED_AD_RESULT_FILEDS = [
+  'data_start_time',
+  'data_end_time',
+  'anomaly_grade',
+  'confidence',
+  'feature_data',
+];
+
+export const getAnomalySummaryQuery = (
+  startTime: number,
+  endTime: number,
+  detectorId: string
+) => {
+  return {
+    index: '.opendistro-anomaly-results*',
+    size: MAX_ANOMALIES,
+    rawQuery: {
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                data_end_time: {
+                  gte: startTime,
+                  lte: endTime,
+                },
+              },
+            },
+            {
+              range: {
+                anomaly_grade: {
+                  gt: 0,
+                },
+              },
+            },
+            {
+              term: {
+                detector_id: detectorId,
+              },
+            },
+          ],
+        },
+      },
+      aggs: {
+        count_anomalies: {
+          value_count: {
+            field: 'anomaly_grade',
+          },
+        },
+        max_confidence: {
+          max: {
+            field: 'confidence',
+          },
+        },
+        min_confidence: {
+          min: {
+            field: 'confidence',
+          },
+        },
+        max_anomaly_grade: {
+          max: {
+            field: 'anomaly_grade',
+          },
+        },
+        min_anomaly_grade: {
+          min: {
+            field: 'anomaly_grade',
+          },
+        },
+        max_data_end_time: {
+          max: {
+            field: 'data_end_time',
+          },
+        },
+      },
+      _source: {
+        includes: RETURNED_AD_RESULT_FILEDS,
+      },
+    },
+  };
+};
+
+export const getAnomalyResultsQuery = (
+  startTime: number,
+  endTime: number,
+  interval: number,
+  detectorId: string
+) => {
+  const fixedInterval = Math.ceil(
+    (endTime - startTime) / (interval * MIN_IN_MILLI_SECS * MAX_DATA_POINTS)
+  );
+  return {
+    index: '.opendistro-anomaly-results*',
+    size: 0,
+    rawQuery: {
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                data_end_time: {
+                  gte: startTime,
+                  lte: endTime,
+                },
+              },
+            },
+            {
+              term: {
+                detector_id: detectorId,
+              },
+            },
+          ],
+        },
+      },
+      aggs: {
+        bucketized_anomaly_grade: {
+          date_histogram: {
+            field: 'data_end_time',
+            fixed_interval: `${fixedInterval}m`,
+          },
+          aggs: {
+            top_anomaly_hits: {
+              top_hits: {
+                sort: [
+                  {
+                    anomaly_grade: {
+                      order: 'desc',
+                    },
+                  },
+                ],
+                _source: {
+                  includes: RETURNED_AD_RESULT_FILEDS,
+                },
+                size: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+export const parseAnomalyResults = (result: any): Anomalies => {
+  const rawAnomalies = get(
+    result,
+    'data.response.aggregations.bucketized_anomaly_grade.buckets',
+    []
+  ) as any[];
+  let anomalies = [] as AnomalyData[];
+  let featureData = {} as { [key: string]: FeatureAggregationData[] };
+  rawAnomalies.forEach(item => {
+    if (get(item, 'top_anomaly_hits.hits.hits', []).length > 0) {
+      const rawAnomaly = get(item, 'top_anomaly_hits.hits.hits.0._source');
+      if (get(rawAnomaly, 'anomaly_grade') !== undefined) {
+        anomalies.push({
+          anomalyGrade: toFixedNumber(get(rawAnomaly, 'anomaly_grade')),
+          confidence: toFixedNumber(get(rawAnomaly, 'confidence')),
+          startTime: get(rawAnomaly, 'data_start_time'),
+          endTime: get(rawAnomaly, 'data_end_time'),
+          plotTime: get(rawAnomaly, 'data_end_time'),
+        });
+      }
+      if (get(rawAnomaly, 'feature_data', []).length > 0) {
+        get(rawAnomaly, 'feature_data', []).forEach(feature => {
+          if (!get(featureData, get(feature, 'feature_id'))) {
+            featureData[get(feature, 'feature_id')] = [];
+          }
+          featureData[get(feature, 'feature_id')].push({
+            data: toFixedNumber(get(feature, 'data')),
+            startTime: get(rawAnomaly, 'data_start_time'),
+            endTime: get(rawAnomaly, 'data_end_time'),
+            plotTime: get(rawAnomaly, 'data_end_time'),
+          });
+        });
+      }
+    }
   });
+  return {
+    anomalies: anomalies,
+    featureData: featureData,
+  };
+};
+
+export const parseAnomalySummary = (
+  anomalySummaryResult: any
+): AnomalySummary => {
+  const anomalyCount = get(
+    anomalySummaryResult,
+    'data.response.aggregations.count_anomalies.value',
+    0
+  );
+  return {
+    anomalyOccurrence: anomalyCount,
+    minAnomalyGrade: anomalyCount
+      ? toFixedNumber(
+          get(
+            anomalySummaryResult,
+            'data.response.aggregations.min_anomaly_grade.value'
+          )
+        )
+      : 0,
+    maxAnomalyGrade: anomalyCount
+      ? toFixedNumber(
+          get(
+            anomalySummaryResult,
+            'data.response.aggregations.max_anomaly_grade.value'
+          )
+        )
+      : 0,
+    minConfidence: anomalyCount
+      ? toFixedNumber(
+          get(
+            anomalySummaryResult,
+            'data.response.aggregations.min_confidence.value'
+          )
+        )
+      : 0,
+    maxConfidence: anomalyCount
+      ? toFixedNumber(
+          get(
+            anomalySummaryResult,
+            'data.response.aggregations.max_confidence.value'
+          )
+        )
+      : 0,
+    lastAnomalyOccurrence: anomalyCount
+      ? minuteDateFormatter(
+          get(
+            anomalySummaryResult,
+            'data.response.aggregations.max_data_end_time.value'
+          )
+        )
+      : '',
+  };
+};
+
+export const parsePureAnomalies = (
+  anomalySummaryResult: any
+): AnomalyData[] => {
+  const anomaliesHits = get(
+    anomalySummaryResult,
+    'data.response.hits.hits',
+    []
+  );
+  const anomalies = [] as AnomalyData[];
+  if (anomaliesHits.length > 0) {
+    anomaliesHits.forEach((item: any) => {
+      const rawAnomaly = get(item, '_source');
+      anomalies.push({
+        anomalyGrade: get(rawAnomaly, 'anomaly_grade'),
+        confidence: get(rawAnomaly, 'confidence'),
+        startTime: get(rawAnomaly, 'data_start_time'),
+        endTime: get(rawAnomaly, 'data_end_time'),
+        plotTime: get(rawAnomaly, 'data_end_time'),
+      });
+    });
+  }
   return anomalies;
 };

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -266,7 +266,7 @@ export const getAnomalySummaryQuery = (
   };
 };
 
-export const getAnomalyResultsQuery = (
+export const getBucketizedAnomalyResultsQuery = (
   startTime: number,
   endTime: number,
   interval: number,
@@ -327,7 +327,7 @@ export const getAnomalyResultsQuery = (
   };
 };
 
-export const parseAnomalyResults = (result: any): Anomalies => {
+export const parseBucketizedAnomalyResults = (result: any): Anomalies => {
   const rawAnomalies = get(
     result,
     'data.response.aggregations.bucketized_anomaly_grade.buckets',

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -184,7 +184,7 @@ export const filterWithDateRange = (
   return anomalies;
 };
 
-export const RETURNED_AD_RESULT_FILEDS = [
+export const RETURNED_AD_RESULT_FIELDS = [
   'data_start_time',
   'data_end_time',
   'anomaly_grade',
@@ -260,7 +260,7 @@ export const getAnomalySummaryQuery = (
         },
       },
       _source: {
-        includes: RETURNED_AD_RESULT_FILEDS,
+        includes: RETURNED_AD_RESULT_FIELDS,
       },
     },
   };
@@ -315,7 +315,7 @@ export const getAnomalyResultsQuery = (
                   },
                 ],
                 _source: {
-                  includes: RETURNED_AD_RESULT_FILEDS,
+                  includes: RETURNED_AD_RESULT_FIELDS,
                 },
                 size: 1,
               },

--- a/public/redux/reducers/anomalies.ts
+++ b/public/redux/reducers/anomalies.ts
@@ -20,13 +20,13 @@ import {
 } from '../middleware/types';
 import handleActions from '../utils/handleActions';
 import { AD_NODE_API } from '../../../utils/constants';
-import { AnomalyPreview } from '../../models/interfaces';
+import { Anomalies } from '../../models/interfaces';
 
 const PREVIEW_DETECTOR = 'ad/PREVIEW_DETECTOR';
 
 export interface Anomalies {
   requesting: boolean;
-  anomaliesResult: AnomalyPreview;
+  anomaliesResult: Anomalies;
   errorMessage: string;
 }
 export const initialDetectorsState: Anomalies = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Tune AD result charts: show more anomaly results

## Before

![Screen Shot 2020-05-06 at 11 13 14 AM](https://user-images.githubusercontent.com/49084640/81213672-928a8880-8f8b-11ea-870a-2b1c8a1f24f0.png)

## After

![Screen Shot 2020-05-06 at 11 14 09 AM](https://user-images.githubusercontent.com/49084640/81213758-b77efb80-8f8b-11ea-9143-384f72d4725a.png)

If user zoom in, they can see more details, like this one

![Screen Shot 2020-05-06 at 11 22 52 AM](https://user-images.githubusercontent.com/49084640/81213938-fd3bc400-8f8b-11ea-8696-475f2627d53f.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
