### PR TITLE
Use bucket aggregation for anomaly distribution. Issue: #91

### DIFF
--- a/server/routes/elasticsearch.ts
+++ b/server/routes/elasticsearch.ts
@@ -53,6 +53,7 @@ const executeSearch = async (
       size = 0,
       sort = undefined,
       collapse = undefined,
+      aggs = undefined,
       rawQuery = undefined,
     } = req.payload as {
       index: string;
@@ -60,6 +61,7 @@ const executeSearch = async (
       size?: number;
       sort?: object;
       collapse?: object;
+      aggs?: object;
       rawQuery: object;
     };
     const requestBody = rawQuery
@@ -68,6 +70,7 @@ const executeSearch = async (
           query: query,
           ...(sort !== undefined && { sort: sort }),
           ...(collapse !== undefined && { collapse: collapse }),
+          ...(aggs !== undefined && { aggs: aggs }),
         };
 
     const params: SearchParams = { index, size, body: requestBody };


### PR DESCRIPTION
*Issue #, if available:*
Issue: #91
*Description of changes:*
Currently we query raw anomalies which has anomaly_grade>0 and aggregate by detector. Generally, the anomalies count should be small. But for long time range or edge case like 1k detectors, it may result in long time loading. We can try bucket aggregation to improve performance.

This PR changes to use bucket aggregation for anomaly distribution. Latency of same request for last 7 days decreases from 80ms to 20ms on 1000 detectors performance domain. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
