### PR TITLE
Add CI for e2e

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 jobs:
   tests:
     name: Run e2e tests
@@ -36,8 +33,9 @@ jobs:
       - name: Checkout Kibana
         uses: actions/checkout@v2
         with:
-          repository: elastic/kibana
-          ref: v7.7.0
+          repository: opendistro-for-elasticsearch/kibana-oss
+          ref: 7.7.0
+          token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
       - name: Get node and yarn versions
         id: versions_step
@@ -58,12 +56,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: kibana/plugins/anomaly-detection-kibana-plugin
-      - name: Attempt to bootstrap the plugin
-        continue-on-error: true
-        run: |
-          cd kibana/plugins/anomaly-detection-kibana-plugin
-          yarn kbn bootstrap
-      - name: Bootstrap the plugin again
+      - name: Bootstrap the plugin
         run: |
           cd kibana/plugins/anomaly-detection-kibana-plugin
           yarn kbn bootstrap

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -15,38 +15,16 @@ jobs:
         java: [14]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout AD ES Plugin
-        uses: actions/checkout@v2
-        with:
-          repository: opendistro-for-elasticsearch/anomaly-detection
-          ref: 'opendistro-1.8'
-          path: 'ad-es'
-
-      - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Run build for AD ES Plugin
-        run: |
-          cd ad-es
-          ./gradlew build
       - name: Pull and Run Docker
         run: |
-          cd ad-es
-          plugin=`ls build/distributions/*.zip`
-          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
-          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
+          version=1.8.0
           echo $version
-          cd ..
           if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
           then
             echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
             ## The ESRestTest Client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
-            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-anomaly-detection ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-anomaly-detection; fi" >> Dockerfile
-            echo "ADD ad-es/build/distributions/opendistro-anomaly-detection-$plugin_version.zip /tmp/" >> Dockerfile
-            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro-anomaly-detection-$plugin_version.zip" >> Dockerfile
             docker build -t odfe-ad:test .
           fi
       - name: Run Docker Image

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -1,0 +1,96 @@
+name: E2E tests workflow
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    name: Run e2e tests
+    strategy:
+      matrix:
+        os: [ubuntu-16.04] # use ubuntu-16.04 as required by cypress: https://github.com/marketplace/actions/cypress-io#important
+        java: [14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout AD ES Plugin
+        uses: actions/checkout@v2
+        with:
+          repository: opendistro-for-elasticsearch/anomaly-detection
+          ref: 'opendistro-1.8'
+          path: 'ad-es'
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run build for AD ES Plugin
+        run: |
+          cd ad-es
+          ./gradlew build
+      - name: Pull and Run Docker
+        run: |
+          cd ad-es
+          plugin=`ls build/distributions/*.zip`
+          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
+          echo $version
+          cd ..
+          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
+          then
+            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            ## The ESRestTest Client uses http by default.
+            ## Need to disable the security plugin to call the rest api over http.
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-anomaly-detection ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-anomaly-detection; fi" >> Dockerfile
+            echo "ADD ad-es/build/distributions/opendistro-anomaly-detection-$plugin_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro-anomaly-detection-$plugin_version.zip" >> Dockerfile
+            docker build -t odfe-ad:test .
+          fi
+      - name: Run Docker Image
+        run: |
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-ad:test
+          sleep 90
+          curl -XGET http://localhost:9200/_cat/plugins
+
+      - name: Checkout Kibana
+        uses: actions/checkout@v2
+        with:
+          repository: elastic/kibana
+          ref: v7.7.0
+          path: kibana
+      - name: Get node and yarn versions
+        id: versions_step
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./kibana/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=yarn_version::$(node -p "(require('./kibana/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions_step.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install correct yarn version for Kibana
+        run: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+      - name: Checkout Anomaly Detection Kibana plugin
+        uses: actions/checkout@v2
+        with:
+          path: kibana/plugins/anomaly-detection-kibana-plugin
+      - name: Attempt to bootstrap the plugin
+        continue-on-error: true
+        run: |
+          cd kibana/plugins/anomaly-detection-kibana-plugin
+          yarn kbn bootstrap
+      - name: Bootstrap the plugin again
+        run: |
+          cd kibana/plugins/anomaly-detection-kibana-plugin
+          yarn kbn bootstrap
+      - name: Run e2e tests
+        uses: cypress-io/github-action@v1
+        with:
+          working-directory: kibana/plugins/anomaly-detection-kibana-plugin
+          command: yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start-cy-server": "yarn start --no-base-path --oss",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test:e2e": "WAIT_ON_TIMEOUT=900000 start-server-and-test 'yarn start-cy-server' http-get://localhost:5601/app/opendistro-anomaly-detection-kibana 'yarn cy:run'"
+    "test:e2e": "CHOKIDAR_USEPOLLING=1 CYPRESS_responseTimeout=180000 WAIT_ON_TIMEOUT=900000 start-server-and-test 'yarn start-cy-server' http-get://localhost:5601/app/opendistro-anomaly-detection-kibana 'echo sleeping to wait for server to get ready && sleep 180 && yarn cy:run'"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css,md}": [


### PR DESCRIPTION
*Description of changes:*
Set up CI for e2e. 

Basic workflow:
1. Start ES docker with AD installed
1. Check out Kibana and set up node to bootstrap
1. Start local kibana and run E2E test against it

Latest E2E run history is here: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/203

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.