### PR TITLE
Move textfield in delete batch action modal to bottom

### DIFF
--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -84,7 +84,7 @@ export const ConfirmDeleteDetectorsModal = (
               ></EuiCallOut>
             </div>
           ) : null}
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
           <div>
             {isLoading ? (
               <EuiLoadingSpinner size="xl" />
@@ -94,10 +94,10 @@ export const ConfirmDeleteDetectorsModal = (
           </div>
         </EuiModalBody>
         <EuiFlexGroup
-          alignItems="center"
+          direction="column"
           style={{
             marginTop: 16,
-            marginBottom: -8,
+            marginBottom: 8,
             marginLeft: 24,
             marginRight: 24,
           }}

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -21,6 +21,7 @@ import {
   EuiFieldText,
   EuiButton,
   EuiButtonEmpty,
+  EuiFlexGroup,
   EuiModal,
   EuiModalHeader,
   EuiModalFooter,
@@ -83,8 +84,24 @@ export const ConfirmDeleteDetectorsModal = (
               ></EuiCallOut>
             </div>
           ) : null}
-
-          <EuiSpacer size="s" />
+          <EuiSpacer size="m" />
+          <div>
+            {isLoading ? (
+              <EuiLoadingSpinner size="xl" />
+            ) : (
+              getNamesAndMonitorsAndStatesGrid(props.detectors, props.monitors)
+            )}
+          </div>
+        </EuiModalBody>
+        <EuiFlexGroup
+          alignItems="center"
+          style={{
+            marginTop: 16,
+            marginBottom: -8,
+            marginLeft: 24,
+            marginRight: 24,
+          }}
+        >
           <EuiText>
             <p>
               To confirm deletion, type <i>delete</i> in the field.
@@ -102,23 +119,15 @@ export const ConfirmDeleteDetectorsModal = (
               }
             }}
           />
-          <EuiSpacer size="m" />
-          <div>
-            {isLoading ? (
-              <EuiLoadingSpinner size="xl" />
-            ) : (
-              getNamesAndMonitorsAndStatesGrid(props.detectors, props.monitors)
-            )}
-          </div>
-        </EuiModalBody>
+        </EuiFlexGroup>
         <EuiModalFooter>
           {isLoading ? null : (
-          <EuiButtonEmpty
-            data-test-subj="cancelButton"
-            onClick={props.onHide}
-          >
-            Cancel
-          </EuiButtonEmpty>
+            <EuiButtonEmpty
+              data-test-subj="cancelButton"
+              onClick={props.onHide}
+            >
+              Cancel
+            </EuiButtonEmpty>
           )}
           <EuiButton
             data-test-subj="confirmButton"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
@@ -61,7 +61,7 @@ export const ConfirmStartDetectorsModal = (
             color="success"
             iconType="play"
           ></EuiCallOut>
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
           <div>
             {isLoading ? (
               <EuiLoadingSpinner size="xl" />
@@ -72,12 +72,12 @@ export const ConfirmStartDetectorsModal = (
         </EuiModalBody>
         <EuiModalFooter>
           {isLoading ? null : (
-          <EuiButtonEmpty
-            data-test-subj="cancelButton"
-            onClick={props.onHide}
-          >
-            Cancel
-          </EuiButtonEmpty>
+            <EuiButtonEmpty
+              data-test-subj="cancelButton"
+              onClick={props.onHide}
+            >
+              Cancel
+            </EuiButtonEmpty>
           )}
           <EuiButton
             data-test-subj="confirmButton"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
@@ -65,7 +65,7 @@ export const ConfirmStopDetectorsModal = (
             color="warning"
             iconType="alert"
           ></EuiCallOut>
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
           <div>
             {isLoading ? (
               <EuiLoadingSpinner size="xl" />
@@ -76,12 +76,12 @@ export const ConfirmStopDetectorsModal = (
         </EuiModalBody>
         <EuiModalFooter>
           {isLoading ? null : (
-          <EuiButtonEmpty
-            data-test-subj="cancelButton"
-            onClick={props.onHide}
-          >
-            Cancel
-          </EuiButtonEmpty>
+            <EuiButtonEmpty
+              data-test-subj="cancelButton"
+              onClick={props.onHide}
+            >
+              Cancel
+            </EuiButtonEmpty>
           )}
           <EuiButton
             data-test-subj="confirmButton"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR simply moves the confirmation prompt and textfield to the bottom of the delete batch action modal, right above the confirmation button.

This makes the modal make more logical sense, as a user would want to review the list of detectors that will be deleted before typing `delete` in the textfield.

Confirmed with UX on changes.

Before:
<img width="1433" alt="Screen Shot 2020-06-09 at 12 59 08 PM" src="https://user-images.githubusercontent.com/62119629/84427754-45c54d80-abda-11ea-9a08-f7f5f86654a8.png">

After:
<img width="1432" alt="Screen Shot 2020-06-12 at 11 21 27 AM" src="https://user-images.githubusercontent.com/62119629/84534534-ed0bb880-ac9e-11ea-96c4-4caf8b50bf55.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
