### PR TITLE
Fix default filter query when creating detector

### DIFF
--- a/public/pages/createDetector/containers/utils/constant.ts
+++ b/public/pages/createDetector/containers/utils/constant.ts
@@ -24,7 +24,7 @@ export const INITIAL_VALUES: ADFormikValues = {
   filters: [],
   index: [],
   filterType: FILTER_TYPES.SIMPLE,
-  filterQuery: JSON.stringify({ query: { bool: { filter: [] } } }, null, 4),
+  filterQuery: JSON.stringify({ bool: { filter: [] } }, null, 4),
   detectionInterval: 10,
   windowDelay: 1,
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the default custom filter query. Before, there was an extra `query` field in the default JSON, which was throwing errors when trying to create the detector. This removes that extra field.

Before:
![Screen Shot 2020-06-30 at 9 22 03 AM](https://user-images.githubusercontent.com/62119629/86151180-42273700-bab3-11ea-84ac-393edd112cfb.png)

After:
![Screen Shot 2020-06-30 at 9 21 26 AM](https://user-images.githubusercontent.com/62119629/86151185-43f0fa80-bab3-11ea-8896-dabca8aa082b.png)

Notes:
- all UT pass
- confirmed custom filter functionality works


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
