### PR TITLE
fix live chart time range;add custom anomaly tooltip

### DIFF
--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -107,11 +107,43 @@ const sampleMaxAnomalyGrade = (anomalies: any[]): any[] => {
   return sampledAnomalies;
 };
 
+export const prepareDataForLiveChart = (
+  data: any[],
+  dateRange: DateRange,
+  interval: number
+) => {
+  if (!data || data.length === 0) {
+    return [];
+  }
+
+  let anomalies = [];
+  for (
+    let time = dateRange.endDate;
+    time > dateRange.startDate;
+    time -= MIN_IN_MILLI_SECS * interval
+  ) {
+    anomalies.push({
+      startTime: time,
+      endTime: time,
+      plotTime: time,
+      confidence: null,
+      anomalyGrade: null,
+    });
+  }
+
+  anomalies.push({
+    startTime: dateRange.startDate,
+    endTime: dateRange.startDate,
+    plotTime: dateRange.startDate,
+    confidence: null,
+    anomalyGrade: null,
+  });
+  return anomalies;
+};
+
 export const prepareDataForChart = (
   data: any[],
   dateRange: DateRange,
-  interval: number = 1,
-  getFloorPlotTime?: any
 ) => {
   if (!data || data.length === 0) {
     return [];
@@ -124,75 +156,20 @@ export const prepareDataForChart = (
   if (anomalies.length > MAX_DATA_POINTS) {
     anomalies = sampleMaxAnomalyGrade(anomalies);
   }
-  if (getFloorPlotTime) {
-    // we need to get floor plot time for bar chart
-    anomalies = anomalies.map(anomaly => {
-      return {
-        ...anomaly,
-        confidence: null,
-        anomalyGrade: null,
-        plotTime: getFloorPlotTime(anomaly.plotTime),
-      };
-    });
-    let startTime =
-      anomalies.length > 0
-        ? anomalies[anomalies.length - 1].plotTime
-        : getFloorPlotTime(dateRange.startDate);
-    let endTime =
-      anomalies.length > 0
-        ? anomalies[0].plotTime
-        : getFloorPlotTime(dateRange.endDate);
-
-    while (endTime < dateRange.endDate) {
-      // make sure the end of plot time is big enough to cover NOW annotation, which is at dateRange.endDate
-      endTime += MIN_IN_MILLI_SECS * interval;
-    }
-    if (anomalies.length === 0) {
-      for (
-        let time = endTime;
-        time > startTime;
-        time -= MIN_IN_MILLI_SECS * interval
-      ) {
-        anomalies.push({
-          startTime: time,
-          endTime: time,
-          plotTime: time,
-          confidence: null,
-          anomalyGrade: null,
-        });
-      }
-    }
-
-    anomalies.push({
-      startTime: dateRange.startDate,
-      endTime: dateRange.startDate,
-      plotTime: startTime - MIN_IN_MILLI_SECS * interval,
-      confidence: null,
-      anomalyGrade: null,
-    });
-    anomalies.unshift({
-      startTime: dateRange.endDate,
-      endTime: dateRange.endDate,
-      plotTime: endTime,
-      confidence: null,
-      anomalyGrade: null,
-    });
-  } else {
-    anomalies.push({
-      startTime: dateRange.startDate,
-      endTime: dateRange.startDate,
-      plotTime: dateRange.startDate,
-      confidence: null,
-      anomalyGrade: null,
-    });
-    anomalies.unshift({
-      startTime: dateRange.endDate,
-      endTime: dateRange.endDate,
-      plotTime: dateRange.endDate,
-      confidence: null,
-      anomalyGrade: null,
-    });
-  }
+  anomalies.push({
+    startTime: dateRange.startDate,
+    endTime: dateRange.startDate,
+    plotTime: dateRange.startDate,
+    confidence: null,
+    anomalyGrade: null,
+  });
+  anomalies.unshift({
+    startTime: dateRange.endDate,
+    endTime: dateRange.endDate,
+    plotTime: dateRange.endDate,
+    confidence: null,
+    anomalyGrade: null,
+  });
   return anomalies;
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Fix wrong bar width cause by X Axis time range

## Before
X Axis shows 1 hour, which is wrong, we should show 6 hours.
![Screen Shot 2020-05-09 at 1 06 29 AM](https://user-images.githubusercontent.com/49084640/81471988-03a78700-91aa-11ea-94a9-e00d2388fae3.png)

## After
![Screen Shot 2020-05-09 at 4 01 45 AM](https://user-images.githubusercontent.com/49084640/81472002-191cb100-91aa-11ea-872d-59a5ecb0dc91.png)

* Add custom tooltip for live anomaly

## Before
![Screen Shot 2020-05-09 at 3 59 46 AM](https://user-images.githubusercontent.com/49084640/81472022-3782ac80-91aa-11ea-88aa-b3f3fd887c48.png)

## After
![Screen Shot 2020-05-09 at 3 56 18 AM](https://user-images.githubusercontent.com/49084640/81472034-3cdff700-91aa-11ea-9d28-ca538cb8b991.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
