### PR TITLE
Fix loading state on detector list

### DIFF
--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -116,7 +116,7 @@ export interface Listener {
 
 const detectorCountFontColor = darkModeEnabled() ? '#98A2B3' : '#535966';
 
-export const getTitleWithCount = (title: string, count: number) => {
+export const getTitleWithCount = (title: string, count: number | string) => {
   return (
     <EuiTitle size={'s'} className={''}>
       <h3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the loading state on the detector list page. Before, if user refreshed or changed any filters (search bar, detector state, detector index, sorted column, sorted direction), the stale data would be displayed until the new data was retrieved and rendered. This fixes that problem by displaying an intermediate loading state while new data is being retrieved to display.

This PR also increases the performance of the page by only retrieving the detectors to display once during a page state change (logic now encapsulated in useEffect()).

After:

![Screen Shot 2020-05-13 at 11 53 00 AM](https://user-images.githubusercontent.com/62119629/81852762-641f2700-9510-11ea-94f5-242fada396c4.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
