### PR TITLE
Change to default plugin icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,17 @@ export default kibana => {
     name: 'opendistro-anomaly-detection-kibana',
     uiExports: {
       app: {
-        title: 'Open Distro for Elasticsearch Anomaly Detection Kibana plugin',
+        title: 'Anomaly Detection',
         description:
           'Open Distro for Elasticsearch Anomaly Detection Kibana plugin',
         main: 'plugins/opendistro-anomaly-detection-kibana/app',
+        /*
+          Commenting out custom svg icon for now. Will use default plugin icon until
+          issue is figured out, or we get a new icon.
+
         icon:
           'plugins/opendistro-anomaly-detection-kibana/images/anomaly_detection_icon.svg',
+        */
       },
       styleSheetPaths: [
         resolve(__dirname, 'public/app.scss'),


### PR DESCRIPTION
*Issue #, if available:* #146 

*Description of changes:*

Changes to default plugin icon until custom icon scaling issue is solved. Will front port change to master after merging.

New icon:
![Screen Shot 2020-05-21 at 5 04 18 PM](https://user-images.githubusercontent.com/62119629/82618896-32016b00-9b89-11ea-9ef4-a9444b9d14d6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
