### PR TITLE
support remote cluster indices

### DIFF
--- a/public/pages/EditFeatures/components/AggregationSelector/AggregationSelector.tsx
+++ b/public/pages/EditFeatures/components/AggregationSelector/AggregationSelector.tsx
@@ -57,7 +57,6 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
               name={`featureList.${props.index}.aggregationBy`}
               options={AGGREGATION_TYPES}
               onChange={e => {
-                debugger;
                 const currentValue = field.value;
                 const aggregationOf = get(
                   form,
@@ -95,6 +94,15 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
               placeholder="Select field"
               singleSelection
               selectedOptions={field.value}
+              onCreateOption={(createdOption: string) => {
+                const normalizedOptions = createdOption.trim();
+                if (!normalizedOptions) return;
+                const customOption = [{ label: normalizedOptions }];
+                form.setFieldValue(
+                  `featureList.${props.index}.aggregationOf`,
+                  customOption
+                );
+              }}
               //@ts-ignore
               options={
                 get(form, `values.featureList.${props.index}.aggregationBy`) ===

--- a/public/pages/EditFeatures/containers/EditFeatures.tsx
+++ b/public/pages/EditFeatures/containers/EditFeatures.tsx
@@ -126,7 +126,7 @@ export function EditFeatures(props: EditFeaturesProps) {
               {get(detector, 'indices.0', '').includes(':') ? (
                 <div>
                   <EuiCallOut
-                    title="This detector is using remote cluster index. Please input field manually."
+                    title="This detector is using a remote cluster index, so you need to manually input the field."
                     color="warning"
                     iconType="alert"
                   />

--- a/public/pages/EditFeatures/containers/EditFeatures.tsx
+++ b/public/pages/EditFeatures/containers/EditFeatures.tsx
@@ -27,6 +27,8 @@ import {
   EuiOverlayMask,
   EuiButtonEmpty,
   EuiIcon,
+  EuiCallOut,
+  EuiSpacer,
 } from '@elastic/eui';
 import { FieldArray, FieldArrayRenderProps, Form, Formik } from 'formik';
 import { get, isEmpty, forOwn } from 'lodash';
@@ -121,6 +123,17 @@ export function EditFeatures(props: EditFeaturesProps) {
           setFirstLoad(false);
           return (
             <Fragment>
+              {get(detector, 'indices.0', '').includes(':') ? (
+                <div>
+                  <EuiCallOut
+                    title="This detector is using remote cluster index. Please input field manually."
+                    color="warning"
+                    iconType="alert"
+                  />
+                  <EuiSpacer size="m" />
+                </div>
+              ) : null}
+
               {values.featureList.map((feature: any, index: number) => (
                 <FeatureAccordion
                   onDelete={() => {

--- a/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
@@ -25,6 +25,7 @@ import {
   EuiPanel,
   EuiText,
   EuiSpacer,
+  EuiCallOut,
 } from '@elastic/eui';
 import {
   Field,
@@ -99,6 +100,17 @@ export const SimpleFilter = (props: DataFilterProps) => {
             {values.filters.map((filter: UIFilter, index: number) => {
               return (
                 <EuiPanel key={index} className="filter-container">
+                  {get(props, 'formikProps.values.index.0.label', '').includes(':') ? (
+                    <div>
+                      <EuiCallOut
+                        title="This detector is using a remote cluster index, so you need to manually input the filter field."
+                        color="warning"
+                        iconType="alert"
+                      />
+                      <EuiSpacer size="m" />
+                    </div>
+                  ) : null}
+
                   <EuiAccordion
                     id={'name'}
                     initialIsOpen={true}
@@ -154,7 +166,7 @@ export const SimpleFilter = (props: DataFilterProps) => {
                                     }}
                                     selectedOptions={field.value}
                                     {...field}
-                                    onChange={options => {
+                                    onChange={(options) => {
                                       //Reset operator and values
                                       replace(
                                         index,

--- a/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
@@ -141,6 +141,17 @@ export const SimpleFilter = (props: DataFilterProps) => {
                                     isClearable
                                     //@ts-ignore
                                     options={indexFields}
+                                    onCreateOption={(createdOption: string) => {
+                                      const normalizedOptions = createdOption.trim();
+                                      if (!normalizedOptions) return;
+                                      const customOption = [
+                                        { label: normalizedOptions },
+                                      ];
+                                      form.setFieldValue(
+                                        `filters.${index}.fieldInfo`,
+                                        customOption
+                                      );
+                                    }}
                                     selectedOptions={field.value}
                                     {...field}
                                     onChange={options => {

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -93,7 +93,7 @@ function DataSource(props: DataFilterProps) {
       {isRemoteIndex() ? (
         <div>
           <EuiCallOut
-            title="This detector is using remote cluster index. Please input time field and filter field manually."
+            title="This detector is using a remote cluster index, so you need to manually input the time field."
             color="warning"
             iconType="alert"
           />

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -13,9 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import { EuiComboBox, EuiSelect } from '@elastic/eui';
+import { EuiComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
-import { debounce, get } from 'lodash';
+import { debounce, get, isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { CatIndex, IndexAlias } from '../../../../../server/models/types';
@@ -39,6 +39,7 @@ import { FormattedFormRow } from '../../components/FormattedFormRow/FormattedFor
 function DataSource(props: DataFilterProps) {
   const dispatch = useDispatch();
   const [queryText, setQueryText] = useState('');
+  const [indexName, setIndexName] = useState(undefined);
   const elasticsearchState = useSelector(
     (state: AppState) => state.elasticsearch
   );
@@ -57,26 +58,48 @@ function DataSource(props: DataFilterProps) {
     }
   }, 300);
 
-  const handleChange = (selectedOptions: any) => {
+  const handleIndexNameChange = (selectedOptions: any) => {
     const indexName = get(selectedOptions, '0.label', '');
+    setIndexName(indexName);
     if (indexName !== '') {
       dispatch(getMappings(indexName));
     }
   };
 
-  const dateFields = Array.from(get(
-    elasticsearchState,
-    'dataTypes.date',
-    []
-  ) as string[]);
-  const timeStampFieldOptions = ['']
-    .concat(dateFields)
-    .map(dateField => ({ value: dateField, text: dateField }));
+  const dateFields = Array.from(
+    get(elasticsearchState, 'dataTypes.date', []) as string[]
+  );
+
+  const timeStampFieldOptions = isEmpty(dateFields)
+    ? []
+    : dateFields.map(dateField => ({ label: dateField }));
+
   const visibleIndices = get(elasticsearchState, 'indices', []) as CatIndex[];
   const visibleAliases = get(elasticsearchState, 'aliases', []) as IndexAlias[];
 
+  const isRemoteIndex = () => {
+    const initialIndex = get(
+      props.formikProps,
+      'initialValues.index.0.label',
+      ''
+    );
+    return indexName !== undefined
+      ? indexName.includes(':')
+      : initialIndex.includes(':');
+  };
+
   return (
     <ContentPanel title="Data Source" titleSize="s">
+      {isRemoteIndex() ? (
+        <div>
+          <EuiCallOut
+            title="This detector is using remote cluster index. Please input time field and filter field manually."
+            color="warning"
+            iconType="alert"
+          />
+          <EuiSpacer size="m" />
+        </div>
+      ) : null}
       <Field name="index" validate={validateIndex}>
         {({ field, form }: FieldProps) => {
           return (
@@ -95,18 +118,19 @@ function DataSource(props: DataFilterProps) {
                 options={getVisibleOptions(visibleIndices, visibleAliases)}
                 onSearchChange={handleSearchChange}
                 onCreateOption={(createdOption: string) => {
-                  const normalizedOptions = createdOption.trim().toLowerCase();
+                  const normalizedOptions = createdOption.trim();
                   if (!normalizedOptions) return;
                   const customOption = [{ label: normalizedOptions }];
                   form.setFieldValue('index', customOption);
-                  handleChange(customOption);
+                  handleIndexNameChange(customOption);
                 }}
                 onBlur={() => {
                   form.setFieldTouched('index', true);
                 }}
                 onChange={options => {
                   form.setFieldValue('index', options);
-                  handleChange(options);
+                  form.setFieldValue('timeField', undefined);
+                  handleIndexNameChange(options);
                 }}
                 selectedOptions={field.value}
                 singleSelection={true}
@@ -131,11 +155,25 @@ function DataSource(props: DataFilterProps) {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiSelect
-              {...field}
+            <EuiComboBox
               id="timeField"
               placeholder="Find timestamp"
               options={timeStampFieldOptions}
+              onSearchChange={handleSearchChange}
+              onCreateOption={(createdOption: string) => {
+                const normalizedOptions = createdOption.trim();
+                if (!normalizedOptions) return;
+                form.setFieldValue('timeField', normalizedOptions);
+              }}
+              onBlur={() => {
+                form.setFieldTouched('timeField', true);
+              }}
+              onChange={options => {
+                form.setFieldValue('timeField', get(options, '0.label'));
+              }}
+              selectedOptions={(field.value && [{ label: field.value }]) || []}
+              singleSelection={true}
+              isClearable={false}
             />
           </FormattedFormRow>
         )}

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -342,38 +342,65 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="euiComboBox"
+              role="combobox"
             >
               <div
-                class="euiFormControlLayout__childrenWrapper"
+                class="euiFormControlLayout"
               >
-                <select
-                  class="euiSelect"
-                  id="random_id"
-                  name="timeField"
-                  placeholder="Find timestamp"
-                >
-                  <option
-                    value=""
-                  />
-                </select>
                 <div
-                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                  class="euiFormControlLayout__childrenWrapper"
                 >
-                  <span
-                    class="euiFormControlLayoutCustomIcon"
+                  <div
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                    data-test-subj="comboBoxInput"
+                    tabindex="-1"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </span>
+                    <p
+                      class="euiComboBoxPlaceholder"
+                    >
+                      Find timestamp
+                    </p>
+                    <div
+                      class="euiComboBox__input"
+                      style="font-size: 14px; display: inline-block;"
+                    >
+                      <input
+                        aria-controls=""
+                        data-test-subj="comboBoxSearchInput"
+                        id="random_id"
+                        role="textbox"
+                        style="box-sizing: content-box; width: 2px;"
+                        value=""
+                      />
+                      <div
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                  >
+                    <button
+                      aria-label="Open list of options"
+                      class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                      data-test-subj="comboBoxToggleListButton"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/public/redux/reducers/elasticsearch.ts
+++ b/public/redux/reducers/elasticsearch.ts
@@ -24,6 +24,7 @@ import handleActions from '../utils/handleActions';
 import { getPathsPerDataType } from './mapper';
 import { CatIndex, IndexAlias } from '../../../server/models/types';
 import { AD_NODE_API } from '../../../utils/constants';
+import { get } from 'lodash';
 
 const GET_INDICES = 'elasticsearch/GET_INDICES';
 const GET_ALIASES = 'elasticsearch/GET_ALIASES';
@@ -93,7 +94,7 @@ const reducer = handleActions<ElasticsearchState>(
       ): ElasticsearchState => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessage: get(action, 'error.data.error', action.error),
       }),
     },
     [GET_ALIASES]: {
@@ -118,7 +119,7 @@ const reducer = handleActions<ElasticsearchState>(
       ): ElasticsearchState => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessage: get(action, 'error.data.error', action.error),
       }),
     },
     [SEARCH_ES]: {
@@ -143,8 +144,7 @@ const reducer = handleActions<ElasticsearchState>(
       ): ElasticsearchState => ({
         ...state,
         requesting: false,
-
-        errorMessage: action.error.data.error,
+        errorMessage: get(action, 'error.data.error', action.error),
       }),
     },
     [GET_MAPPINGS]: {
@@ -169,7 +169,8 @@ const reducer = handleActions<ElasticsearchState>(
       ): ElasticsearchState => ({
         ...state,
         requesting: false,
-        errorMessage: action.error.data.error,
+        errorMessage: get(action, 'error.data.error', action.error),
+        dataTypes: {}
       }),
     },
   },

--- a/server/routes/elasticsearch.ts
+++ b/server/routes/elasticsearch.ts
@@ -146,6 +146,6 @@ const getMapping = async (
     return { ok: true, response: { mappings: response } };
   } catch (err) {
     console.log('Anomaly detector - Unable to get mappings', err);
-    return { ok: false, error: err.message };
+    return { ok: false, error: err };
   }
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Community has requirements to create detector on top of remote cluster’s indices, refer to Github issue (https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/215). User can do this with create detector public API, but can’t choose/input remote cluster indices and its fields on Kibana.

Currently Elasticsearch doesn’t support listing indices on remote cluster, nor get index mapping.  So we just support remote cluster indices by allowing user input index and filed name manually. 

## Create/edit detector page
![Screen Shot 2020-06-24 at 10 12 59 PM](https://user-images.githubusercontent.com/49084640/85660365-6675b480-b66a-11ea-887c-af30eab61209.png)

## Edit feature page
![Screen Shot 2020-06-24 at 10 12 03 PM](https://user-images.githubusercontent.com/49084640/85660411-71304980-b66a-11ea-90e2-b4f943163901.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
