### PR TITLE
Fix custom icon scaling issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,13 +28,8 @@ export default kibana => {
         description:
           'Open Distro for Elasticsearch Anomaly Detection Kibana plugin',
         main: 'plugins/opendistro-anomaly-detection-kibana/app',
-        /*
-          Commenting out custom svg icon for now. Will use default plugin icon until
-          issue is figured out, or we get a new icon.
-
         icon:
           'plugins/opendistro-anomaly-detection-kibana/images/anomaly_detection_icon.svg',
-        */
       },
       styleSheetPaths: [
         resolve(__dirname, 'public/app.scss'),

--- a/public/app.scss
+++ b/public/app.scss
@@ -20,3 +20,4 @@
 @import 'pages/AnomalyCharts/index.scss';
 @import 'pages/DetectorResults/index.scss';
 @import 'pages/DetectorDetail/index.scss';
+@import 'images/icon.scss';

--- a/public/images/icon.scss
+++ b/public/images/icon.scss
@@ -1,0 +1,9 @@
+/*
+Fixes the custom plugin icon scaling issue
+*/
+figure {
+  max-width: 16px !important;
+  margin-right: 12px;
+  flex-grow: 0;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes the custom icon scaling issue. Adds formatting for the `figure` element which is how custom plugin icons used to be formatted by adding the css class [here](https://github.com/elastic/eui/blob/master/src/components/list_group/_list_group_item.scss#L109) to the `figure` element. This is no longer included in Kibana 7.7.X.

This fixes the scaling issue by adding this styling back in a separate `icon.scss` file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
