### PR TITLE
Fix detector detail loading state

### DIFF
--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -64,12 +64,12 @@ interface DetectorDetailProps
 const tabs = [
   {
     id: DETECTOR_DETAIL_TABS.RESULTS,
-    name: 'Anomaly Results',
+    name: 'Anomaly results',
     route: DETECTOR_DETAIL_TABS.RESULTS,
   },
   {
     id: DETECTOR_DETAIL_TABS.CONFIGURATIONS,
-    name: 'Detector Configuration',
+    name: 'Detector configuration',
     route: DETECTOR_DETAIL_TABS.CONFIGURATIONS,
   },
 ];

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -26,6 +26,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiFieldText,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 // @ts-ignore
 import { toastNotifications } from 'ui/notify';
@@ -294,7 +295,9 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                   </EuiHealth>
                 ) : detector.curState === DETECTOR_STATE.FEATURE_REQUIRED ? (
                   <EuiHealth color={DETECTOR_STATE_COLOR.FEATURE_REQUIRED}>Feature required to start the detector</EuiHealth>
-                ) : isLoading ? 'Loading...' : ''}
+                ) : isLoading
+                ? <div><EuiLoadingSpinner size="xl" /></div>
+                : ''}
               </h1>
             </EuiTitle>
           </EuiFlexItem>

--- a/public/pages/DetectorDetail/hooks/useFetchMonitorInfo.ts
+++ b/public/pages/DetectorDetail/hooks/useFetchMonitorInfo.ts
@@ -23,7 +23,12 @@ import { searchMonitors } from '../../../redux/reducers/alerting';
 //A hook which gets AD monitor.
 export const useFetchMonitorInfo = (
   detectorId: string
-): { monitor: Monitor | undefined; fetchMonitorError: boolean } => {
+):
+{
+  monitor: Monitor | undefined;
+  fetchMonitorError: boolean;
+  isLoadingMonitor: boolean
+} => {
   const dispatch = useDispatch();
   useEffect(() => {
     const fetchAdMonitors = async () => {
@@ -32,6 +37,7 @@ export const useFetchMonitorInfo = (
     fetchAdMonitors();
   }, []);
 
+  const isMonitorRequesting = useSelector((state: AppState) => state.alerting.requesting);
   const monitors = useSelector((state: AppState) => state.alerting.monitors);
   const monitor = get(monitors, `${detectorId}.0`);
   const hasError = useSelector(
@@ -40,5 +46,6 @@ export const useFetchMonitorInfo = (
   return {
     monitor: monitor,
     fetchMonitorError: !isEmpty(hasError) && isEmpty(monitor),
+    isLoadingMonitor: isMonitorRequesting,
   };
 };

--- a/public/pages/DetectorsList/List/List.tsx
+++ b/public/pages/DetectorsList/List/List.tsx
@@ -283,11 +283,13 @@ export const DetectorList = (props: ListProps) => {
     pageSizeOptions: [5, 10, 20, 50],
   };
 
+  const isLoading = isRequestingFromES || isLoadingFinalDetectors;
+
   return (
     <EuiPage>
       <EuiPageBody>
         <ContentPanel
-          title={isLoadingFinalDetectors ? getTitleWithCount('Detectors', '...') : getTitleWithCount('Detectors', selectedDetectors.length)}
+          title={isLoading ? getTitleWithCount('Detectors', '...') : getTitleWithCount('Detectors', selectedDetectors.length)}
           actions={[
             <EuiButton fill href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}>
               Create detector
@@ -297,7 +299,7 @@ export const DetectorList = (props: ListProps) => {
           <ListControls
             activePage={state.page}
             pageCount={
-              isLoadingFinalDetectors ? 0 : Math.ceil(selectedDetectors.length / state.queryParams.size) || 1
+              isLoading ? 0 : Math.ceil(selectedDetectors.length / state.queryParams.size) || 1
             }
             search={state.queryParams.search}
             selectedDetectorStates={state.selectedDetectorStates}
@@ -311,13 +313,13 @@ export const DetectorList = (props: ListProps) => {
           />
           <EuiHorizontalRule margin="xs" />
           <EuiBasicTable<any>
-            items={isLoadingFinalDetectors ? [] : detectorsToDisplay}
+            items={isLoading ? [] : detectorsToDisplay}
             columns={staticColumn}
             onChange={handleTableChange}
             sorting={sorting}
             pagination={pagination}
             noItemsMessage={
-              isRequestingFromES || isLoadingFinalDetectors ? (
+              isLoading ? (
                 'Loading detectors...'
               ) : (
                 <EmptyDetectorMessage

--- a/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
+++ b/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
@@ -26,7 +26,12 @@ import { getMappings } from '../../../redux/reducers/elasticsearch';
 // 2. Gets index mapping
 export const useFetchDetectorInfo = (
   detectorId: string
-): { detector: Detector; hasError: boolean } => {
+):
+{
+  detector: Detector;
+  hasError: boolean;
+  isLoadingDetector: boolean; 
+} => {
   const dispatch = useDispatch();
   const detector = useSelector(
     (state: AppState) => state.ad.detectors[detectorId]
@@ -55,5 +60,6 @@ export const useFetchDetectorInfo = (
   return {
     detector: detector || {},
     hasError: !isEmpty(hasError) && isEmpty(detector),
+    isLoadingDetector: isDetectorRequesting || isIndicesRequesting,
   };
 };


### PR DESCRIPTION
*Issue #, if available:* #151 

*Description of changes:*

When loading the detector details page, the intermediate state shows a blank detector name and defaults to the 'Feature required' detector state.

This fixes that by keeping track of when data is being requested and loaded, so an intermediate loading state can be shown. Some logic and code cleanup was also made regarding rendering the detector state at the top of the page.

Before:

<img width="232" alt="Screen Shot 2020-05-18 at 5 00 16 PM" src="https://user-images.githubusercontent.com/62119629/82270265-13049e00-9929-11ea-99c1-cf1623b8dc4e.png">

After:

![Screen Shot 2020-05-18 at 7 57 58 PM](https://user-images.githubusercontent.com/62119629/82279671-f88aee80-9941-11ea-9d78-b906d2425560.png)

This PR also makes a minor change to the detector list loading state, where the requesting of info from the backend and the sorting/filtering in the frontend both display a consistent loading page to the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
