### PR TITLE
Fix loading bug on anomalies live chart

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -96,14 +96,22 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   const getLiveAnomalyResults = async () => {
     setIsLoadingAnomalies(true);
     // check if there is any anomaly result in last 30mins
-    const latestSingleLiveAnomalyResult = await getLatestAnomalyResultsByTimeRange(
-      searchES,
-      '30m',
-      dispatch,
-      -1,
-      1,
-      true
-    );
+    // need to initially check if there is an error when accessing anomaly results index
+    // in the case that it doesn't exist upon cluster initialization
+    let latestSingleLiveAnomalyResult = [] as any[];
+    try {
+      latestSingleLiveAnomalyResult = await getLatestAnomalyResultsByTimeRange(
+        searchES,
+        '30m',
+        dispatch,
+        -1,
+        1,
+        true
+      );
+    } catch (err) {
+      console.log('Error getting latest anomaly results', err);
+      setIsLoadingAnomalies(false);
+    }
 
     setHasLatestAnomalyResult(!isEmpty(latestSingleLiveAnomalyResult));
 

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -109,7 +109,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         true
       );
     } catch (err) {
-      console.log('Error getting latest anomaly results', err);
+      console.log('Error getting latest anomaly results - index may not exist yet', err);
       setIsLoadingAnomalies(false);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds error checking to anomalies live chart in the case that .opendistro-anomaly-results index does not exist yet. Without error checking, chart was getting stuck in an infinite loading state. This fixes that.

Before:

![Screen Shot 2020-05-11 at 10 52 28 AM](https://user-images.githubusercontent.com/62119629/81594334-96e0e800-9375-11ea-8f67-e3649831f02c.png)

After:

![Screen Shot 2020-05-11 at 10 51 59 AM](https://user-images.githubusercontent.com/62119629/81594352-9ba59c00-9375-11ea-8b8e-d7654c3f2e1c.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
