### PR TITLE
Fix unnecessary filter when getting single anomaly result

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -52,6 +52,7 @@ import {
   visualizeAnomalyResultForXYChart,
   getFloorPlotTime,
   getLatestAnomalyResultsForDetectorsByTimeRange,
+  getLatestAnomalyResultsByTimeRange,
 } from '../utils/utils';
 import { MAX_ANOMALIES } from '../../../utils/constants';
 
@@ -92,14 +93,12 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   const getLiveAnomalyResults = async () => {
     setIsLoadingAnomalies(true);
     // check if there is any anomaly result in last 30mins
-    const latestSingleLiveAnomalyResult = await getLatestAnomalyResultsForDetectorsByTimeRange(
+    const latestSingleLiveAnomalyResult = await getLatestAnomalyResultsByTimeRange(
       searchES,
-      props.selectedDetectors,
       '30m',
       dispatch,
       -1,
-      1,
-      MAX_LIVE_DETECTORS
+      1
     );
 
     setHasLatestAnomalyResult(!isEmpty(latestSingleLiveAnomalyResult));
@@ -115,22 +114,18 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
       MAX_LIVE_DETECTORS
     );
 
-    const nonZeroAnomalyResult = latestLiveAnomalyResult.filter(
-      anomalyData => get(anomalyData, AD_DOC_FIELDS.ANOMALY_GRADE, 0) > 0
-    );
-
-    setLiveAnomalyData(nonZeroAnomalyResult);
+    setLiveAnomalyData(latestLiveAnomalyResult);
 
     setLatestLiveAnomalousDetectorsCount(
       new Set(
-        nonZeroAnomalyResult.map(anomalyData =>
+        latestLiveAnomalyResult.map(anomalyData =>
           get(anomalyData, AD_DOC_FIELDS.DETECTOR_ID, '')
         )
       ).size
     );
 
-    if (!isEmpty(nonZeroAnomalyResult)) {
-      setLastAnomalyResult(nonZeroAnomalyResult[0]);
+    if (!isEmpty(latestLiveAnomalyResult)) {
+      setLastAnomalyResult(latestLiveAnomalyResult[0]);
     } else {
       setLastAnomalyResult(undefined);
     }

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -472,6 +472,53 @@ export const buildGetAnomalyResultQueryByRange = (
   };
 };
 
+export const getLatestAnomalyResultsByTimeRange = async (
+  func: (request: any) => APIAction,
+  timeRange: string,
+  dispatch: Dispatch<any>,
+  threshold: number,
+  anomalySize: number
+): Promise<object[]> => {
+  let from = 0;
+  let numResults: number;
+  let anomalyResults = [] as object[];
+  do {
+    const searchResponse = await dispatch(
+      func(
+        buildGetAnomalyResultQueryByRange(
+          timeRange,
+          from,
+          anomalySize,
+          threshold
+        )
+      )
+    );
+    const searchAnomalyResponse = searchResponse.data.response;
+
+    numResults = get(searchAnomalyResponse, 'hits.total.value', 0);
+    if (numResults === 0) {
+      break;
+    }
+
+    const anomalies: any[] = get(searchAnomalyResponse, 'hits.hits', []).map(
+      (result: any) => {
+        return {
+          [AD_DOC_FIELDS.DETECTOR_ID]: result._source.detector_id,
+          [AD_DOC_FIELDS.ANOMALY_GRADE]: Number(
+            result._source.anomaly_grade
+          ).toFixed(2),
+          [AD_DOC_FIELDS.DATA_START_TIME]: result._source.data_start_time,
+          [AD_DOC_FIELDS.DATA_END_TIME]: result._source.data_end_time,
+        };
+      }
+    );
+    anomalyResults = [...anomalyResults, ...anomalies];
+    from += anomalySize;
+  } while (numResults === MAX_ANOMALIES);
+
+  return anomalyResults;
+};
+
 export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
   func: (request: any) => APIAction,
   selectedDetectors: DetectorListItem[],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix unnecessary filter when getting single anomaly result.

Root cause: when we get latest anomaly result, because of the filter above, we filter out result since latest anomaly result may be from detector which is not in the selected detectors. 

In case of selecting 1 detector via Filters, the latest anomaly result is from a different detector, which falsely tells live chart there is no detector running. The reason why we get single latest anomaly result is to check if there is anomaly result in last 30 min, regardless of detector.

Before fix:
![Screen Shot 2020-05-08 at 6 13 20 PM](https://user-images.githubusercontent.com/59710443/81460067-d03c0c80-9157-11ea-87ea-f3ac7e7a7b46.png)

After:
![Screen Shot 2020-05-08 at 6 15 18 PM](https://user-images.githubusercontent.com/59710443/81460118-0bd6d680-9158-11ea-9008-223c8debdf40.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
