### PR TITLE
Add Cypress tests for dashboard and detector list

### DIFF
--- a/.cypress/fixtures/delete_detector_response.json
+++ b/.cypress/fixtures/delete_detector_response.json
@@ -1,0 +1,15 @@
+{
+  "_index": ".opendistro-anomaly-detectors",
+  "_type": "_doc",
+  "_id": "ulgqpXEBqtadYz9j2MHG",
+  "_version": 2,
+  "result": "deleted",
+  "forced_refresh": true,
+  "_shards": {
+    "total": 2,
+    "successful": 2,
+    "failed": 0
+  },
+  "_seq_no": 6,
+  "_primary_term": 1
+}

--- a/.cypress/fixtures/multiple_detectors_response.json
+++ b/.cypress/fixtures/multiple_detectors_response.json
@@ -1,0 +1,135 @@
+{
+  "ok": true,
+  "response": {
+    "totalDetectors": 1,
+    "detectorList": [
+      {
+        "id": "ulgqpXEBqtadYz7j2MHG",
+        "description": "test",
+        "indices": ["feature-required-index"],
+        "lastUpdateTime": 1587614056945,
+        "name": "feature-required-detector",
+        "timeField": "timestamp",
+        "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
+        "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
+        "schemaVersion": 0,
+        "filterQuery": { "match_all": { "boost": 1 } },
+        "featureAttributes": [],
+        "uiMetadata": {
+          "features": {},
+          "filters": [],
+          "filterType": "simple_filter"
+        },
+        "enabled": false,
+        "totalAnomalies": 0,
+        "lastActiveAnomaly": 1591593056550,
+        "curState": "Feature required"
+      },
+      {
+        "id": "ulgqpXEBqtadYz6j2MHG",
+        "description": "test",
+        "indices": ["initializing-index"],
+        "lastUpdateTime": 1587614056945,
+        "name": "initializing-detector",
+        "timeField": "timestamp",
+        "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
+        "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
+        "schemaVersion": 0,
+        "filterQuery": { "match_all": { "boost": 1 } },
+        "featureAttributes": [
+          {
+            "featureId": "1mMspXEBcngjFp58AS_u",
+            "featureName": "test-f",
+            "featureEnabled": true,
+            "aggregationQuery": { "aa": { "sum": { "field": "value" } } }
+          }
+        ],
+        "uiMetadata": {
+          "features": {
+            "aa": {
+              "aggregationBy": "sum",
+              "aggregationOf": "value",
+              "featureType": "simple_aggs"
+            }
+          },
+          "filters": [],
+          "filterType": "simple_filter"
+        },
+        "enabled": true,
+        "totalAnomalies": 0,
+        "lastActiveAnomaly": 1591593056550,
+        "curState": "Initializing"
+      },
+      {
+        "id": "ulgqpXEBqtadYz8j2MHG",
+        "description": "test",
+        "indices": ["running-index"],
+        "lastUpdateTime": 1587614056945,
+        "name": "running-detector",
+        "timeField": "timestamp",
+        "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
+        "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
+        "schemaVersion": 0,
+        "filterQuery": { "match_all": { "boost": 1 } },
+        "featureAttributes": [
+          {
+            "featureId": "1mMspXEBcngjFp58AS_u",
+            "featureName": "test-f",
+            "featureEnabled": true,
+            "aggregationQuery": { "aa": { "sum": { "field": "value" } } }
+          }
+        ],
+        "uiMetadata": {
+          "features": {
+            "aa": {
+              "aggregationBy": "sum",
+              "aggregationOf": "value",
+              "featureType": "simple_aggs"
+            }
+          },
+          "filters": [],
+          "filterType": "simple_filter"
+        },
+        "enabled": true,
+        "totalAnomalies": 0,
+        "lastActiveAnomaly": 1591593056550,
+        "curState": "Running"
+      },
+      {
+        "id": "ulgqpXEBqtadYz9j2MHG",
+        "description": "test",
+        "indices": ["stopped-index"],
+        "lastUpdateTime": 1587614056945,
+        "name": "stopped-detector",
+        "timeField": "timestamp",
+        "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
+        "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
+        "schemaVersion": 0,
+        "filterQuery": { "match_all": { "boost": 1 } },
+        "featureAttributes": [
+          {
+            "featureId": "1mMspXEBcngjFp58AS_u",
+            "featureName": "test-f",
+            "featureEnabled": true,
+            "aggregationQuery": { "aa": { "sum": { "field": "value" } } }
+          }
+        ],
+        "uiMetadata": {
+          "features": {
+            "aa": {
+              "aggregationBy": "sum",
+              "aggregationOf": "value",
+              "featureType": "simple_aggs"
+            }
+          },
+          "filters": [],
+          "filterType": "simple_filter"
+        },
+        "enabled": false,
+        "totalAnomalies": 0,
+        "lastActiveAnomaly": 1591593056550,
+        "curState": "Stopped"
+      }
+    ]
+  }
+}

--- a/.cypress/fixtures/single_running_detector_response.json
+++ b/.cypress/fixtures/single_running_detector_response.json
@@ -8,7 +8,7 @@
         "description": "test",
         "indices": ["test-index"],
         "lastUpdateTime": 1587614056945,
-        "name": "name-0",
+        "name": "running-detector",
         "timeField": "timestamp",
         "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
         "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
@@ -33,10 +33,10 @@
           "filters": [],
           "filterType": "simple_filter"
         },
-        "enabled": false,
+        "enabled": true,
         "totalAnomalies": 0,
         "lastActiveAnomaly": 1591593056550,
-        "curState": "Stopped"
+        "curState": "Running"
       }
     ]
   }

--- a/.cypress/fixtures/single_stopped_detector_response.json
+++ b/.cypress/fixtures/single_stopped_detector_response.json
@@ -1,0 +1,43 @@
+{
+  "ok": true,
+  "response": {
+    "totalDetectors": 1,
+    "detectorList": [
+      {
+        "id": "ulgqpXEBqtadYz9j2MHG",
+        "description": "test",
+        "indices": ["test-index"],
+        "lastUpdateTime": 1587614056945,
+        "name": "stopped-detector",
+        "timeField": "timestamp",
+        "detectionInterval": { "period": { "interval": 1, "unit": "Minutes" } },
+        "windowDelay": { "period": { "interval": 1, "unit": "Minutes" } },
+        "schemaVersion": 0,
+        "filterQuery": { "match_all": { "boost": 1 } },
+        "featureAttributes": [
+          {
+            "featureId": "1mMspXEBcngjFp58AS_u",
+            "featureName": "test-f",
+            "featureEnabled": true,
+            "aggregationQuery": { "aa": { "sum": { "field": "value" } } }
+          }
+        ],
+        "uiMetadata": {
+          "features": {
+            "aa": {
+              "aggregationBy": "sum",
+              "aggregationOf": "value",
+              "featureType": "simple_aggs"
+            }
+          },
+          "filters": [],
+          "filterType": "simple_filter"
+        },
+        "enabled": false,
+        "totalAnomalies": 0,
+        "lastActiveAnomaly": 1591593056550,
+        "curState": "Stopped"
+      }
+    ]
+  }
+}

--- a/.cypress/fixtures/start_detector_response.json
+++ b/.cypress/fixtures/start_detector_response.json
@@ -1,0 +1,6 @@
+{
+  "_id": "ulgqpXEBqtadYz9j2MHG",
+  "_version": 1,
+  "_seq_no": 1,
+  "_primary_term": 1
+}

--- a/.cypress/fixtures/stop_detector_response.json
+++ b/.cypress/fixtures/stop_detector_response.json
@@ -1,0 +1,3 @@
+{
+  "Stopped detector": "ulgqpXEBqtadYz9j2MHG"
+}

--- a/.cypress/integration/ad/dashboard/ad_dashboard.spec.ts
+++ b/.cypress/integration/ad/dashboard/ad_dashboard.spec.ts
@@ -32,7 +32,7 @@ context('AD Dashboard', () => {
   });
 
   it('AD dashboard - single stopped detector', () => {
-    cy.mockGetDetectorOnAction('single_detector_response.json', () => {
+    cy.mockGetDetectorOnAction('single_stopped_detector_response.json', () => {
       cy.visit(buildAdAppUrl(DASHBOARD));
     });
 
@@ -55,5 +55,46 @@ context('AD Dashboard', () => {
     });
 
     cy.contains('h1', 'Create detector');
+  });
+
+  it('Filter by detector', () => {
+    cy.mockGetDetectorOnAction('multiple_detectors_response.json', () => {
+      cy.visit(buildAdAppUrl(DASHBOARD));
+    });
+
+    cy.contains('stopped-detector');
+    cy.contains('running-detector');
+
+    cy.get('[data-test-subj=comboBoxToggleListButton]')
+      .first()
+      .click({ force: true });
+    cy.get('.euiFilterSelectItem')
+      .first()
+      .click({ force: true });
+    cy.get('.euiPageSideBar').click({ force: true });
+
+    cy.contains('feature-required-detector'); // first one in the list returned by multiple_detectors_response.json
+    cy.contains('stopped-detector').should('not.be.visible');
+    cy.contains('running-detector').should('not.be.visible');
+  });
+
+  it('Filter by detector state', () => {
+    cy.mockGetDetectorOnAction('multiple_detectors_response.json', () => {
+      cy.visit(buildAdAppUrl(DASHBOARD));
+    });
+
+    cy.contains('stopped-detector');
+    cy.contains('running-detector');
+
+    cy.get('[data-test-subj=comboBoxToggleListButton]')
+      .eq(1)
+      .click({ force: true });
+    cy.get('.euiFilterSelectItem')
+      .first()
+      .click({ force: true });
+    cy.get('.euiPageSideBar').click({ force: true });
+
+    cy.contains('stopped-detector'); // because stopped is the first item in the detector state dropdown
+    cy.contains('running-detector').should('not.be.visible');
   });
 });

--- a/.cypress/integration/ad/detectorList/detector_list.spec.ts
+++ b/.cypress/integration/ad/detectorList/detector_list.spec.ts
@@ -13,11 +13,12 @@
  * permissions and limitations under the License.
  */
 
-import { DETECTORS } from '../../../utils/constants';
+import { DETECTORS, TEST_DETECTOR_ID } from '../../../utils/constants';
+import { DETECTOR_STATE } from '../../../../public/utils/constants';
 import { buildAdAppUrl } from '../../../utils/helpers';
 
 context('Detector list', () => {
-  it.only('Empty detectors - no detector index', () => {
+  it('Empty detectors - no detector index', () => {
     cy.mockGetDetectorOnAction('no_detector_index_response.json', () => {
       cy.visit(buildAdAppUrl(DETECTORS));
     });
@@ -30,7 +31,7 @@ context('Detector list', () => {
     cy.get('.euiButton--primary.euiButton--fill').should('have.length', 2);
   });
 
-  it.only('Empty detectors - empty detector index', () => {
+  it('Empty detectors - empty detector index', () => {
     cy.mockGetDetectorOnAction('empty_detector_index_response.json', () => {
       cy.visit(buildAdAppUrl(DETECTORS));
     });
@@ -41,5 +42,153 @@ context('Detector list', () => {
       'Anomaly detectors take an input of information and discover patterns of anomalies. Create an anomaly detector to get started.'
     );
     cy.get('.euiButton--primary.euiButton--fill').should('have.length', 2);
+  });
+
+  it('One detector - single stopped detector index', () => {
+    cy.mockGetDetectorOnAction('single_stopped_detector_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+
+    cy.contains('p', '(1)');
+    cy.contains('stopped-detector');
+    cy.contains('Stopped');
+    cy.contains('test-index');
+    cy.get('.euiButton--primary.euiButton--fill').should('have.length', 1);
+  });
+
+  it('Multiple detectors - multiple detectors index', () => {
+    cy.mockGetDetectorOnAction('multiple_detectors_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+
+    cy.contains('p', '(4)');
+    cy.contains('stopped-detector');
+    cy.contains('initializing-detector');
+    cy.contains('running-detector');
+    cy.contains('feature-required-detector');
+    cy.contains('stopped-index');
+    cy.contains('initializing-index');
+    cy.contains('running-index');
+    cy.contains('feature-required-index');
+    cy.contains(DETECTOR_STATE.DISABLED);
+    cy.contains(DETECTOR_STATE.INIT);
+    cy.contains(DETECTOR_STATE.RUNNING);
+    cy.contains(DETECTOR_STATE.FEATURE_REQUIRED);
+    cy.get('.euiButton--primary.euiButton--fill').should('have.length', 1);
+  });
+
+  it('Redirect to create detector', () => {
+    cy.mockGetDetectorOnAction('single_stopped_detector_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+    cy.get('[data-test-subj=addDetector]').click({ force: true });
+    cy.contains('h1', 'Create detector');
+  });
+
+  it('Start single detector', () => {
+    cy.mockGetDetectorOnAction('single_stopped_detector_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+    cy.get('.euiCheckbox__input')
+      .last()
+      .click({ force: true });
+    cy.get('[data-test-subj=listActionsButton]').click({ force: true });
+    cy.get('[data-test-subj=startDetectors]').click({ force: true });
+    cy.contains('The following detectors will begin initializing.');
+    cy.contains('stopped-detector');
+    cy.mockStartDetectorOnAction(
+      'start_detector_response.json',
+      TEST_DETECTOR_ID,
+      () => {
+        cy.get('[data-test-subj=confirmButton]').click({ force: true });
+      }
+    );
+    cy.contains('All selected detectors have been started successfully');
+  });
+
+  it('Stop single detector', () => {
+    cy.mockGetDetectorOnAction('single_running_detector_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+    cy.get('.euiCheckbox__input')
+      .last()
+      .click({ force: true });
+    cy.get('[data-test-subj=listActionsButton]').click({ force: true });
+    cy.get('[data-test-subj=stopDetectors]').click({ force: true });
+    cy.contains('The following detectors will be stopped.');
+    cy.contains('running-detector');
+    cy.mockStopDetectorOnAction(
+      'stop_detector_response.json',
+      TEST_DETECTOR_ID,
+      () => {
+        cy.get('[data-test-subj=confirmButton]').click({ force: true });
+      }
+    );
+    cy.contains('All selected detectors have been stopped successfully');
+  });
+
+  it('Delete single detector', () => {
+    cy.mockGetDetectorOnAction('single_stopped_detector_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+    cy.get('.euiCheckbox__input')
+      .last()
+      .click({ force: true });
+    cy.get('[data-test-subj=listActionsButton]').click({ force: true });
+    cy.get('[data-test-subj=deleteDetectors]').click({ force: true });
+    cy.contains(
+      'The following detectors and feature configurations will be permanently removed. This action is irreversible.'
+    );
+    cy.contains('stopped-detector');
+    cy.contains('Running');
+    cy.contains('No');
+    cy.get('[data-test-subj=typeDeleteField]')
+      .click({ force: true })
+      .type('delete');
+    cy.mockDeleteDetectorOnAction(
+      'delete_detector_response.json',
+      TEST_DETECTOR_ID,
+      () => {
+        cy.get('[data-test-subj=confirmButton]').click({ force: true });
+      }
+    );
+    cy.contains('All selected detectors have been deleted successfully');
+  });
+
+  it('Filter by detector search', () => {
+    cy.mockGetDetectorOnAction('multiple_detectors_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+
+    cy.contains('stopped-detector');
+    cy.contains('running-detector');
+
+    cy.get('[data-test-subj=detectorListSearch]')
+      .first()
+      .click({ force: true })
+      .type('stopped-detector');
+
+    cy.contains('stopped-detector');
+    cy.contains('running-detector').should('not.be.visible');
+  });
+
+  it('Filter by detector state', () => {
+    cy.mockGetDetectorOnAction('multiple_detectors_response.json', () => {
+      cy.visit(buildAdAppUrl(DETECTORS));
+    });
+
+    cy.contains('stopped-detector');
+    cy.contains('running-detector');
+
+    cy.get('[data-test-subj=comboBoxToggleListButton]')
+      .first()
+      .click({ force: true });
+    cy.get('.euiFilterSelectItem')
+      .first()
+      .click({ force: true });
+    cy.get('.euiPageSideBar').click({ force: true });
+
+    cy.contains('stopped-detector'); // because stopped is the first item in the detector state dropdown
+    cy.contains('running-detector').should('not.be.visible');
   });
 });

--- a/.cypress/support/commands.ts
+++ b/.cypress/support/commands.ts
@@ -12,7 +12,15 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-import { DETECTORS, INDICES_PATH, MAPPINGS_PATH } from '../utils/constants';
+import {
+  DETECTORS,
+  INDICES_PATH,
+  MAPPINGS_PATH,
+  START_PATH,
+  STOP_PATH,
+  SLASH,
+  SEARCH_PATH,
+} from '../utils/constants';
 import { buildAdApiUrl } from '../utils/helpers';
 
 Cypress.Commands.add('mockGetDetectorOnAction', function(
@@ -63,6 +71,20 @@ Cypress.Commands.add('mockSearchIndexOnAction', function(
   cy.wait('@getIndices');
 });
 
+Cypress.Commands.add('mockSearchOnAction', function(
+  fixtureFileName: string,
+  funcMockedOn: VoidFunction
+) {
+  cy.server();
+  cy.route('POST', buildAdApiUrl(SEARCH_PATH), `fixture:${fixtureFileName}`).as(
+    'searchES'
+  );
+
+  funcMockedOn();
+
+  cy.wait('@searchES');
+});
+
 Cypress.Commands.add('mockGetIndexMappingsOnAction', function(
   fixtureFileName: string,
   funcMockedOn: VoidFunction
@@ -77,4 +99,55 @@ Cypress.Commands.add('mockGetIndexMappingsOnAction', function(
   funcMockedOn();
 
   cy.wait('@getMappings');
+});
+
+Cypress.Commands.add('mockStartDetectorOnAction', function(
+  fixtureFileName: string,
+  detectorId: string,
+  funcMockedOn: VoidFunction
+) {
+  cy.server();
+  cy.route(
+    'POST',
+    buildAdApiUrl([DETECTORS, detectorId, START_PATH].join(SLASH)),
+    `fixture:${fixtureFileName}`
+  ).as('startDetector');
+
+  funcMockedOn();
+
+  cy.wait('@startDetector');
+});
+
+Cypress.Commands.add('mockStopDetectorOnAction', function(
+  fixtureFileName: string,
+  detectorId: string,
+  funcMockedOn: VoidFunction
+) {
+  cy.server();
+  cy.route(
+    'POST',
+    buildAdApiUrl([DETECTORS, detectorId, STOP_PATH].join(SLASH)),
+    `fixture:${fixtureFileName}`
+  ).as('stopDetector');
+
+  funcMockedOn();
+
+  cy.wait('@stopDetector');
+});
+
+Cypress.Commands.add('mockDeleteDetectorOnAction', function(
+  fixtureFileName: string,
+  detectorId: string,
+  funcMockedOn: VoidFunction
+) {
+  cy.server();
+  cy.route(
+    'DELETE',
+    buildAdApiUrl([DETECTORS, detectorId].join(SLASH)),
+    `fixture:${fixtureFileName}`
+  ).as('deleteDetector');
+
+  funcMockedOn();
+
+  cy.wait('@deleteDetector');
 });

--- a/.cypress/support/index.d.ts
+++ b/.cypress/support/index.d.ts
@@ -26,8 +26,27 @@ declare namespace Cypress {
       fixtureFileName: string,
       funcMockedOn: VoidFunction
     ): Chainable<any>;
+    mockSearchOnAction(
+      fixtureFileName: string,
+      funcMockedOn: VoidFunction
+    ): Chainable<any>;
     mockGetIndexMappingsOnAction(
       fixtureFileName: string,
+      funcMockedOn: VoidFunction
+    ): Chainable<any>;
+    mockStartDetectorOnAction(
+      fixtureFileName: string,
+      detectorId: string,
+      funcMockedOn: VoidFunction
+    ): Chainable<any>;
+    mockStopDetectorOnAction(
+      fixtureFileName: string,
+      detectorId: string,
+      funcMockedOn: VoidFunction
+    ): Chainable<any>;
+    mockDeleteDetectorOnAction(
+      fixtureFileName: string,
+      detectorId: string,
       funcMockedOn: VoidFunction
     ): Chainable<any>;
   }

--- a/.cypress/utils/constants.ts
+++ b/.cypress/utils/constants.ts
@@ -17,10 +17,15 @@ export const AD_URL = 'opendistro-anomaly-detection-kibana#';
 export const APP_URL_PREFIX = 'app';
 export const API_URL_PREFIX = 'api';
 export const AD_PATH = 'anomaly_detectors';
+export const SEARCH_PATH = '_search';
 export const INDICES_PATH = '_indices';
 export const MAPPINGS_PATH = '_mappings';
+export const START_PATH = 'start';
+export const STOP_PATH = 'stop';
 export const SLASH = '/';
 
 export const DASHBOARD = 'dashboard';
 export const DETECTORS = 'detectors';
 export const CREATE_AD = 'create-ad';
+
+export const TEST_DETECTOR_ID = 'ulgqpXEBqtadYz9j2MHG';

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -136,9 +136,9 @@ export function DashboardOverview() {
     if (allDetectorsSelected) {
       detectorsToFilter = cloneDeep(Object.values(allDetectorList));
     } else {
-      detectorsToFilter = cloneDeep(Object.values(allDetectorList)).filter(
-        detectorItem => selectedNameList.includes(detectorItem.name)
-      );
+      detectorsToFilter = cloneDeep(
+        Object.values(allDetectorList)
+      ).filter(detectorItem => selectedNameList.includes(detectorItem.name));
     }
 
     let filteredDetectorItemsByNamesAndIndex = detectorsToFilter;
@@ -215,6 +215,7 @@ export function DashboardOverview() {
             <EuiFlexItem>
               <EuiComboBox
                 id="detectorFilter"
+                data-test-subj="detectorFilter"
                 placeholder={ALL_DETECTORS_MESSAGE}
                 options={getDetectorOptions(allDetectorList)}
                 onChange={handleDetectorsFilterChange}
@@ -226,6 +227,7 @@ export function DashboardOverview() {
             <EuiFlexItem>
               <EuiComboBox
                 id="detectorStateFilter"
+                data-test-subj="detectorStateFilter"
                 placeholder={ALL_DETECTOR_STATES_MESSAGE}
                 options={getDetectorStateOptions()}
                 onChange={handleDetectorStateFilterChange}
@@ -237,6 +239,7 @@ export function DashboardOverview() {
             <EuiFlexItem>
               <EuiComboBox
                 id="indicesFilter"
+                data-test-subj="indicesFilter"
                 placeholder={ALL_INDICES_MESSAGE}
                 options={getVisibleOptions(visibleIndices, visibleAliases)}
                 onChange={handleIndicesFilterChange}

--- a/public/pages/DetectorsList/components/ListActions/ListActions.tsx
+++ b/public/pages/DetectorsList/components/ListActions/ListActions.tsx
@@ -41,10 +41,10 @@ export const ListActions = (props: ListActionsProps) => {
           id="actionsPopover"
           button={
             <EuiButton
+              data-test-subj="listActionsButton"
               disabled={props.isActionsDisabled}
               iconType="arrowDown"
               iconSide="right"
-              data-test-subj="actionsButton"
               onClick={() => setIsOpen(!isOpen)}
             >
               Actions

--- a/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
+++ b/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
@@ -52,6 +52,7 @@ export const ListFilters = (props: ListFiltersProps) => (
     <EuiFlexItem>
       <EuiComboBox
         id="selectedDetectorStates"
+        data-test-subj="detectorStateFilter"
         placeholder="All detector states"
         isClearable={true}
         singleSelection={false}
@@ -68,6 +69,7 @@ export const ListFilters = (props: ListFiltersProps) => (
     <EuiFlexItem>
       <EuiComboBox
         id="selectedIndices"
+        data-test-subj="indicesFilter"
         placeholder="All indices"
         isClearable={true}
         singleSelection={false}

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -135,6 +135,7 @@ export const ConfirmDeleteDetectorsModal = (
           </EuiText>
           <EuiSpacer size="s" />
           <EuiFieldText
+            data-test-subj="typeDeleteField"
             fullWidth={true}
             placeholder="delete"
             onChange={e => {

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -628,7 +628,11 @@ export const DetectorList = (props: ListProps) => {
               isStartDisabled={listActionsState.isStartDisabled}
               isStopDisabled={listActionsState.isStopDisabled}
             />,
-            <EuiButton fill href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}>
+            <EuiButton
+              data-test-subj="addDetector"
+              fill
+              href={`${PLUGIN_NAME}#${APP_PATH.CREATE_DETECTOR}`}
+            >
               Create detector
             </EuiButton>,
           ]}


### PR DESCRIPTION
*Issue #, if available:* #231 

*Description of changes:*

This PR adds several Cypress integration tests to test various workflows on the 2 home pages of the plugin (dashboard and detector list).

Dashboard:
- tests filtering of the dropdown filter

Detector list:
- tests filtering of the dropdown filter
- tests rendering of the page when different indices are empty
- tests batch action functionality (start/stop/delete)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
