### PR TITLE
Fix issue of not resetting to first page when applying filters

### DIFF
--- a/public/pages/DetectorsList/List/List.tsx
+++ b/public/pages/DetectorsList/List/List.tsx
@@ -168,6 +168,7 @@ export const DetectorList = (props: ListProps) => {
     const searchText = e.target.value;
     setState({
       ...state,
+      page: 0,
       queryParams: {
         ...state.queryParams,
         search: searchText,
@@ -181,6 +182,10 @@ export const DetectorList = (props: ListProps) => {
       const sanitizedQuery = sanitizeSearchText(searchValue);
       setIndexQuery(sanitizedQuery);
       await dispatch(getPrioritizedIndices(sanitizedQuery));
+      setState(state => ({
+        ...state,
+        page: 0,
+      }));
     }
   }, 300);
 
@@ -195,6 +200,7 @@ export const DetectorList = (props: ListProps) => {
         : options.map(option => option.label as DETECTOR_STATE);
     setState(state => ({
       ...state,
+      page: 0,
       selectedDetectorStates: states,
     }));
   };
@@ -209,6 +215,7 @@ export const DetectorList = (props: ListProps) => {
 
     setState({
       ...state,
+      page: 0,
       selectedIndices: indices,
     });
   };
@@ -234,8 +241,6 @@ export const DetectorList = (props: ListProps) => {
     state.selectedDetectorStates,
     state.queryParams.sortField,
     state.queryParams.sortDirection,
-    state.queryParams.size,
-    state.page
   );
 
   // get detectors to display based on this page

--- a/public/pages/utils/helpers.ts
+++ b/public/pages/utils/helpers.ts
@@ -72,9 +72,7 @@ export const filterAndSortDetectors = (
   selectedIndices: string[],
   selectedDetectorStates: DETECTOR_STATE[],
   sortField: string,
-  sortDirection: string,
-  size: number,
-  page: number
+  sortDirection: string
 ) => {
   let filteredBySearch =
     search == ''


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On the detector list page, if user is on a page other than the first page and applies a filter, it may show no detectors even if some exist with the filter applied. This is because the page is not reset to the first page when a filter is applied. This fixes that issue, and will reset the page to the first page for the 4 possible filter changes:
1. Searching in search bar
2. Filtering by detector state
3. Filtering by index
4. Searching by index

Before:

![Screen Shot 2020-05-08 at 10 29 08 AM](https://user-images.githubusercontent.com/62119629/81432360-9e0aba80-9117-11ea-9dc6-30e7109211f6.png)

After:

![Screen Shot 2020-05-08 at 10 28 37 AM](https://user-images.githubusercontent.com/62119629/81432367-a4009b80-9117-11ea-8371-daf61ec11278.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
