### PR TITLE
Add brace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "@elastic/charts": "^18.2.2",
     "babel-polyfill": "^6.26.0",
+    "brace": "^0.11.1",
     "eslint-plugin-cypress": "^2.11.1",
     "formik": "^1.5.8",
     "query-string": "^6.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2123,6 +2123,11 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
+  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
+
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds explicit dependency to `brace` library in `package.json`. This fixes the problem of binary Kibana not starting when installing the binary version of this plugin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
