### PR TITLE
Tune error message when creating detector

### DIFF
--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -120,11 +120,17 @@ export function CreateDetector(props: CreateADProps) {
       );
     } catch (err) {
       const resp = await dispatch(
-        searchDetector({ query: { bool: { must_not: { match: { name: "" } } } } })
+        searchDetector({
+          query: { bool: { must_not: { match: { name: '' } } } },
+        })
       );
       const totalDetectors = resp.data.response.totalDetectors;
       if (totalDetectors === MAX_DETECTORS) {
-        toastNotifications.addDanger('Cannot create detector - limit of ' + MAX_DETECTORS + ' detectors reached')
+        toastNotifications.addDanger(
+          'Cannot create detector - limit of ' +
+            MAX_DETECTORS +
+            ' detectors reached'
+        );
       } else {
         toastNotifications.addDanger(
           getErrorMessage(err, 'There was a problem creating detector')

--- a/public/redux/reducers/__tests__/ad.test.ts
+++ b/public/redux/reducers/__tests__/ad.test.ts
@@ -156,9 +156,9 @@ describe('detector reducer actions', () => {
 
     test('should invoke [REQUEST, FAILURE]', async () => {
       const expectedDetector = getRandomDetector();
-      httpMockedClient.post = jest.fn().mockRejectedValue({
-        data: { ok: false, error: 'Internal server error' },
-      });
+      httpMockedClient.post = jest
+        .fn()
+        .mockRejectedValue('Internal server error');
       try {
         await store.dispatch(createDetector(expectedDetector));
       } catch {

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -72,7 +72,7 @@ const reducer = handleActions<Detectors>(
       FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessage: action.error,
       }),
     },
     [GET_DETECTOR]: {

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -32,7 +32,12 @@ import {
 } from '../models/types';
 import { Router } from '../router';
 import { SORT_DIRECTION, AD_DOC_FIELDS } from '../utils/constants';
-import { mapKeysDeep, toCamel, toSnake, toFixedNumberForAnomaly } from '../utils/helpers';
+import {
+  mapKeysDeep,
+  toCamel,
+  toSnake,
+  toFixedNumberForAnomaly,
+} from '../utils/helpers';
 import {
   anomalyResultMapper,
   convertDetectorKeysToCamelCase,
@@ -150,9 +155,9 @@ const putDetector = async (
     console.log('Anomaly detector - PutDetector', err);
     //FIXME: This is temporary as backend should send error message inside message instead of body
     if (err.statusCode === 400) {
-      return { ok: false, error: err.body };
+      return { ok: false, error: err.body.error.reason };
     }
-    return { ok: false, error: err.message };
+    return { ok: false, error: err.message.data.error };
   }
 };
 
@@ -593,13 +598,17 @@ const getAnomalyResults = async (
           result._source.confidence != null &&
           result._source.confidence !== 'NaN' &&
           result._source.confidence > 0
-            ? toFixedNumberForAnomaly(Number.parseFloat(result._source.confidence))
+            ? toFixedNumberForAnomaly(
+                Number.parseFloat(result._source.confidence)
+              )
             : 0,
         anomalyGrade:
           result._source.anomaly_grade != null &&
           result._source.anomaly_grade !== 'NaN' &&
           result._source.anomaly_grade > 0
-            ? toFixedNumberForAnomaly(Number.parseFloat(result._source.anomaly_grade))
+            ? toFixedNumberForAnomaly(
+                Number.parseFloat(result._source.anomaly_grade)
+              )
             : 0,
       });
       result._source.feature_data.forEach((featureData: any) => {


### PR DESCRIPTION
*Issue #, if available:* #187 

*Description of changes:*

This PR tunes the error message when there are errors creating a detector. Currently, there is an undefined exception when trying to parse the error message. This fixes that and propagates the correct error message to the toast notification. Also note that some of the changes are just formatting changes caused by autosaving.

Before:
<img width="1346" alt="Screen Shot 2020-05-28 at 10 03 27 AM" src="https://user-images.githubusercontent.com/62119629/83174098-c1010c80-a0ce-11ea-8ad8-6c7e03229807.png">

After:
<img width="1346" alt="Screen Shot 2020-05-28 at 10 29 27 AM" src="https://user-images.githubusercontent.com/62119629/83174132-ccecce80-a0ce-11ea-9deb-dff385faeb34.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
