### PR TITLE
Fix 2 issues

### DIFF
--- a/public/pages/DetectorConfig/containers/DetectorConfig.tsx
+++ b/public/pages/DetectorConfig/containers/DetectorConfig.tsx
@@ -13,34 +13,44 @@
  * permissions and limitations under the License.
  */
 
-import { Detector } from '../../../models/interfaces';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MetaData } from './MetaData';
 import { Features } from './Features';
 import { EuiSpacer, EuiPage, EuiPageBody } from '@elastic/eui';
 import { RouteComponentProps } from 'react-router';
+import { AppState } from '../../../redux/reducers';
+import { useSelector, useDispatch } from 'react-redux';
+import { getDetector } from '../../../redux/reducers/ad';
 
 interface DetectorConfigProps extends RouteComponentProps {
   detectorId: string;
-  detector: Detector;
   onEditFeatures(): void;
   onEditDetector(): void;
 }
 
 export const DetectorConfig = (props: DetectorConfigProps) => {
+  const dispatch = useDispatch();
+  const detector = useSelector(
+    (state: AppState) => state.ad.detectors[props.detectorId]
+  );
+
+  useEffect(() => {
+    dispatch(getDetector(props.detectorId));
+  }, []);
+
   return (
     <EuiPage style={{ marginTop: '16px', paddingTop: '0px' }}>
       <EuiPageBody>
         <EuiSpacer size="l" />
         <MetaData
           detectorId={props.detectorId}
-          detector={props.detector}
+          detector={detector}
           onEditDetector={props.onEditDetector}
         />
         <EuiSpacer />
         <Features
           detectorId={props.detectorId}
-          detector={props.detector}
+          detector={detector}
           onEditFeatures={props.onEditFeatures}
         />
       </EuiPageBody>

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -89,8 +89,8 @@ interface DetectorDetailModel {
 export const DetectorDetail = (props: DetectorDetailProps) => {
   const dispatch = useDispatch();
   const detectorId = get(props, 'match.params.detectorId', '') as string;
-  const { monitor, fetchMonitorError } = useFetchMonitorInfo(detectorId);
   const { detector, hasError } = useFetchDetectorInfo(detectorId);
+  const { monitor, fetchMonitorError } = useFetchMonitorInfo(detectorId);
 
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
@@ -460,7 +460,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
             <DetectorConfig
               {...props}
               detectorId={detectorId}
-              detector={detector}
+              // detector={detector}
               onEditFeatures={handleEditFeature}
               onEditDetector={handleEditDetector}
             />

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -460,7 +460,6 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
             <DetectorConfig
               {...props}
               detectorId={detectorId}
-              // detector={detector}
               onEditFeatures={handleEditFeature}
               onEditDetector={handleEditDetector}
             />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fix issue where given detector fails initialization, after updating its config, detector status is shown as 'Detector is not started', which is inconsistent with correct status, 'Initialization failure'
2. Get detector info before fetching monitor in Detector Details page: we found issue where sometimes fetching detector info call is not made after fetching monitor call is done, and this made Detector detail page blank. To avoid this, we move fetching detector info call before fetching monitor. 

Before:
![Screen Shot 2020-05-07 at 3 34 56 PM](https://user-images.githubusercontent.com/59710443/81352080-84fffc00-907a-11ea-8776-f038196625b4.png)

After
![Screen Shot 2020-05-07 at 3 35 18 PM](https://user-images.githubusercontent.com/59710443/81352173-bbd61200-907a-11ea-865d-467725282cc6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
