### PR TITLE
Fix callout when error creating detector

### DIFF
--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -161,7 +161,7 @@ export function CreateDetector(props: CreateADProps) {
       },
     } = props;
     if (isEmpty(detectorName)) {
-      throw 'Detector name can not be empty';
+      throw 'Detector name cannot be empty';
     } else {
       const error = validateName(detectorName);
       if (error) {

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -41,7 +41,7 @@ import {
   searchDetector,
   updateDetector,
 } from '../../../redux/reducers/ad';
-import { BREADCRUMBS } from '../../../utils/constants';
+import { BREADCRUMBS, MAX_DETECTORS } from '../../../utils/constants';
 import { getErrorMessage, validateName } from '../../../utils/utils';
 import { DetectorInfo } from '../components/DetectorInfo';
 import { useFetchDetectorInfo } from '../hooks/useFetchDetectorInfo';
@@ -119,9 +119,17 @@ export function CreateDetector(props: CreateADProps) {
         `/detectors/${detectorResp.data.response.id}/configurations/`
       );
     } catch (err) {
-      toastNotifications.addDanger(
-        getErrorMessage(err, 'There was a problem creating detector')
+      const resp = await dispatch(
+        searchDetector({ query: { bool: { must_not: { match: { name: "" } } } } })
       );
+      const totalDetectors = resp.data.response.totalDetectors;
+      if (totalDetectors === MAX_DETECTORS) {
+        toastNotifications.addDanger('Cannot create detector - limit of ' + MAX_DETECTORS + ' detectors reached')
+      } else {
+        toastNotifications.addDanger(
+          getErrorMessage(err, 'There was a problem creating detector')
+        );
+      }
     }
   };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When user has reached the limit of detectors, a confusing exception is thrown and shown to the user when trying to create a new detector. This fixes that, and shows a more informative callout message.

Before:

![Screen Shot 2020-05-11 at 6 52 28 PM](https://user-images.githubusercontent.com/62119629/81629942-307db900-93b9-11ea-8133-c5c0e4200d75.png)

After:

![Screen Shot 2020-05-11 at 6 51 04 PM](https://user-images.githubusercontent.com/62119629/81629897-19d76200-93b9-11ea-8005-04263d682714.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
