### PR TITLE
Create draft release and attach artifact during CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,12 +9,18 @@ jobs:
     name: Build and upload artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Get tag version
+        run: |
+          tag=${GITHUB_REF/refs\/tags\//}
+          echo ::set-env name=TAG_VERSION::"${tag:1}"
+
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - name: Checkout Kibana
         uses: actions/checkout@v2
         with:
@@ -22,39 +28,63 @@ jobs:
           ref: 7.7.0
           token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
+
       - name: Get node and yarn versions
         id: versions_step
         run: |
           echo "::set-output name=node_version::$(node -p "(require('./kibana/package.json').engines.node).match(/[.0-9]+/)[0]")"
           echo "::set-output name=yarn_version::$(node -p "(require('./kibana/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.versions_step.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install correct yarn version for Kibana
         run: |
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+
       - name: Checkout Anomaly Detection Kibana plugin
         uses: actions/checkout@v2
         with:
           path: kibana/plugins/anomaly-detection-kibana-plugin
-      - name: Attempt to bootstrap the plugin
-        continue-on-error: true
+
+      - name: Bootstrap the plugin
         run: |
           cd kibana/plugins/anomaly-detection-kibana-plugin
           yarn kbn bootstrap
-      - name: Bootstrap the plugin again
-        if: ${{ always() }}
-        run: |
-          cd kibana/plugins/anomaly-detection-kibana-plugin
-          yarn kbn bootstrap
+
       - name: Build the artifact
-        if: ${{ always() }}
         run: |
           cd kibana/plugins/anomaly-detection-kibana-plugin
           yarn build
+
+      - name: Upload the artifact
+        run: |
+          cd kibana/plugins/anomaly-detection-kibana-plugin
           artifact=`ls build/*.zip`
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-anomaly-detection/
+
+      - name: Create GitHub draft release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Version ${{ env.TAG_VERSION }}
+          draft: true
+          prerelease: false
+
+      - name: Upload zip asset to draft release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: opendistro-anomaly-detection-kibana-${{ env.TAG_VERSION }}.zip
+          asset_path: kibana/plugins/anomaly-detection-kibana-plugin/build
+          asset_content_type: application/zip


### PR DESCRIPTION
*Issue #, if available:* #223 

*Description of changes:*

This PR helps automate the ODFE release process by automatically creating a draft release with the pushed tag, as well as building and attaching the zip artifact to the draft release. This is all triggered whenever new tags are pushed to the repository.

Also removes the extra bootstrap step since that issue was fixed by #210 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
