### PR TITLE
Fix anomaly results pagination

### DIFF
--- a/public/pages/DetectorResults/components/ListControls/ListControls.tsx
+++ b/public/pages/DetectorResults/components/ListControls/ListControls.tsx
@@ -27,13 +27,15 @@ export const ListControls = (props: ListControlsProps) => (
     alignItems="center"
     justifyContent="flexEnd"
   >
-    <EuiFlexItem grow={false}>
-      <EuiPagination
-        pageCount={props.pageCount}
-        activePage={props.activePage}
-        onPageClick={props.onPageClick}
-        data-test-subj="anomaliesPageControls"
-      />
-    </EuiFlexItem>
+    {props.pageCount > 1 ? (
+      <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
+        <EuiPagination
+          pageCount={props.pageCount}
+          activePage={props.activePage}
+          onPageClick={props.onPageClick}
+          data-test-subj="anomaliesPageControls"
+        />
+      </EuiFlexItem>
+    ) : null}
   </EuiFlexGroup>
 );

--- a/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
@@ -127,7 +127,7 @@ export function AnomalyResultsTable(props: AnomalyResultsTableProps) {
       <ListControls
         activePage={state.page}
         pageCount={
-          Math.ceil(targetAnomalies.length / state.queryParams.size) || 1
+          Math.ceil(totalAnomalies.length / state.queryParams.size) || 1
         }
         onPageClick={handlePageChange}
       />


### PR DESCRIPTION
*Issue #, if available:* #179 

*Description of changes:*

This PR fixes the pagination on the anomaly results table and makes it consistent with pagination on detector list table. Changes include:

1. Don't show top pagination if only 1 page of results
2. Show pagination with multiple pages if there are multiple pages of results

After:
![Screen Shot 2020-05-26 at 12 15 09 PM](https://user-images.githubusercontent.com/62119629/82941641-8f136d00-9f4b-11ea-8ec8-8f08ff6022ce.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
