### PR TITLE
Fix error handling when getting detector and detector list

### DIFF
--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -32,6 +32,8 @@ import {
 } from '@elastic/eui';
 //@ts-ignore
 import chrome from 'ui/chrome';
+// @ts-ignore
+import { toastNotifications } from 'ui/notify';
 import { AnomalousDetectorsList } from '../Components/AnomalousDetectorsList';
 import {
   GET_ALL_DETECTORS_QUERY_PARAMS,
@@ -51,6 +53,10 @@ export function DashboardOverview() {
   const dispatch = useDispatch();
 
   const adState = useSelector((state: AppState) => state.ad);
+
+  const fetchDetectorsError = useSelector(
+    (state: AppState) => state.ad.errorMessages.getDetectorList
+  );
 
   const allDetectorList = adState.detectorList;
 
@@ -136,9 +142,9 @@ export function DashboardOverview() {
     if (allDetectorsSelected) {
       detectorsToFilter = cloneDeep(Object.values(allDetectorList));
     } else {
-      detectorsToFilter = cloneDeep(Object.values(allDetectorList)).filter(
-        detectorItem => selectedNameList.includes(detectorItem.name)
-      );
+      detectorsToFilter = cloneDeep(
+        Object.values(allDetectorList)
+      ).filter(detectorItem => selectedNameList.includes(detectorItem.name));
     }
 
     let filteredDetectorItemsByNamesAndIndex = detectorsToFilter;
@@ -170,6 +176,14 @@ export function DashboardOverview() {
     dispatch(getIndices(''));
     dispatch(getAliases(''));
   };
+
+  useEffect(() => {
+    if (fetchDetectorsError) {
+      toastNotifications.addDanger(
+        `Unable to retrieve all detectors: ${fetchDetectorsError}`
+      );
+    }
+  }, [fetchDetectorsError]);
 
   useEffect(() => {
     intializeDetectors();

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -91,8 +91,12 @@ interface DetectorDetailModel {
 export const DetectorDetail = (props: DetectorDetailProps) => {
   const dispatch = useDispatch();
   const detectorId = get(props, 'match.params.detectorId', '') as string;
-  const { detector, hasError, isLoadingDetector } = useFetchDetectorInfo(detectorId);
-  const { monitor, fetchMonitorError, isLoadingMonitor } = useFetchMonitorInfo(detectorId);
+  const { detector, hasError, isLoadingDetector } = useFetchDetectorInfo(
+    detectorId
+  );
+  const { monitor, fetchMonitorError, isLoadingMonitor } = useFetchMonitorInfo(
+    detectorId
+  );
 
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
@@ -266,7 +270,10 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
               : { ...lightStyles, flexGrow: 'unset' }),
           }}
         >
-          <EuiFlexGroup justifyContent="spaceBetween" style={{ padding: '10px' }}>
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
+            style={{ padding: '10px' }}
+          >
             <EuiFlexItem grow={false}>
               <EuiTitle size="l">
                 <h1>
@@ -282,19 +289,29 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                     </EuiHealth>
                   ) : detector.enabled &&
                     detector.curState === DETECTOR_STATE.INIT ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>Initializing</EuiHealth>
+                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>
+                      Initializing
+                    </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.INIT_FAILURE ||
                     detector.curState === DETECTOR_STATE.UNEXPECTED_FAILURE ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT_FAILURE}>Initialization failure</EuiHealth>
+                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT_FAILURE}>
+                      Initialization failure
+                    </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.DISABLED ? (
                     <EuiHealth color={DETECTOR_STATE_COLOR.DISABLED}>
                       {detector.disabledTime
-                      ? `Stopped at ${moment(detector.disabledTime).format('MM/DD/YY h:mm A')}`
-                      : 'Detector is stopped'}
+                        ? `Stopped at ${moment(detector.disabledTime).format(
+                            'MM/DD/YY h:mm A'
+                          )}`
+                        : 'Detector is stopped'}
                     </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.FEATURE_REQUIRED ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.FEATURE_REQUIRED}>Feature required to start the detector</EuiHealth>
-                  ) : ''}
+                    <EuiHealth color={DETECTOR_STATE_COLOR.FEATURE_REQUIRED}>
+                      Feature required to start the detector
+                    </EuiHealth>
+                  ) : (
+                    ''
+                  )}
                 </h1>
               </EuiTitle>
             </EuiFlexItem>

--- a/public/pages/EditFeatures/components/CustomAggregation/CustomAggregation.tsx
+++ b/public/pages/EditFeatures/components/CustomAggregation/CustomAggregation.tsx
@@ -19,8 +19,6 @@ import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import { isInvalid, getError } from '../../../../utils/utils';
 
-import 'brace/ext/language_tools';
-
 interface CustomAggregationProps {
   index: number;
 }

--- a/public/pages/createDetector/components/DataFilters/QueryDataFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/QueryDataFilter.tsx
@@ -24,7 +24,6 @@ import {
 import { Field, FieldProps } from 'formik';
 import { isInvalid, getError } from '../../../../utils/utils';
 import 'brace/mode/json';
-import 'brace/ext/language_tools';
 import 'brace/theme/github';
 import { validFilterQuery } from './utils/helpers';
 

--- a/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
+++ b/public/pages/createDetector/hooks/useFetchDetectorInfo.ts
@@ -26,17 +26,18 @@ import { getMappings } from '../../../redux/reducers/elasticsearch';
 // 2. Gets index mapping
 export const useFetchDetectorInfo = (
   detectorId: string
-):
-{
+): {
   detector: Detector;
   hasError: boolean;
-  isLoadingDetector: boolean; 
+  isLoadingDetector: boolean;
 } => {
   const dispatch = useDispatch();
   const detector = useSelector(
     (state: AppState) => state.ad.detectors[detectorId]
   );
-  const hasError = useSelector((state: AppState) => state.ad.errorMessage);
+  const hasError = useSelector(
+    (state: AppState) => state.ad.errorMessages.getDetector
+  );
   const isDetectorRequesting = useSelector(
     (state: AppState) => state.ad.requesting
   );

--- a/public/redux/reducers/__tests__/ad.test.ts
+++ b/public/redux/reducers/__tests__/ad.test.ts
@@ -48,9 +48,7 @@ describe('detector reducer actions', () => {
     });
     test('should invoke [REQUEST, FAILURE]', async () => {
       const detectorId = 'randomDetectorID';
-      httpMockedClient.get = jest
-        .fn()
-        .mockRejectedValue({ data: { ok: false, error: 'Not found' } });
+      httpMockedClient.get = jest.fn().mockRejectedValue('Not found');
       try {
         await store.dispatch(getDetector(detectorId));
       } catch (e) {
@@ -64,7 +62,10 @@ describe('detector reducer actions', () => {
         expect(reducer(initialDetectorsState, actions[1])).toEqual({
           ...initialDetectorsState,
           requesting: false,
-          errorMessage: 'Not found',
+          errorMessages: {
+            ...initialDetectorsState.errorMessages,
+            getDetector: 'Not found',
+          },
         });
         expect(httpMockedClient.get).toHaveBeenCalledWith(
           `..${BASE_NODE_API_PATH}/detectors/${detectorId}`
@@ -116,7 +117,10 @@ describe('detector reducer actions', () => {
         expect(reducer(initialDetectorsState, actions[1])).toEqual({
           ...initialDetectorsState,
           requesting: false,
-          errorMessage: 'Detector is consumed by Monitor',
+          errorMessages: {
+            ...initialDetectorsState.errorMessages,
+            deleteDetector: 'Detector is consumed by Monitor',
+          },
         });
         expect(httpMockedClient.delete).toHaveBeenCalledWith(
           `..${BASE_NODE_API_PATH}/detectors/${expectedDetector.id}`
@@ -174,7 +178,10 @@ describe('detector reducer actions', () => {
         expect(reducer(initialDetectorsState, actions[1])).toEqual({
           ...initialDetectorsState,
           requesting: false,
-          errorMessage: 'Internal server error',
+          errorMessages: {
+            ...initialDetectorsState.errorMessages,
+            createDetector: 'Internal server error',
+          },
         });
         expect(httpMockedClient.post).toHaveBeenCalledWith(
           `..${BASE_NODE_API_PATH}/detectors`,
@@ -206,7 +213,10 @@ describe('detector reducer actions', () => {
           [detectorId]: {
             ...randomDetector,
             id: detectorId,
-            lastUpdateTime: get(result, `detectors.${detectorId}.lastUpdateTime`)
+            lastUpdateTime: get(
+              result,
+              `detectors.${detectorId}.lastUpdateTime`
+            ),
           },
         },
       });
@@ -241,7 +251,10 @@ describe('detector reducer actions', () => {
         expect(reducer(initialDetectorsState, actions[1])).toEqual({
           ...initialDetectorsState,
           requesting: false,
-          errorMessage: 'Internal server error',
+          errorMessages: {
+            ...initialDetectorsState.errorMessages,
+            updateDetector: 'Internal server error',
+          },
         });
         expect(httpMockedClient.post).toHaveBeenCalledWith(
           `..${BASE_NODE_API_PATH}/detectors`,
@@ -310,7 +323,10 @@ describe('detector reducer actions', () => {
         expect(reducer(initialDetectorsState, actions[1])).toEqual({
           ...initialDetectorsState,
           requesting: false,
-          errorMessage: 'Internal server error',
+          errorMessages: {
+            ...initialDetectorsState.errorMessages,
+            updateDetector: 'Internal server error',
+          },
         });
         expect(httpMockedClient.post).toHaveBeenCalledWith(
           `..${BASE_NODE_API_PATH}/detectors`,

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -37,19 +37,43 @@ const START_DETECTOR = 'ad/START_DETECTOR';
 const STOP_DETECTOR = 'ad/STOP_DETECTOR';
 const GET_DETECTOR_PROFILE = 'ad/GET_DETECTOR_PROFILE';
 
+export interface ErrorMessages {
+  createDetector: string;
+  getDetector: string;
+  startDetector: string;
+  stopDetector: string;
+  searchDetector: string;
+  getDetectorList: string;
+  updateDetector: string;
+  deleteDetector: string;
+  getDetectorProfile: string;
+}
+
+export const initialErrorMessages: ErrorMessages = {
+  createDetector: '',
+  getDetector: '',
+  startDetector: '',
+  stopDetector: '',
+  searchDetector: '',
+  getDetectorList: '',
+  updateDetector: '',
+  deleteDetector: '',
+  getDetectorProfile: '',
+};
+
 export interface Detectors {
   requesting: boolean;
   detectors: { [key: string]: Detector };
   detectorList: { [key: string]: DetectorListItem };
   totalDetectors: number;
-  errorMessage: string;
+  errorMessages: ErrorMessages;
 }
 export const initialDetectorsState: Detectors = {
   requesting: false,
   detectors: {},
   detectorList: {},
-  errorMessage: '',
   totalDetectors: 0,
+  errorMessages: initialErrorMessages,
 };
 
 const reducer = handleActions<Detectors>(
@@ -58,11 +82,13 @@ const reducer = handleActions<Detectors>(
       REQUEST: (state: Detectors): Detectors => ({
         ...state,
         requesting: true,
-        errorMessage: '',
+        errorMessages: {
+          ...state.errorMessages,
+          createDetector: '',
+        },
       }),
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
-        errorMessage: '',
         requesting: false,
         detectors: {
           ...state.detectors,
@@ -72,14 +98,20 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessages: {
+          ...state.errorMessages,
+          createDetector: action.error.data.error,
+        },
       }),
     },
     [GET_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => ({
         ...state,
         requesting: true,
-        errorMessage: '',
+        errorMessages: {
+          ...state.errorMessages,
+          getDetector: '',
+        },
       }),
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
@@ -94,12 +126,22 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessages: {
+          ...state.errorMessages,
+          getDetector: action.error,
+        },
       }),
     },
     [START_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => {
-        const newState = { ...state, requesting: true, errorMessage: '' };
+        const newState = {
+          ...state,
+          requesting: true,
+          errorMessages: {
+            ...state.errorMessages,
+            startDetector: '',
+          },
+        };
         return newState;
       },
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
@@ -119,13 +161,23 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error,
+        errorMessages: {
+          ...state.errorMessages,
+          startDetector: action.error,
+        },
       }),
     },
 
     [STOP_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => {
-        const newState = { ...state, requesting: true, errorMessage: '' };
+        const newState = {
+          ...state,
+          requesting: true,
+          errorMessages: {
+            ...state.errorMessages,
+            stopDetector: '',
+          },
+        };
         return newState;
       },
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
@@ -145,14 +197,20 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error,
+        errorMessages: {
+          ...state.errorMessages,
+          stopDetector: action.error,
+        },
       }),
     },
     [SEARCH_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => ({
         ...state,
         requesting: true,
-        errorMessage: '',
+        errorMessages: {
+          ...state.errorMessages,
+          searchDetector: '',
+        },
       }),
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
@@ -168,16 +226,23 @@ const reducer = handleActions<Detectors>(
           ),
         },
       }),
-      FAILURE: (state: Detectors): Detectors => ({
+      FAILURE: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
         requesting: false,
+        errorMessages: {
+          ...state.errorMessages,
+          searchDetector: action.error,
+        },
       }),
     },
     [GET_DETECTOR_LIST]: {
       REQUEST: (state: Detectors): Detectors => ({
         ...state,
         requesting: true,
-        errorMessage: '',
+        errorMessages: {
+          ...state.errorMessages,
+          getDetectorList: '',
+        },
       }),
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
@@ -191,14 +256,25 @@ const reducer = handleActions<Detectors>(
         ),
         totalDetectors: action.result.data.response.totalDetectors,
       }),
-      FAILURE: (state: Detectors): Detectors => ({
+      FAILURE: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
         requesting: false,
+        errorMessages: {
+          ...state.errorMessages,
+          getDetectorList: action.error,
+        },
       }),
     },
     [UPDATE_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => {
-        const newState = { ...state, requesting: true, errorMessage: '' };
+        const newState = {
+          ...state,
+          requesting: true,
+          errorMessages: {
+            ...state.errorMessages,
+            updateDetector: '',
+          },
+        };
         return newState;
       },
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
@@ -213,15 +289,26 @@ const reducer = handleActions<Detectors>(
           },
         },
       }),
-      FAILURE: (state: Detectors): Detectors => ({
+      FAILURE: (state: Detectors, action: APIResponseAction): Detectors => ({
         ...state,
         requesting: false,
+        errorMessages: {
+          ...state.errorMessages,
+          updateDetector: action.error,
+        },
       }),
     },
 
     [DELETE_DETECTOR]: {
       REQUEST: (state: Detectors): Detectors => {
-        const newState = { ...state, requesting: true, errorMessage: '' };
+        const newState = {
+          ...state,
+          requesting: true,
+          errorMessages: {
+            ...state.errorMessages,
+            deleteDetector: '',
+          },
+        };
         return newState;
       },
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
@@ -235,13 +322,23 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error,
+        errorMessages: {
+          ...state.errorMessages,
+          deleteDetector: action.error,
+        },
       }),
     },
 
     [GET_DETECTOR_PROFILE]: {
       REQUEST: (state: Detectors): Detectors => {
-        const newState = { ...state, requesting: true, errorMessage: '' };
+        const newState = {
+          ...state,
+          requesting: true,
+          errorMessages: {
+            ...state.errorMessages,
+            getDetectorProfile: '',
+          },
+        };
         return newState;
       },
       SUCCESS: (state: Detectors, action: APIResponseAction): Detectors => ({
@@ -258,7 +355,10 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error,
+        errorMessages: {
+          ...state.errorMessages,
+          getDetectorProfile: action.error,
+        },
       }),
     },
   },


### PR DESCRIPTION
*Issue #, if available:* #157 

*Description of changes:*

Fixes error handling when there are errors (1) getting a detector and (2) getting detector list:
- Fixes error message in `getDetector()` to prevent exception which leads to infinite loading state on detector details pages
- Fixes error handling in `getDetectorList()` which will catch exceptions if there's errors in retrieving detector state for any detectors
- Propagate errors getting detector list to dashboard and detector list page via toast notification (will confirm with UX how to handle this)
- Refactors error messages in the ad reducer to be unique for each function. This is necessary because during detector deletion, a `getDetector()` error is thrown. We don't want to propagate this message to user on detector list page, which is where UI is redirected after deletion. Detector list / dashboard pages should only be concerned about errors retrieving all detectors, not a leftover error message caused by a different page.

**Infinite loading state (before)**
<img width="721" alt="Screen Shot 2020-05-21 at 12 24 06 PM" src="https://user-images.githubusercontent.com/62119629/82597659-2e0c2380-9b5e-11ea-94d8-a2da0fd8d623.png">

**Infinite loading state (after)**
<img width="722" alt="Screen Shot 2020-05-21 at 12 24 49 PM" src="https://user-images.githubusercontent.com/62119629/82597690-37958b80-9b5e-11ea-8e17-25f1b59a6ff9.png">

**Error getting detector list (before)**
<img width="1440" alt="Screen Shot 2020-05-21 at 12 29 55 PM" src="https://user-images.githubusercontent.com/62119629/82598171-13867a00-9b5f-11ea-9985-0c650fc6692f.png">
<img width="1432" alt="Screen Shot 2020-05-21 at 12 30 09 PM" src="https://user-images.githubusercontent.com/62119629/82598208-1ed9a580-9b5f-11ea-90a3-63842435bdb5.png">

**Error getting detector list (after)**
<img width="1440" alt="Screen Shot 2020-05-20 at 4 45 15 PM" src="https://user-images.githubusercontent.com/62119629/82598233-2a2cd100-9b5f-11ea-8e58-91e102e2a774.png">
<img width="1437" alt="Screen Shot 2020-05-20 at 4 44 55 PM" src="https://user-images.githubusercontent.com/62119629/82598240-2ef18500-9b5f-11ea-8a02-af041acd9e92.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
