### PR TITLE
Automate release notes generation on pushes to master

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -20,6 +20,7 @@ categories:
   - title: 'Bug Fixes'
     labels:
       - 'bug'
+      - 'bug fix'
   - title: 'Infra Changes'
     labels:
       - 'infra'

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,32 @@
+# The overall template of the release notes
+template: |
+  Compatible with Kibana (**set version here**) and Open Distro for Elasticsearch (**set version here**).
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '- $TITLE (PR #$NUMBER)'
+sort-by: merged_at
+sort-direction: ascending
+
+# Organizing the tagged PRs into categories
+categories:
+  - title: 'Major changes'
+    labels:
+      - 'feature'
+  - title: 'Enhancements'
+    labels:
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Infra Changes'
+    labels:
+      - 'infra'
+      - 'test'
+      - 'documentation'
+      - 'dependencies'
+  - title: 'Version Upgrades'
+    labels:
+      - 'version upgrade'
+      - 'odfe-release'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -15,6 +15,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - name: Checkout Kibana
         uses: actions/checkout@v2
         with:
@@ -22,39 +23,42 @@ jobs:
           ref: 7.7.0
           token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
+
       - name: Get node and yarn versions
         id: versions_step
         run: |
           echo "::set-output name=node_version::$(node -p "(require('./kibana/package.json').engines.node).match(/[.0-9]+/)[0]")"
           echo "::set-output name=yarn_version::$(node -p "(require('./kibana/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.versions_step.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
+
       - name: Install correct yarn version for Kibana
         run: |
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+
       - name: Checkout Anomaly Detection Kibana plugin
         uses: actions/checkout@v2
         with:
           path: kibana/plugins/anomaly-detection-kibana-plugin
-      - name: Attempt to bootstrap the plugin
-        continue-on-error: true
+
+      - name: Bootstrap the plugin
         run: |
           cd kibana/plugins/anomaly-detection-kibana-plugin
           yarn kbn bootstrap
-      - name: Bootstrap the plugin again
-        if: ${{ always() }}
-        run: |
-          cd kibana/plugins/anomaly-detection-kibana-plugin
-          yarn kbn bootstrap
+
       - name: Build the artifact
-        if: ${{ always() }}
         run: |
           cd kibana/plugins/anomaly-detection-kibana-plugin
           yarn build
+
+      - name: Upload the artifact
+        run: |
+          cd kibana/plugins/anomaly-detection-kibana-plugin
           artifact=`ls build/*.zip`
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-anomaly-detection/

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          name: Version (set here)
+          tag: (None)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:* #223 

*Description of changes:*

This PR adds an action ([details here](https://github.com/release-drafter/release-drafter)) to automatically create and update draft release notes by adding new merged PR commits into the notes in an organized fashion.

This also removes the unnecessary second bootstrap command in the CD action, which was fixed by #210 

**NOTE** this will require new PRs to be labeled so they can be correctly categorized in the release notes. For example, if a PR is considered an `enhancement`, it will need to be labeled with the `enhancement` tag. Then, when merged into master, the release notes will add the commit under the `Enhancements` header automatically.

Example (on my forked repo): 
![Screen Shot 2020-06-16 at 11 47 31 AM](https://user-images.githubusercontent.com/62119629/84815012-37ef3e00-afc7-11ea-85bc-0a92d8c889b6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
