### PR TITLE
Use original anomaly grade for dashboard; use fixed height for live chart

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -47,7 +47,10 @@ import {
 } from '@elastic/charts';
 import { EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
-import { TIME_NOW_LINE_STYLE } from '../utils/constants';
+import {
+  TIME_NOW_LINE_STYLE,
+  SHOW_DECIMAL_NUMBER_THRESHOLD,
+} from '../utils/constants';
 import {
   visualizeAnomalyResultForXYChart,
   getFloorPlotTime,
@@ -274,9 +277,14 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                 title={
                   lastAnomalyResult === undefined
                     ? '-'
-                    : Number(
+                    : get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0) <
+                      SHOW_DECIMAL_NUMBER_THRESHOLD
+                    ? Number(
                         get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
                       ).toExponential(2)
+                    : Number(
+                        get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
+                      ).toFixed(2)
                 }
                 titleSize="s"
               />

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -224,6 +224,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
       }
       actions={[fullScreenButton()]}
       contentPanelClassName={isFullScreen ? 'full-screen' : undefined}
+      panelStyles={{ height: !isFullScreen ? '390px' : undefined }}
     >
       {isLoadingAnomalies ? (
         <EuiFlexGroup justifyContent="center">
@@ -273,7 +274,9 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
                 title={
                   lastAnomalyResult === undefined
                     ? '-'
-                    : get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
+                    : Number(
+                        get(lastAnomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0)
+                      ).toExponential(2)
                 }
                 titleSize="s"
               />

--- a/public/pages/Dashboard/utils/constants.ts
+++ b/public/pages/Dashboard/utils/constants.ts
@@ -88,3 +88,5 @@ export const GET_ALL_DETECTORS_QUERY_PARAMS = {
 export const ALL_DETECTORS_MESSAGE = 'All detectors';
 export const ALL_DETECTOR_STATES_MESSAGE = 'All detector states';
 export const ALL_INDICES_MESSAGE = 'All indices';
+
+export const SHOW_DECIMAL_NUMBER_THRESHOLD = 0.01;

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -421,6 +421,11 @@ export const visualizeAnomalyResultForXYChart = (
     [AD_DOC_FIELDS.PLOT_TIME]: getFloorPlotTime(
       get(anomalyResult, AD_DOC_FIELDS.DATA_START_TIME, 0)
     ),
+    [AD_DOC_FIELDS.ANOMALY_GRADE]: get(
+      anomalyResult,
+      AD_DOC_FIELDS.ANOMALY_GRADE,
+      0
+    ),
   };
 };
 
@@ -503,9 +508,7 @@ export const getLatestAnomalyResultsByTimeRange = async (
       (result: any) => {
         return {
           [AD_DOC_FIELDS.DETECTOR_ID]: result._source.detector_id,
-          [AD_DOC_FIELDS.ANOMALY_GRADE]: Number(
-            result._source.anomaly_grade
-          ).toFixed(2),
+          [AD_DOC_FIELDS.ANOMALY_GRADE]: result._source.anomaly_grade,
           [AD_DOC_FIELDS.DATA_START_TIME]: result._source.data_start_time,
           [AD_DOC_FIELDS.DATA_END_TIME]: result._source.data_end_time,
         };
@@ -554,9 +557,7 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
         const detector = detectorAndIdMap.get(result._source.detector_id);
         return {
           [AD_DOC_FIELDS.DETECTOR_ID]: result._source.detector_id,
-          [AD_DOC_FIELDS.ANOMALY_GRADE]: Number(
-            result._source.anomaly_grade
-          ).toFixed(2),
+          [AD_DOC_FIELDS.ANOMALY_GRADE]: result._source.anomaly_grade,
           [AD_DOC_FIELDS.DATA_START_TIME]: result._source.data_start_time,
           [AD_DOC_FIELDS.DATA_END_TIME]: result._source.data_end_time,
           [AD_DOC_FIELDS.DETECTOR_NAME]: get(

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -34,6 +34,7 @@ import { get, orderBy, isEmpty } from 'lodash';
 import { APIAction } from 'public/redux/middleware/types';
 import { Dispatch } from 'redux';
 import { EuiBasicTableColumn } from '@elastic/eui';
+import { SHOW_DECIMAL_NUMBER_THRESHOLD } from './constants';
 
 /**
  * Get the recent anomaly result query for the last timeRange period(Date-Math)
@@ -416,16 +417,16 @@ const buildDetectorAnomalyResultMap = (
 export const visualizeAnomalyResultForXYChart = (
   anomalyResult: any
 ): object => {
+  const actualAnomalyGrade = get(anomalyResult, AD_DOC_FIELDS.ANOMALY_GRADE, 0);
   return {
     ...anomalyResult,
     [AD_DOC_FIELDS.PLOT_TIME]: getFloorPlotTime(
       get(anomalyResult, AD_DOC_FIELDS.DATA_START_TIME, 0)
     ),
-    [AD_DOC_FIELDS.ANOMALY_GRADE]: get(
-      anomalyResult,
-      AD_DOC_FIELDS.ANOMALY_GRADE,
-      0
-    ),
+    [AD_DOC_FIELDS.ANOMALY_GRADE]:
+      actualAnomalyGrade < SHOW_DECIMAL_NUMBER_THRESHOLD
+        ? Number(actualAnomalyGrade).toExponential(2)
+        : Number(actualAnomalyGrade).toFixed(2),
   };
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use original anomaly grade for dashboard; use fixed height for live chart

Before the change, live chart/sunburst chart will ignore anomaly grade < 0.005. Since I do `Number(anomaly_grade).toFixed(2)`, and filter out number === 0, any number less than 0.005 will be 0.00 after `toFixed()`. This causes that dashboard shows 1 anomaly less the number on Detector list.

Another change, use fixed height for dashboard live chart so that when loading icon is showing during live chart refreshing, dashboard live chart will shrink.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
