### PR TITLE
Improve batch action modal loading state

### DIFF
--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -44,7 +44,8 @@ import {
 interface ConfirmDeleteDetectorsModalProps {
   detectors: DetectorListItem[];
   monitors: { [key: string]: Monitor };
-  hideModal(): void;
+  onHide(): void;
+  onConfirm(): void;
   onStopDetectors(listener?: Listener): void;
   onDeleteDetectors(): void;
   isListLoading: boolean;
@@ -55,10 +56,11 @@ export const ConfirmDeleteDetectorsModal = (
 ) => {
   const containsEnabled = containsEnabledDetectors(props.detectors);
   const [deleteTyped, setDeleteTyped] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isModalLoading, setIsModalLoading] = useState<boolean>(false);
+  const isLoading = isModalLoading || props.isListLoading;
   return (
     <EuiOverlayMask>
-      <EuiModal onClose={props.hideModal}>
+      <EuiModal onClose={props.onHide}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
             {'Are you sure you want to delete the selected detectors?'}&nbsp;
@@ -102,7 +104,7 @@ export const ConfirmDeleteDetectorsModal = (
           />
           <EuiSpacer size="m" />
           <div>
-            {props.isListLoading ? (
+            {isLoading ? (
               <EuiLoadingSpinner size="xl" />
             ) : (
               getNamesAndMonitorsAndStatesGrid(props.detectors, props.monitors)
@@ -110,32 +112,34 @@ export const ConfirmDeleteDetectorsModal = (
           </div>
         </EuiModalBody>
         <EuiModalFooter>
+          {isLoading ? null : (
           <EuiButtonEmpty
             data-test-subj="cancelButton"
-            onClick={props.hideModal}
+            onClick={props.onHide}
           >
             Cancel
           </EuiButtonEmpty>
+          )}
           <EuiButton
             data-test-subj="confirmButton"
             color="danger"
             disabled={!deleteTyped}
             fill
-            isLoading={isLoading || props.isListLoading}
+            isLoading={isLoading}
             onClick={async () => {
-              setIsLoading(true);
+              setIsModalLoading(true);
               if (containsEnabled) {
                 const listener: Listener = {
                   onSuccess: () => {
                     props.onDeleteDetectors();
-                    props.hideModal();
+                    props.onConfirm();
                   },
-                  onException: props.hideModal,
+                  onException: props.onConfirm,
                 };
                 props.onStopDetectors(listener);
               } else {
                 props.onDeleteDetectors();
-                props.hideModal();
+                props.onConfirm();
               }
             }}
           >

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
@@ -36,7 +36,8 @@ import { getNamesGrid } from './utils/helpers';
 
 interface ConfirmStartDetectorsModalProps {
   detectors: DetectorListItem[];
-  hideModal(): void;
+  onHide(): void;
+  onConfirm(): void;
   onStartDetectors(): void;
   isListLoading: boolean;
 }
@@ -44,10 +45,11 @@ interface ConfirmStartDetectorsModalProps {
 export const ConfirmStartDetectorsModal = (
   props: ConfirmStartDetectorsModalProps
 ) => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isModalLoading, setIsModalLoading] = useState<boolean>(false);
+  const isLoading = isModalLoading || props.isListLoading;
   return (
     <EuiOverlayMask>
-      <EuiModal onClose={props.hideModal}>
+      <EuiModal onClose={props.onHide}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
             {'Are you sure you want to start the selected detectors?'}&nbsp;
@@ -61,7 +63,7 @@ export const ConfirmStartDetectorsModal = (
           ></EuiCallOut>
           <EuiSpacer size="m" />
           <div>
-            {props.isListLoading ? (
+            {isLoading ? (
               <EuiLoadingSpinner size="xl" />
             ) : (
               getNamesGrid(props.detectors)
@@ -69,21 +71,23 @@ export const ConfirmStartDetectorsModal = (
           </div>
         </EuiModalBody>
         <EuiModalFooter>
+          {isLoading ? null : (
           <EuiButtonEmpty
             data-test-subj="cancelButton"
-            onClick={props.hideModal}
+            onClick={props.onHide}
           >
             Cancel
           </EuiButtonEmpty>
+          )}
           <EuiButton
             data-test-subj="confirmButton"
             color="primary"
             fill
-            isLoading={isLoading || props.isListLoading}
+            isLoading={isLoading}
             onClick={async () => {
-              setIsLoading(true);
+              setIsModalLoading(true);
               props.onStartDetectors();
-              props.hideModal();
+              props.onConfirm();
             }}
           >
             {'Start detectors'}

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
@@ -39,7 +39,8 @@ import { getNamesAndMonitorsGrid } from './utils/helpers';
 interface ConfirmStopDetectorsModalProps {
   detectors: DetectorListItem[];
   monitors: { [key: string]: Monitor };
-  hideModal(): void;
+  onHide(): void;
+  onConfirm(): void;
   onStopDetectors(listener?: Listener): void;
   isListLoading: boolean;
 }
@@ -47,10 +48,11 @@ interface ConfirmStopDetectorsModalProps {
 export const ConfirmStopDetectorsModal = (
   props: ConfirmStopDetectorsModalProps
 ) => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isModalLoading, setIsModalLoading] = useState<boolean>(false);
+  const isLoading = isModalLoading || props.isListLoading;
   return (
     <EuiOverlayMask>
-      <EuiModal onClose={props.hideModal}>
+      <EuiModal onClose={props.onHide}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
             {'Are you sure you want to stop the selected detectors?'}&nbsp;
@@ -65,7 +67,7 @@ export const ConfirmStopDetectorsModal = (
           ></EuiCallOut>
           <EuiSpacer size="m" />
           <div>
-            {props.isListLoading ? (
+            {isLoading ? (
               <EuiLoadingSpinner size="xl" />
             ) : (
               getNamesAndMonitorsGrid(props.detectors, props.monitors)
@@ -73,21 +75,23 @@ export const ConfirmStopDetectorsModal = (
           </div>
         </EuiModalBody>
         <EuiModalFooter>
+          {isLoading ? null : (
           <EuiButtonEmpty
             data-test-subj="cancelButton"
-            onClick={props.hideModal}
+            onClick={props.onHide}
           >
             Cancel
           </EuiButtonEmpty>
+          )}
           <EuiButton
             data-test-subj="confirmButton"
             color="primary"
             fill
-            isLoading={isLoading || props.isListLoading}
+            isLoading={isLoading}
             onClick={async () => {
-              setIsLoading(true);
+              setIsModalLoading(true);
               props.onStopDetectors();
-              props.hideModal();
+              props.onConfirm();
             }}
           >
             {'Stop detectors'}

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmDeleteDetectorsModal.test.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmDeleteDetectorsModal.test.tsx
@@ -43,7 +43,8 @@ testMonitor['detector-id-0'] = [
 const defaultDeleteProps = {
   detectors: testDetectors,
   monitors: {},
-  hideModal: jest.fn(),
+  onHide: jest.fn(),
+  onConfirm: jest.fn(),
   onStopDetectors: jest.fn(),
   onDeleteDetectors: jest.fn(),
   isListLoading: false,
@@ -89,7 +90,7 @@ describe('<ConfirmDeleteDetectorsModal /> spec', () => {
       await wait();
       expect(defaultDeleteProps.onStopDetectors).not.toHaveBeenCalled();
       expect(defaultDeleteProps.onDeleteDetectors).not.toHaveBeenCalled();
-      expect(defaultDeleteProps.hideModal).not.toHaveBeenCalled();
+      expect(defaultDeleteProps.onConfirm).not.toHaveBeenCalled();
     });
     test('should have delete button enabled if delete typed', async () => {
       const { getByTestId, getByPlaceholderText } = render(
@@ -99,7 +100,7 @@ describe('<ConfirmDeleteDetectorsModal /> spec', () => {
       await wait();
       userEvent.click(getByTestId('confirmButton'));
       await wait();
-      expect(defaultDeleteProps.hideModal).toHaveBeenCalled();
+      expect(defaultDeleteProps.onConfirm).toHaveBeenCalled();
     });
     test('should not show callout and set running to no if no detectors are running', async () => {
       const { queryByText, getAllByText } = render(
@@ -140,13 +141,13 @@ describe('<ConfirmDeleteDetectorsModal /> spec', () => {
       expect(getAllByText('No')).toHaveLength(1);
       expect(getAllByText('Yes')).toHaveLength(2);
     });
-    test('should call hideModal() when closing', async () => {
+    test('should call onHide() when closing', async () => {
       const { getByTestId } = render(
         <ConfirmDeleteDetectorsModal {...defaultDeleteProps} />
       );
       fireEvent.click(getByTestId('cancelButton'));
       await wait();
-      expect(defaultDeleteProps.hideModal).toHaveBeenCalled();
+      expect(defaultDeleteProps.onHide).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmStartDetectorsModal.test.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmStartDetectorsModal.test.tsx
@@ -40,7 +40,8 @@ testMonitor['detector-id-0'] = [
 
 const defaultStartProps = {
   detectors: testDetectors,
-  hideModal: jest.fn(),
+  onHide: jest.fn(),
+  onConfirm: jest.fn(),
   onStartDetectors: jest.fn(),
   isListLoading: false,
 };
@@ -59,21 +60,22 @@ describe('<ConfirmStartDetectorsModal /> spec', () => {
       getByText('detector-0');
       getByText('detector-1');
     });
-    test('should call onStartDetectors() when confirming', async () => {
+    test('should call onStartDetectors() and onConfirm() when confirming', async () => {
       const { getByTestId } = render(
         <ConfirmStartDetectorsModal {...defaultStartProps} />
       );
       fireEvent.click(getByTestId('confirmButton'));
       await wait();
       expect(defaultStartProps.onStartDetectors).toHaveBeenCalled();
+      expect(defaultStartProps.onConfirm).toHaveBeenCalled();
     });
-    test('should call hideModal() when closing', async () => {
+    test('should call onHide() when closing', async () => {
       const { getByTestId } = render(
         <ConfirmStartDetectorsModal {...defaultStartProps} />
       );
       fireEvent.click(getByTestId('cancelButton'));
       await wait();
-      expect(defaultStartProps.hideModal).toHaveBeenCalled();
+      expect(defaultStartProps.onHide).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmStopDetectorsModal.test.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/__tests__/ConfirmStopDetectorsModal.test.tsx
@@ -41,7 +41,8 @@ testMonitor['detector-id-0'] = [
 const defaultStopProps = {
   detectors: testDetectors,
   monitors: {},
-  hideModal: jest.fn(),
+  onHide: jest.fn(),
+  onConfirm: jest.fn(),
   onStopDetectors: jest.fn(),
   isListLoading: false,
 };
@@ -84,13 +85,13 @@ describe('<ConfirmStopDetectorsModal /> spec', () => {
       await wait();
       expect(defaultStopProps.onStopDetectors).toHaveBeenCalled();
     });
-    test('should call hideModal() when closing', async () => {
+    test('should call onHide() when closing', async () => {
       const { getByTestId } = render(
         <ConfirmStopDetectorsModal {...defaultStopProps} />
       );
       fireEvent.click(getByTestId('cancelButton'));
       await wait();
-      expect(defaultStopProps.hideModal).toHaveBeenCalled();
+      expect(defaultStopProps.onHide).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -223,17 +223,6 @@ export const DetectorList = (props: ListProps) => {
     setIsLoadingFinalDetectors(false);
   }, [allDetectors]);
 
-  const getUpdatedDetectors = async () => {
-    try {
-      dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
-    } catch (error) {
-      toastNotifications.addDanger(
-        `Error is found while getting detector list: ${error}`
-      );
-      setIsLoadingFinalDetectors(false);
-    }
-  };
-
   // Update modal state if user decides to close
   useEffect(() => {
     if (confirmModalState.isRequestingToClose) {
@@ -252,6 +241,17 @@ export const DetectorList = (props: ListProps) => {
       }
     }
   }, [confirmModalState.isRequestingToClose, isLoading]);
+
+  const getUpdatedDetectors = async () => {
+    try {
+      dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
+    } catch (error) {
+      toastNotifications.addDanger(
+        `Error is found while getting detector list: ${error}`
+      );
+      setIsLoadingFinalDetectors(false);
+    }
+  };
 
   const handlePageChange = (pageNumber: number) => {
     setState({ ...state, page: pageNumber });
@@ -494,7 +494,14 @@ export const DetectorList = (props: ListProps) => {
     return `${item.id}-${item.currentTime}`;
   };
 
-  const hideConfirmModal = () => {
+  const handleHideModal = () => {
+    setConfirmModalState({
+      ...confirmModalState,
+      isOpen: false,
+    });
+  };
+
+  const handleConfirmModal = () => {
     setConfirmModalState({
       ...confirmModalState,
       isRequestingToClose: true,
@@ -510,7 +517,8 @@ export const DetectorList = (props: ListProps) => {
             <ConfirmStartDetectorsModal
               detectors={confirmModalState.affectedDetectors}
               onStartDetectors={handleStartDetectorJobs}
-              hideModal={hideConfirmModal}
+              onHide={handleHideModal}
+              onConfirm={handleConfirmModal}
               isListLoading={isLoading}
             />
           );
@@ -521,7 +529,8 @@ export const DetectorList = (props: ListProps) => {
               detectors={confirmModalState.affectedDetectors}
               monitors={confirmModalState.affectedMonitors}
               onStopDetectors={handleStopDetectorJobs}
-              hideModal={hideConfirmModal}
+              onHide={handleHideModal}
+              onConfirm={handleConfirmModal}
               isListLoading={isLoading}
             />
           );
@@ -533,7 +542,8 @@ export const DetectorList = (props: ListProps) => {
               monitors={confirmModalState.affectedMonitors}
               onStopDetectors={handleStopDetectorJobs}
               onDeleteDetectors={handleDeleteDetectorJobs}
-              hideModal={hideConfirmModal}
+              onHide={handleHideModal}
+              onConfirm={handleConfirmModal}
               isListLoading={isLoading}
             />
           );


### PR DESCRIPTION
*Issue #, if available:* #212 

*Description of changes:*

This PR improves the handling of different cases while the batch action detector modals are in loading state.

Specifically:
1. Removes the `Cancel` button when loading
2. Adds functionality to the `x` to close the modal when loading
3. Adds a function parameter to the modals to differ between when a user is confirming the action (putting the modal in loading state) versus just closing the modal.

Screenshot of the delete batch action modal (before):

<img width="813" alt="Screen Shot 2020-06-09 at 5 00 25 PM" src="https://user-images.githubusercontent.com/62119629/84295327-4937d680-aaff-11ea-836b-9003836749da.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
