### PR TITLE
Use endTime of detectionInterval as plotTime on Dashboard live chart

### DIFF
--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -371,7 +371,7 @@ export const visualizeAnomalyResultForXYChart = (
   return {
     ...anomalyResult,
     [AD_DOC_FIELDS.PLOT_TIME]: getFloorPlotTime(
-      get(anomalyResult, AD_DOC_FIELDS.DATA_START_TIME, 0)
+      get(anomalyResult, AD_DOC_FIELDS.DATA_END_TIME, 0)
     ),
     [AD_DOC_FIELDS.ANOMALY_GRADE]:
       actualAnomalyGrade < SHOW_DECIMAL_NUMBER_THRESHOLD


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use endTime of detectionInterval as plotTime on Dashboard live chart, so that plot time is consistent with AnomalyHistory Chart 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
