### PR TITLE
Bump Kibana compatibility to 7.8.0

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
-          ref: 7.7.0
+          ref: 7.8.0
           token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
 

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Pull and Run Docker
         run: |
-          version=1.8.0
+          version=1.9.0
           echo $version
           if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
           then
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
-          ref: 7.7.0
+          ref: 7.8.0
           token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
       - name: Get node and yarn versions

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opendistro-for-elasticsearch/kibana-oss
-          ref: 7.7.0
+          ref: 7.8.0
           token: ${{ secrets.KIBANA_OSS_ACCESS }}
           path: kibana
       - name: Get node and yarn versions

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/opendistro-anomaly-detection-kibana-1.8.0.0.zip`
+Example output: `./build/opendistro-anomaly-detection-kibana-1.9.0.0.zip`
 
 ## Run
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opendistro-anomaly-detection-kibana",
-  "version": "1.8.0.0",
+  "version": "1.9.0.0",
   "description": "Open Distro for Elasticsearch Anomaly Detection Kibana plugin",
   "main": "index.js",
   "kibana": {
-    "version": "7.7.0",
+    "version": "7.8.0",
     "templateVersion": "1.0.0"
   },
   "scripts": {

--- a/public/pages/AnomalyCharts/components/AlertsFlyout/__tests__/__snapshots__/AlertsFlyout.test.tsx.snap
+++ b/public/pages/AnomalyCharts/components/AlertsFlyout/__tests__/__snapshots__/AlertsFlyout.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with monitor 1`] 
         tabindex="0"
       >
         <button
-          aria-label="Closes this dialog"
+          aria-label="Close this dialog"
           class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
@@ -297,7 +297,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with undefined mo
         tabindex="0"
       >
         <button
-          aria-label="Closes this dialog"
+          aria-label="Close this dialog"
           class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
           data-test-subj="euiFlyoutCloseButton"
           type="button"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.5.5":
+"@babel/core@^7.1.0", "@babel/core@^7.9.0":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.2.tgz#bd6786046668a925ac2bd2fd95b579b92a23b36a"
   integrity sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==
@@ -3600,7 +3600,7 @@ execa@^2.0.3:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^4.0.0:
+execa@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.2.tgz#ad87fb7b2d9d564f70d2b62d511bee41d5cbb240"
   integrity sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==
@@ -8168,7 +8168,7 @@ vinyl-sourcemaps-apply@^0.2.0:
   dependencies:
     source-map "^0.5.1"
 
-vinyl@^2.0.0, vinyl@^2.1.0:
+vinyl@^2.0.0, vinyl@^2.1.0, vinyl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
   integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==


### PR DESCRIPTION
*Issue #, if available:* #238 

*Description of changes:*

This PR bumps the Kibana compatibility to version 7.8.0.
- Confirmed all unit and integration tests pass locally
- Confirmed all plugin pages render normally
- Confirmed basic functionality (creating/stopping/starting/deleting detectors) works

Will backport all latest changes to 1.9.0 branch after merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
