### PR TITLE
Prevent unnecessary update when doing batch delete

### DIFF
--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -461,7 +461,10 @@ export const DetectorList = (props: ListProps) => {
         if (listener) listener.onException();
       })
       .finally(() => {
-        getUpdatedDetectors();
+        // only need to get updated list if we're just stopping (no need if deleting also)
+        if (confirmModalState.action === DETECTOR_ACTION.STOP) {
+          getUpdatedDetectors();
+        }
       });
   };
 


### PR DESCRIPTION
*Issue #, if available:* #213 

*Description of changes:*

This PR fixes the issue where the detector list occasionally tries to retrieve already-deleted detectors when performing the delete batch action.

Currently, when performing a batch delete action, we have to perform a batch stop for any detectors that are currently running first. We then kick off an async action to retrieve updated detectors. Meanwhile, we perform the batch delete, resulting in the async action to occasionally try to get an update for an already-deleted detector. This fixes that by only retrieving updated detectors after the stop action if the **overall** action is just to stop, and not to delete immediately after. It also eliminates extra unnecessary processing when performing the delete action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
