### PR TITLE
Fix compile error: duplicate declaration of MAX_DETECTOR caused by cherry-pick

### DIFF
--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -36,7 +36,6 @@ import { APIAction } from 'public/redux/middleware/types';
 import { useDispatch } from 'react-redux';
 import { Dispatch } from 'redux';
 import { SHOW_DECIMAL_NUMBER_THRESHOLD } from './constants';
-import { MAX_DETECTORS } from '../../../pages/utils/constants';
 
 /**
  * Get the recent anomaly result query for the last timeRange period(Date-Math)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix compile error: duplicate declaration of MAX_DETECTOR caused by cherry-pick. This issue only happens for 1.4 branch. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
