### PR TITLE
Handle error on detector detail pages

### DIFF
--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -91,8 +91,12 @@ interface DetectorDetailModel {
 export const DetectorDetail = (props: DetectorDetailProps) => {
   const dispatch = useDispatch();
   const detectorId = get(props, 'match.params.detectorId', '') as string;
-  const { detector, hasError, isLoadingDetector } = useFetchDetectorInfo(detectorId);
-  const { monitor, fetchMonitorError, isLoadingMonitor } = useFetchMonitorInfo(detectorId);
+  const { detector, hasError, isLoadingDetector } = useFetchDetectorInfo(
+    detectorId
+  );
+  const { monitor, fetchMonitorError, isLoadingMonitor } = useFetchMonitorInfo(
+    detectorId
+  );
 
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
@@ -266,7 +270,10 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
               : { ...lightStyles, flexGrow: 'unset' }),
           }}
         >
-          <EuiFlexGroup justifyContent="spaceBetween" style={{ padding: '10px' }}>
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
+            style={{ padding: '10px' }}
+          >
             <EuiFlexItem grow={false}>
               <EuiTitle size="l">
                 <h1>
@@ -282,19 +289,29 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                     </EuiHealth>
                   ) : detector.enabled &&
                     detector.curState === DETECTOR_STATE.INIT ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>Initializing</EuiHealth>
+                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>
+                      Initializing
+                    </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.INIT_FAILURE ||
                     detector.curState === DETECTOR_STATE.UNEXPECTED_FAILURE ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT_FAILURE}>Initialization failure</EuiHealth>
+                    <EuiHealth color={DETECTOR_STATE_COLOR.INIT_FAILURE}>
+                      Initialization failure
+                    </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.DISABLED ? (
                     <EuiHealth color={DETECTOR_STATE_COLOR.DISABLED}>
                       {detector.disabledTime
-                      ? `Stopped at ${moment(detector.disabledTime).format('MM/DD/YY h:mm A')}`
-                      : 'Detector is stopped'}
+                        ? `Stopped at ${moment(detector.disabledTime).format(
+                            'MM/DD/YY h:mm A'
+                          )}`
+                        : 'Detector is stopped'}
                     </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.FEATURE_REQUIRED ? (
-                    <EuiHealth color={DETECTOR_STATE_COLOR.FEATURE_REQUIRED}>Feature required to start the detector</EuiHealth>
-                  ) : ''}
+                    <EuiHealth color={DETECTOR_STATE_COLOR.FEATURE_REQUIRED}>
+                      Feature required to start the detector
+                    </EuiHealth>
+                  ) : (
+                    ''
+                  )}
                 </h1>
               </EuiTitle>
             </EuiFlexItem>

--- a/public/redux/reducers/__tests__/ad.test.ts
+++ b/public/redux/reducers/__tests__/ad.test.ts
@@ -48,9 +48,7 @@ describe('detector reducer actions', () => {
     });
     test('should invoke [REQUEST, FAILURE]', async () => {
       const detectorId = 'randomDetectorID';
-      httpMockedClient.get = jest
-        .fn()
-        .mockRejectedValue({ data: { ok: false, error: 'Not found' } });
+      httpMockedClient.get = jest.fn().mockRejectedValue('Not found');
       try {
         await store.dispatch(getDetector(detectorId));
       } catch (e) {
@@ -206,7 +204,10 @@ describe('detector reducer actions', () => {
           [detectorId]: {
             ...randomDetector,
             id: detectorId,
-            lastUpdateTime: get(result, `detectors.${detectorId}.lastUpdateTime`)
+            lastUpdateTime: get(
+              result,
+              `detectors.${detectorId}.lastUpdateTime`
+            ),
           },
         },
       });

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -94,7 +94,7 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessage: action.error,
       }),
     },
     [START_DETECTOR]: {


### PR DESCRIPTION
*Issue #, if available:* #172 

*Description of changes:*

Handles errors when an invalid detector id is passed to the detector detail pages (results and configuration pages). This could be caused by changing the url directly, or refreshing a stale page if the detector has been deleted in another window.

Before (infinite loading state):
<img width="721" alt="Screen Shot 2020-05-21 at 12 24 06 PM" src="https://user-images.githubusercontent.com/62119629/82610721-be089800-9b73-11ea-9c75-9ca8daf0f906.png">

After (redirects to detector list page, toast displaying error):
<img width="722" alt="Screen Shot 2020-05-21 at 12 24 49 PM" src="https://user-images.githubusercontent.com/62119629/82610963-45560b80-9b74-11ea-85d2-9b58c6087e52.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
