### PR TITLE
use annotation for live chart

### DIFF
--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -129,6 +129,8 @@ export const prepareDataForChart = (
     anomalies = anomalies.map(anomaly => {
       return {
         ...anomaly,
+        confidence: null,
+        anomalyGrade: null,
         plotTime: getFloorPlotTime(anomaly.plotTime),
       };
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* use annotation for live chart

<img width="1141" alt="Screen Shot 2020-05-08 at 6 59 18 PM" src="https://user-images.githubusercontent.com/49084640/81461055-1e540e80-915e-11ea-903c-335e23e6e99f.png">

<img width="1137" alt="Screen Shot 2020-05-08 at 7 00 53 PM" src="https://user-images.githubusercontent.com/49084640/81461076-45124500-915e-11ea-90db-5a6881c520d5.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
