### PR TITLE
Remove unused language_tools import

### DIFF
--- a/public/pages/EditFeatures/components/CustomAggregation/CustomAggregation.tsx
+++ b/public/pages/EditFeatures/components/CustomAggregation/CustomAggregation.tsx
@@ -19,8 +19,6 @@ import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import { isInvalid, getError } from '../../../../utils/utils';
 
-import 'brace/ext/language_tools';
-
 interface CustomAggregationProps {
   index: number;
 }

--- a/public/pages/createDetector/components/DataFilters/QueryDataFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/QueryDataFilter.tsx
@@ -24,7 +24,6 @@ import {
 import { Field, FieldProps } from 'formik';
 import { isInvalid, getError } from '../../../../utils/utils';
 import 'brace/mode/json';
-import 'brace/ext/language_tools';
 import 'brace/theme/github';
 import { validFilterQuery } from './utils/helpers';
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes unused `language_tools` import that was breaking the build of ODFE docker images. Need to backport change to opendistro-1.8 branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
