### PR TITLE
Fix issue where live chart height is only partial of window in fullscreen mode. Issue: #186

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -109,7 +109,10 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         true
       );
     } catch (err) {
-      console.log('Error getting latest anomaly results - index may not exist yet', err);
+      console.log(
+        'Error getting latest anomaly results - index may not exist yet',
+        err
+      );
       setIsLoadingAnomalies(false);
     }
 
@@ -236,7 +239,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         </EuiFlexItem>
       }
       actions={[fullScreenButton()]}
-      contentPanelClassName={isFullScreen ? 'full-screen' : undefined}
+      contentPanelClassName={isFullScreen ? 'dashboard-full-screen' : undefined}
     >
       {isLoadingAnomalies ? (
         <EuiFlexGroup

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -239,7 +239,7 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         </EuiFlexItem>
       }
       actions={[fullScreenButton()]}
-      contentPanelClassName={isFullScreen ? 'dashboard-full-screen' : undefined}
+      contentPanelClassName={isFullScreen ? 'full-screen' : undefined}
     >
       {isLoadingAnomalies ? (
         <EuiFlexGroup

--- a/public/pages/Dashboard/index.scss
+++ b/public/pages/Dashboard/index.scss
@@ -32,11 +32,11 @@
   width: 400px;
 }
 
-.full-screen {
+.dashboard-full-screen {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   z-index: 1000;
 }

--- a/public/pages/Dashboard/index.scss
+++ b/public/pages/Dashboard/index.scss
@@ -31,12 +31,3 @@
   height: 400px;
   width: 400px;
 }
-
-.dashboard-full-screen {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100vh;
-  z-index: 1000;
-}

--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -67,7 +67,7 @@ export function Main(props: MainProps) {
   ];
 
   return (
-    <EuiPage>
+    <EuiPage style={{ height: '100%' }}>
       <EuiPageSideBar style={{ minWidth: 150 }} hidden={hideSideNavBar}>
         <EuiSideNav style={{ width: 150 }} items={sideNav} />
       </EuiPageSideBar>


### PR DESCRIPTION
*Issue #, if available:*
#186 
*Description of changes:*
Fix issue where live chart height is only partial of window in fullscreen mode. 

The root cause: `<EuiPage>` doesn't explicitly set height as 100%, such that Dashboard page shrinks automatically if no live result or no sunburst result. Even `full-screen` css sets 100% height, the result height of full screen live chart is only 100% of the `shrinked` Dashboard page, while the height of live chart is fixed to 400px in full screen mode. More explanation: https://stackoverflow.com/a/31728799

Before:
![Screen Shot 2020-05-28 at 3 13 52 PM](https://user-images.githubusercontent.com/59710443/83206327-7b136b00-a105-11ea-9996-b7e118ab98c3.png)

After:
![Screen Shot 2020-05-28 at 5 37 46 PM](https://user-images.githubusercontent.com/59710443/83208245-faa33900-a109-11ea-8c69-5a07b446a504.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
