### PR TITLE
Move plugin into Kibana app category

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,9 @@ import 'babel-polyfill';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 import { ADPlugin } from './server/plugin';
+import { DEFAULT_APP_CATEGORIES } from '../../src/core/utils';
 
-export default kibana => {
+export default (kibana) => {
   return new kibana.Plugin({
     require: ['kibana', 'elasticsearch'],
     name: 'opendistro-anomaly-detection-kibana',
@@ -30,11 +31,12 @@ export default kibana => {
         main: 'plugins/opendistro-anomaly-detection-kibana/app',
         icon:
           'plugins/opendistro-anomaly-detection-kibana/images/anomaly_detection_icon.svg',
+        category: DEFAULT_APP_CATEGORIES.kibana,
       },
       styleSheetPaths: [
         resolve(__dirname, 'public/app.scss'),
         resolve(__dirname, 'public/app.css'),
-      ].find(p => existsSync(p)),
+      ].find((p) => existsSync(p)),
       hacks: [],
     },
 
@@ -61,9 +63,9 @@ export default kibana => {
         logger: {
           get() {
             return {
-              info: log => console.log(log),
-              error: log => console.error(log),
-              warn: log => console.warn(log),
+              info: (log) => console.log(log),
+              error: (log) => console.error(log),
+              warn: (log) => console.warn(log),
             };
           },
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In Kibana 7.8.0, a new nav sidebar was introduced that categorized the plugins. This PR moves the AD plugin into the Kibana app category so it shows up under the `Kibana` collapsible menu for the side nav bar. Note that some of the other changes were just auto-formatting.

Before:
![Screen Shot 2020-06-23 at 2 00 04 PM](https://user-images.githubusercontent.com/62119629/85484643-14eefc00-b57c-11ea-87c3-ded53d4783ac.png)




After:
![Screen Shot 2020-06-23 at 6 03 15 PM](https://user-images.githubusercontent.com/62119629/85484659-1e786400-b57c-11ea-8594-0f5cb43990d4.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
