### PR TITLE
Add missing feature alert if recent feature data is missing

### DIFF
--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -117,20 +117,24 @@ export const FeatureChart = (props: FeatureChartProps) => {
   const featureData = prepareDataForChart(props.featureData, props.dateRange);
 
   // return undefined if featureMissingDataPointAnnotationStartDate is missing
+  // OR it is even behind the specified date range
   const getFeatureMissingAnnotationDateRange = (
     dateRange: DateRange,
     featureMissingDataPointAnnotationStartDate?: number
   ) => {
-    if (!featureMissingDataPointAnnotationStartDate) {
-      return undefined;
+    if (
+      featureMissingDataPointAnnotationStartDate &&
+      dateRange.endDate > featureMissingDataPointAnnotationStartDate
+    ) {
+      return {
+        startDate: Math.max(
+          dateRange.startDate,
+          featureMissingDataPointAnnotationStartDate
+        ),
+        endDate: dateRange.endDate,
+      };
     }
-    return {
-      startDate: Math.max(
-        dateRange.startDate,
-        featureMissingDataPointAnnotationStartDate
-      ),
-      endDate: dateRange.endDate,
-    };
+    return undefined;
   };
 
   return (

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -22,8 +22,10 @@ import {
   Position,
   Settings,
   ScaleType,
+  LineAnnotation,
+  AnnotationDomainTypes,
 } from '@elastic/charts';
-import { EuiEmptyPrompt, EuiText, EuiLink, EuiButton } from '@elastic/eui';
+import { EuiText, EuiLink, EuiButton, EuiIcon } from '@elastic/eui';
 import React, { useState, Fragment } from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { useDelayedLoader } from '../../../../hooks/useDelayedLoader';
@@ -32,14 +34,15 @@ import {
   FeatureAttributes,
   DateRange,
   FEATURE_TYPE,
+  Schedule,
 } from '../../../../models/interfaces';
 import { darkModeEnabled } from '../../../../utils/kibanaUtils';
-import { prepareDataForChart } from '../../../utils/anomalyResultUtils';
-import { CodeModal } from '../../../DetectorConfig/components/CodeModal/CodeModal';
 import {
-  CHART_FIELDS,
-  FEATURE_CHART_THEME,
-} from '../../utils/constants';
+  prepareDataForChart,
+  getFeatureMissingDataAnnotations,
+} from '../../../utils/anomalyResultUtils';
+import { CodeModal } from '../../../DetectorConfig/components/CodeModal/CodeModal';
+import { CHART_FIELDS, FEATURE_CHART_THEME } from '../../utils/constants';
 
 interface FeatureChartProps {
   feature: FeatureAttributes;
@@ -54,6 +57,10 @@ interface FeatureChartProps {
   featureDataSeriesName: string;
   edit?: boolean;
   onEdit?(): void;
+  detectorInterval: Schedule;
+  showFeatureMissingDataPointAnnotation?: boolean;
+  detectorEnabledTime?: number;
+  rawFeatureData: FeatureAggregationData[];
 }
 const getDisabledChartBackground = () =>
   darkModeEnabled() ? '#25262E' : '#F0F0F0';
@@ -108,6 +115,24 @@ export const FeatureChart = (props: FeatureChartProps) => {
   );
 
   const featureData = prepareDataForChart(props.featureData, props.dateRange);
+
+  // return undefined if featureMissingDataPointAnnotationStartDate is missing
+  const getFeatureMissingAnnotationDateRange = (
+    dateRange: DateRange,
+    featureMissingDataPointAnnotationStartDate?: number
+  ) => {
+    if (!featureMissingDataPointAnnotationStartDate) {
+      return undefined;
+    }
+    return {
+      startDate: Math.max(
+        dateRange.startDate,
+        featureMissingDataPointAnnotationStartDate
+      ),
+      endDate: dateRange.endDate,
+    };
+  };
+
   return (
     <ContentPanel
       title={
@@ -125,72 +150,86 @@ export const FeatureChart = (props: FeatureChartProps) => {
         props.edit ? <EuiButton onClick={props.onEdit}>Edit</EuiButton> : null
       }
     >
-      {props.featureData.length > 0 ? (
-        <div
-          style={{
-            height: '200px',
-            width: '100%',
-            opacity: showLoader ? 0.2 : 1,
-          }}
-        >
-          <Chart>
-            <Settings
-              showLegend
-              showLegendExtra={false}
-              //TODO: research more why only set this old property will work.
-              showLegendDisplayValue={false}
-              legendPosition={Position.Right}
-              theme={FEATURE_CHART_THEME}
-            />
-            {props.feature.featureEnabled ? (
-              <RectAnnotation
-                dataValues={props.annotations || []}
-                id="annotations"
-                style={{
-                  stroke: darkModeEnabled() ? 'red' : '#D5DBDB',
-                  strokeWidth: 1,
-                  opacity: 0.8,
-                  fill: darkModeEnabled() ? 'red' : '#D5DBDB',
-                }}
-              />
-            ) : null}
-            <Axis
-              id="left"
-              title={props.featureDataSeriesName}
-              position="left"
-              showGridLines
-            />
-            <Axis id="bottom" position="bottom" tickFormat={timeFormatter} />
-            <LineSeries
-              id="featureData"
-              name={props.featureDataSeriesName}
-              xScaleType={ScaleType.Time}
-              yScaleType={ScaleType.Linear}
-              xAccessor={CHART_FIELDS.PLOT_TIME}
-              yAccessors={[CHART_FIELDS.DATA]}
-              data={featureData}
-            />
-          </Chart>
-          {showCustomExpression ? (
-            <CodeModal
-              title={props.feature.featureName}
-              subtitle="Custom expression"
-              code={JSON.stringify(props.feature.aggregationQuery, null, 4)}
-              getModalVisibilityChange={() => true}
-              closeModal={() => setShowCustomExpression(false)}
+      <div
+        style={{
+          height: '200px',
+          width: '100%',
+          opacity: showLoader ? 0.2 : 1,
+        }}
+      >
+        <Chart>
+          <Settings
+            showLegend
+            showLegendExtra={false}
+            //TODO: research more why only set this old property will work.
+            showLegendDisplayValue={false}
+            legendPosition={Position.Right}
+            theme={FEATURE_CHART_THEME}
+          />
+          {props.feature.featureEnabled ? (
+            <RectAnnotation
+              dataValues={props.annotations || []}
+              id="annotations"
+              style={{
+                stroke: darkModeEnabled() ? 'red' : '#D5DBDB',
+                strokeWidth: 1,
+                opacity: 0.8,
+                fill: darkModeEnabled() ? 'red' : '#D5DBDB',
+              }}
             />
           ) : null}
-        </div>
-      ) : (
-        <EuiEmptyPrompt
-          style={{ maxWidth: '45em' }}
-          body={
-            <EuiText>
-              <p>{`There is no data to display for feature ${props.feature.featureName}`}</p>
-            </EuiText>
-          }
-        />
-      )}
+          {props.feature.featureEnabled &&
+          props.showFeatureMissingDataPointAnnotation &&
+          props.detectorEnabledTime
+            ? [
+                <LineAnnotation
+                  id="featureMissingAnnotations"
+                  domainType={AnnotationDomainTypes.XDomain}
+                  dataValues={getFeatureMissingDataAnnotations(
+                    props.showFeatureMissingDataPointAnnotation
+                      ? props.rawFeatureData
+                      : props.featureData,
+                    props.detectorInterval.interval,
+                    getFeatureMissingAnnotationDateRange(
+                      props.dateRange,
+                      props.detectorEnabledTime
+                    ),
+                    props.dateRange
+                  )}
+                  marker={<EuiIcon type="alert" />}
+                  style={{
+                    line: { stroke: 'red', strokeWidth: 1, opacity: 0.8 },
+                  }}
+                />,
+              ]
+            : null}
+          <Axis
+            id="left"
+            title={props.featureDataSeriesName}
+            position="left"
+            showGridLines
+          />
+          <Axis id="bottom" position="bottom" tickFormat={timeFormatter} />
+          <LineSeries
+            id="featureData"
+            name={props.featureDataSeriesName}
+            xScaleType={ScaleType.Time}
+            yScaleType={ScaleType.Linear}
+            xAccessor={CHART_FIELDS.PLOT_TIME}
+            yAccessors={[CHART_FIELDS.DATA]}
+            data={featureData}
+          />
+        </Chart>
+        {showCustomExpression ? (
+          <CodeModal
+            title={props.feature.featureName}
+            subtitle="Custom expression"
+            code={JSON.stringify(props.feature.aggregationQuery, null, 4)}
+            getModalVisibilityChange={() => true}
+            closeModal={() => setShowCustomExpression(false)}
+          />
+        ) : null}
+      </div>
     </ContentPanel>
   );
 };

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -64,7 +64,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
       props.detector.enabledTime &&
       props.isFeatureDataMissing ? (
         <EuiCallOut
-          title={`Show missing data only after last enabled time: ${moment(
+          title={`Missing data is only shown since last enabled time: ${moment(
             props.detector.enabledTime
           ).format('MM/DD/YY h:mm A')}`}
           color={'warning'}

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -64,7 +64,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
       props.detector.enabledTime &&
       props.isFeatureDataMissing ? (
         <EuiCallOut
-          title={`Show missing data only after last enable time: ${moment(
+          title={`Show missing data only after last enabled time: ${moment(
             props.detector.enabledTime
           ).format('MM/DD/YY h:mm A')}`}
           color={'warning'}

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -15,7 +15,13 @@
 
 import React from 'react';
 import { get } from 'lodash';
-import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiTitle,
+  EuiSpacer,
+  EuiCallOut,
+} from '@elastic/eui';
 import { FeatureChart } from '../components/FeatureChart/FeatureChart';
 import {
   Detector,
@@ -26,6 +32,7 @@ import {
 } from '../../../models/interfaces';
 import { NoFeaturePrompt } from '../components/FeatureChart/NoFeaturePrompt';
 import { focusOnFeatureAccordion } from '../../EditFeatures/utils/helpers';
+import moment from 'moment';
 
 interface FeatureBreakDownProps {
   title?: string;
@@ -37,6 +44,7 @@ interface FeatureBreakDownProps {
   featureDataSeriesName: string;
   showFeatureMissingDataPointAnnotation?: boolean;
   rawAnomalyResults?: Anomalies;
+  isFeatureDataMissing?: boolean;
 }
 
 export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
@@ -52,7 +60,18 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : null}
-
+      {props.showFeatureMissingDataPointAnnotation &&
+      props.detector.enabledTime &&
+      props.isFeatureDataMissing ? (
+        <EuiCallOut
+          title={`Show missing data only after last enable time: ${moment(
+            props.detector.enabledTime
+          ).format('MM/DD/YY h:mm A')}`}
+          color={'warning'}
+          iconType={'alert'}
+          style={{ marginBottom: '20px' }}
+        />
+      ) : null}
       {get(props, 'detector.featureAttributes', []).map(
         (feature: FeatureAttributes, index: number) => (
           <React.Fragment key={`${feature.featureName}-${feature.featureId}`}>

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -35,6 +35,8 @@ interface FeatureBreakDownProps {
   isLoading: boolean;
   dateRange: DateRange;
   featureDataSeriesName: string;
+  showFeatureMissingDataPointAnnotation?: boolean;
+  rawAnomalyResults?: Anomalies;
 }
 
 export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
@@ -46,7 +48,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
             <EuiTitle size="s" className="preview-title">
               <h4>{props.title}</h4>
             </EuiTitle>
-          <EuiSpacer size="s" />
+            <EuiSpacer size="s" />
           </EuiFlexItem>
         </EuiFlexGroup>
       ) : null}
@@ -59,6 +61,11 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               featureData={get(
                 props,
                 `anomaliesResult.featureData.${feature.featureId}`,
+                []
+              )}
+              rawFeatureData={get(
+                props,
+                `rawAnomalyResults.featureData.${feature.featureId}`,
                 []
               )}
               annotations={props.annotations}
@@ -97,8 +104,13 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               onEdit={() => {
                 focusOnFeatureAccordion(index);
               }}
+              detectorInterval={props.detector.detectionInterval.period}
+              showFeatureMissingDataPointAnnotation={
+                props.showFeatureMissingDataPointAnnotation
+              }
+              detectorEnabledTime={props.detector.enabledTime}
             />
-            <EuiSpacer size='m'/>
+            <EuiSpacer size="m" />
           </React.Fragment>
         )
       )}

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -22,8 +22,7 @@ import {
   EuiLoadingSpinner,
 } from '@elastic/eui';
 import moment from 'moment';
-import { useSelector, useDispatch } from 'react-redux';
-import { AppState } from 'public/redux/reducers';
+import { useDispatch } from 'react-redux';
 import {
   AnomalyData,
   Detector,
@@ -33,13 +32,13 @@ import {
   Anomalies,
 } from '../../../models/interfaces';
 import {
-  getAnomalyResultsWithDateRange,
   filterWithDateRange,
   getAnomalySummaryQuery,
   getBucketizedAnomalyResultsQuery,
   parseBucketizedAnomalyResults,
   parseAnomalySummary,
   parsePureAnomalies,
+  buildParamsForGetAnomalyResultsWithDateRange,
 } from '../../utils/anomalyResultUtils';
 import { get } from 'lodash';
 import { AnomalyResultsTable } from './AnomalyResultsTable';
@@ -51,6 +50,7 @@ import { searchES } from '../../../redux/reducers/elasticsearch';
 import { MIN_IN_MILLI_SECS } from '../../../../server/utils/constants';
 import { INITIAL_ANOMALY_SUMMARY } from '../../AnomalyCharts/utils/constants';
 import { MAX_ANOMALIES } from '../../../utils/constants';
+import { getDetectorResults } from '../../../redux/reducers/anomalyResults';
 
 interface AnomalyHistoryProps {
   detector: Detector;
@@ -60,9 +60,8 @@ interface AnomalyHistoryProps {
 
 export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   const dispatch = useDispatch();
-  const isLoading = useSelector(
-    (state: AppState) => state.anomalyResults.requesting
-  );
+
+  const [isLoading, setIsLoading] = useState(false);
   const initialStartDate = moment().subtract(7, 'days');
   const initialEndDate = moment();
   const [dateRange, setDateRange] = useState<DateRange>({
@@ -124,30 +123,68 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         );
       } finally {
         setIsLoadingAnomalyResults(false);
+        fetchRawAnomalyResults(false);
       }
     }
 
     if (
       dateRange.endDate - dateRange.startDate >
-      get(props.detector, 'detectionInterval.period.interval', 1) *
-        MIN_IN_MILLI_SECS *
-        MAX_ANOMALIES
+      detectorInterval * MIN_IN_MILLI_SECS * MAX_ANOMALIES
     ) {
       getBucketizedAnomalyResults();
     } else {
       setBucketizedAnomalyResults(undefined);
-      getAnomalyResultsWithDateRange(
-        dispatch,
-        dateRange.startDate,
-        dateRange.endDate,
-        props.detector.id
-      );
+      fetchRawAnomalyResults(true);
     }
   }, [dateRange]);
 
-  const atomicAnomalyResults = useSelector(
-    (state: AppState) => state.anomalyResults
+  const detectorInterval = get(
+    props.detector,
+    'detectionInterval.period.interval',
+    1
   );
+
+  const fetchRawAnomalyResults = async (
+    shouldSetAtomicAnomalyResults: boolean
+  ) => {
+    if (shouldSetAtomicAnomalyResults) {
+      setIsLoading(true);
+    }
+
+    try {
+      const params = buildParamsForGetAnomalyResultsWithDateRange(
+        dateRange.startDate - detectorInterval * MIN_IN_MILLI_SECS,
+        dateRange.endDate
+      );
+      const detectorResultResponse = await dispatch(
+        getDetectorResults(props.detector.id, params)
+      );
+      const anomaliesData = get(detectorResultResponse, 'data.response', []);
+
+      if (shouldSetAtomicAnomalyResults) {
+        setAtomicAnomalyResults({
+          anomalies: get(anomaliesData, 'results', []),
+          featureData: get(anomaliesData, 'featureResults', []),
+        });
+      }
+      setRawAnomalyResults({
+        anomalies: get(anomaliesData, 'results', []),
+        featureData: get(anomaliesData, 'featureResults', []),
+      });
+    } catch (err) {
+      console.error(
+        `Failed to get atomic anomaly results for ${props.detector.id}`,
+        err
+      );
+    } finally {
+      if (shouldSetAtomicAnomalyResults) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  const [atomicAnomalyResults, setAtomicAnomalyResults] = useState<Anomalies>();
+  const [rawAnomalyResults, setRawAnomalyResults] = useState<Anomalies>();
 
   const anomalyResults = bucketizedAnomalyResults
     ? bucketizedAnomalyResults
@@ -224,7 +261,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         dateRange={dateRange}
         onDateRangeChange={handleDateRangeChange}
         onZoomRangeChange={handleZoomChange}
-        anomalies={anomalyResults.anomalies}
+        anomalies={anomalyResults ? anomalyResults.anomalies : []}
         bucketizedAnomalies={bucketizedAnomalyResults !== undefined}
         anomalySummary={bucketizedAnomalySummary}
         isLoading={isLoading || isLoadingAnomalyResults}
@@ -259,20 +296,24 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                 detector={props.detector}
                 // @ts-ignore
                 anomaliesResult={anomalyResults}
+                rawAnomalyResults={rawAnomalyResults}
                 annotations={annotations}
                 isLoading={isLoading}
                 dateRange={zoomRange}
                 featureDataSeriesName="Feature output"
+                showFeatureMissingDataPointAnnotation={true}
               />
             ) : (
               <AnomalyResultsTable
                 anomalies={
                   bucketizedAnomalyResults === undefined
-                    ? filterWithDateRange(
-                        anomalyResults.anomalies,
-                        zoomRange,
-                        'plotTime'
-                      )
+                    ? anomalyResults
+                      ? filterWithDateRange(
+                          anomalyResults.anomalies,
+                          zoomRange,
+                          'plotTime'
+                        )
+                      : []
                     : pureAnomalies
                 }
               />

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -39,6 +39,7 @@ import {
   parseAnomalySummary,
   parsePureAnomalies,
   buildParamsForGetAnomalyResultsWithDateRange,
+  FEATURE_DATA_CHECK_WINDOW_OFFSET,
 } from '../../utils/anomalyResultUtils';
 import { get } from 'lodash';
 import { AnomalyResultsTable } from './AnomalyResultsTable';
@@ -56,6 +57,7 @@ interface AnomalyHistoryProps {
   detector: Detector;
   monitor: Monitor | undefined;
   createFeature(): void;
+  isFeatureDataMissing?: boolean;
 }
 
 export const AnomalyHistory = (props: AnomalyHistoryProps) => {
@@ -153,7 +155,10 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
 
     try {
       const params = buildParamsForGetAnomalyResultsWithDateRange(
-        dateRange.startDate - detectorInterval * MIN_IN_MILLI_SECS,
+        dateRange.startDate -
+          FEATURE_DATA_CHECK_WINDOW_OFFSET *
+            detectorInterval *
+            MIN_IN_MILLI_SECS,
         dateRange.endDate
       );
       const detectorResultResponse = await dispatch(
@@ -301,7 +306,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                 isLoading={isLoading}
                 dateRange={zoomRange}
                 featureDataSeriesName="Feature output"
-                showFeatureMissingDataPointAnnotation={true}
+                showFeatureMissingDataPointAnnotation={props.detector.enabled}
+                isFeatureDataMissing={props.isFeatureDataMissing}
               />
             ) : (
               <AnomalyResultsTable

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -55,6 +55,7 @@ import {
   buildParamsForGetAnomalyResultsWithDateRange,
   getFeatureMissingSeverities,
   getFeatureDataMissingMessageAndActionItem,
+  FEATURE_DATA_CHECK_WINDOW_OFFSET,
 } from '../../utils/anomalyResultUtils';
 import { getDetectorResults } from '../../../redux/reducers/anomalyResults';
 
@@ -165,7 +166,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       startDate: Math.max(
         moment()
           .subtract(
-            (FEATURE_DATA_POINTS_WINDOW + 1) * detectorIntervalInMin,
+            (FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET) *
+              detectorIntervalInMin,
             'minutes'
           )
           .valueOf(),
@@ -184,7 +186,6 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       const detectorResultResponse = await dispatch(
         getDetectorResults(detectorId, params)
       );
-
       const featuresData = get(
         detectorResultResponse,
         'data.response.featureResults',
@@ -318,8 +319,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               isDetectorFailed ? (
                 <Fragment>
                   {isDetectorUpdated ||
-                  (isDetectorInitializing &&
-                    isDetectorMissingData != undefined) ||
+                  ((isDetectorInitializing || isDetectorRunning) &&
+                    isDetectorMissingData) ||
                   isDetectorFailed ? (
                     <EuiCallOut
                       title={getCalloutTitle()}
@@ -366,6 +367,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                     createFeature={() =>
                       props.history.push(`/detectors/${detectorId}/features`)
                     }
+                    isFeatureDataMissing={isDetectorMissingData}
                   />
                 </Fragment>
               ) : detector ? (

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -159,7 +159,10 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     : undefined;
 
   const isInitializingNormally =
-    isDetectorInitializing && !isInitOvertime && !isDetectorMissingData;
+    isDetectorInitializing &&
+    !isInitOvertime &&
+    isDetectorMissingData != undefined &&
+    !isDetectorMissingData;
 
   const checkLatestFeatureDataPoints = async () => {
     const featureDataPointsRange = {
@@ -319,8 +322,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               isDetectorFailed ? (
                 <Fragment>
                   {isDetectorUpdated ||
-                  ((isDetectorInitializing || isDetectorRunning) &&
-                    isDetectorMissingData) ||
+                  isDetectorMissingData ||
+                  isInitializingNormally ||
                   isDetectorFailed ? (
                     <EuiCallOut
                       title={getCalloutTitle()}

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -23,13 +23,18 @@ import {
   EuiButton,
 } from '@elastic/eui';
 import { get } from 'lodash';
-import React, { useEffect, Fragment } from 'react';
+import React, { useEffect, Fragment, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 //@ts-ignore
 import chrome from 'ui/chrome';
 import { AppState } from '../../../redux/reducers';
-import { BREADCRUMBS, DETECTOR_STATE } from '../../../utils/constants';
+import {
+  BREADCRUMBS,
+  DETECTOR_STATE,
+  FEATURE_DATA_POINTS_WINDOW,
+  MISSING_FEATURE_DATA_SEVERITY,
+} from '../../../utils/constants';
 import { AnomalyResultsLiveChart } from './AnomalyResultsLiveChart';
 import { AnomalyHistory } from './AnomalyHistory';
 import { DetectorStateDetails } from './DetectorStateDetails';
@@ -43,6 +48,15 @@ import {
 import { getDetector } from '../../../redux/reducers/ad';
 import { MIN_IN_MILLI_SECS } from '../../../../server/utils/constants';
 import { getInitFailureMessageAndActionItem } from '../../DetectorDetail/utils/helpers';
+import moment from 'moment';
+import { DateRange } from '../../../models/interfaces';
+import {
+  getFeatureDataPointsForDetector,
+  buildParamsForGetAnomalyResultsWithDateRange,
+  getFeatureMissingSeverities,
+  getFeatureDataMissingMessageAndActionItem,
+} from '../../utils/anomalyResultUtils';
+import { getDetectorResults } from '../../../redux/reducers/anomalyResults';
 
 interface AnomalyResultsProps extends RouteComponentProps {
   detectorId: string;
@@ -78,6 +92,20 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     }
   }, [detector]);
 
+  useEffect(() => {
+    if (
+      detector &&
+      (detector.curState === DETECTOR_STATE.INIT ||
+        detector.curState === DETECTOR_STATE.RUNNING)
+    ) {
+      checkLatestFeatureDataPoints();
+      const id = setInterval(checkLatestFeatureDataPoints, MIN_IN_MILLI_SECS);
+      return () => {
+        clearInterval(id);
+      };
+    }
+  }, [detector]);
+
   const monitors = useSelector((state: AppState) => state.alerting.monitors);
   const monitor = get(monitors, `${detectorId}.0`);
 
@@ -105,13 +133,178 @@ export function AnomalyResults(props: AnomalyResultsProps) {
   const initErrorMessage = get(initDetails, INIT_ERROR_MESSAGE_FIELD, '');
   const initActionItem = get(initDetails, INIT_ACTION_ITEM_FIELD, '');
 
-  const isInitializingNormally = isDetectorInitializing && !isInitOvertime;
-
   const isDetectorFailed =
     detector &&
     (detector.curState === DETECTOR_STATE.INIT_FAILURE ||
       detector.curState === DETECTOR_STATE.UNEXPECTED_FAILURE);
 
+  const detectorIntervalInMin = get(
+    detector,
+    'detectionInterval.period.interval',
+    1
+  );
+
+  const [featureMissingSeverity, setFeatureMissingSeverity] = useState<
+    MISSING_FEATURE_DATA_SEVERITY
+  >();
+
+  const [featureNamesAtHighSev, setFeatureNamesAtHighSev] = useState(
+    [] as string[]
+  );
+
+  const isDetectorMissingData = featureMissingSeverity
+    ? (isDetectorInitializing || isDetectorRunning) &&
+      featureMissingSeverity > MISSING_FEATURE_DATA_SEVERITY.GREEN
+    : undefined;
+
+  const isInitializingNormally =
+    isDetectorInitializing && !isInitOvertime && !isDetectorMissingData;
+
+  const checkLatestFeatureDataPoints = async () => {
+    const featureDataPointsRange = {
+      startDate: Math.max(
+        moment()
+          .subtract(
+            (FEATURE_DATA_POINTS_WINDOW + 1) * detectorIntervalInMin,
+            'minutes'
+          )
+          .valueOf(),
+        //@ts-ignore
+        detector.enabledTime
+      ),
+      endDate: moment().valueOf(),
+    } as DateRange;
+
+    const params = buildParamsForGetAnomalyResultsWithDateRange(
+      featureDataPointsRange.startDate,
+      featureDataPointsRange.endDate
+    );
+
+    try {
+      const detectorResultResponse = await dispatch(
+        getDetectorResults(detectorId, params)
+      );
+
+      const featuresData = get(
+        detectorResultResponse,
+        'data.response.featureResults',
+        []
+      );
+      const featureDataPoints = getFeatureDataPointsForDetector(
+        detector,
+        featuresData,
+        detectorIntervalInMin,
+        featureDataPointsRange
+      );
+
+      const featureMissingSeveritiesMap = getFeatureMissingSeverities(
+        featureDataPoints
+      );
+      let highestSeverity = MISSING_FEATURE_DATA_SEVERITY.GREEN;
+      let featuresAtHighestSev = [] as string[];
+      featureMissingSeveritiesMap.forEach((featureNames, severity, map) => {
+        if (severity > highestSeverity) {
+          highestSeverity = severity;
+          featuresAtHighestSev = featureNames;
+        }
+      });
+
+      setFeatureMissingSeverity(highestSeverity);
+      setFeatureNamesAtHighSev(featuresAtHighestSev);
+    } catch (err) {
+      console.error(
+        `Failed to get anomaly results for ${detectorId} during getting latest feature data points`,
+        err
+      );
+    }
+  };
+
+  const getCalloutTitle = () => {
+    if (isDetectorUpdated) {
+      return 'The detector configuration has changed since it was last stopped.';
+    }
+    if (isDetectorMissingData) {
+      return get(
+        getFeatureDataMissingMessageAndActionItem(
+          featureMissingSeverity,
+          featureNamesAtHighSev
+        ),
+        'message',
+        ''
+      );
+    }
+    if (isInitializingNormally) {
+      return 'The detector is being initialized based on the latest configuration changes.';
+    }
+    if (isInitOvertime) {
+      return `Detector initialization is not complete because ${initErrorMessage}.`;
+    }
+    if (isDetectorFailed) {
+      return `The detector is not initialized because ${get(
+        getInitFailureMessageAndActionItem(
+          //@ts-ignore
+          detector.stateError
+        ),
+        'cause',
+        ''
+      )}.`;
+    }
+  };
+  const getCalloutColor = () => {
+    if (
+      isDetectorFailed ||
+      featureMissingSeverity === MISSING_FEATURE_DATA_SEVERITY.RED
+    ) {
+      return 'danger';
+    }
+    if (
+      isInitOvertime ||
+      isDetectorUpdated ||
+      featureMissingSeverity === MISSING_FEATURE_DATA_SEVERITY.YELLOW
+    ) {
+      return 'warning';
+    }
+    if (isInitializingNormally) {
+      return 'primary';
+    }
+  };
+
+  const getCalloutContent = () => {
+    return isDetectorUpdated ? (
+      <p>
+        Restart the detector to see accurate anomalies based on configuration
+        changes.
+      </p>
+    ) : isDetectorMissingData ? (
+      <p>
+        {get(
+          getFeatureDataMissingMessageAndActionItem(
+            featureMissingSeverity,
+            featureNamesAtHighSev
+          ),
+          'actionItem',
+          ''
+        )}
+      </p>
+    ) : isInitializingNormally ? (
+      <p>
+        After the initialization is complete, you will see the anomaly results
+        based on your latest configuration changes.
+      </p>
+    ) : isInitOvertime ? (
+      <p>{`${initActionItem}`}</p>
+    ) : (
+      // detector has failure
+      <p>{`${get(
+        getInitFailureMessageAndActionItem(
+          //@ts-ignore
+          detector.stateError
+        ),
+        'actionItem',
+        ''
+      )}`}</p>
+    );
+  };
   return (
     <Fragment>
       <EuiPage style={{ marginTop: '16px', paddingTop: '0px' }}>
@@ -125,70 +318,29 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               isDetectorFailed ? (
                 <Fragment>
                   {isDetectorUpdated ||
-                  isDetectorInitializing ||
+                  (isDetectorInitializing &&
+                    isDetectorMissingData != undefined) ||
                   isDetectorFailed ? (
                     <EuiCallOut
-                      title={
-                        isDetectorUpdated
-                          ? 'The detector configuration has changed since it was last stopped.'
-                          : isInitializingNormally
-                          ? 'The detector is being initialized based on the latest configuration changes.'
-                          : isInitOvertime
-                          ? `Detector initialization is not complete because ${initErrorMessage}.`
-                          : // detector has failure
-                            `The detector is not initialized because ${get(
-                              getInitFailureMessageAndActionItem(
-                                //@ts-ignore
-                                detector.stateError
-                              ),
-                              'cause',
-                              ''
-                            )}.`
-                      }
-                      color={
-                        isInitializingNormally
-                          ? 'primary'
-                          : isInitOvertime || isDetectorUpdated
-                          ? 'warning'
-                          : // detector has failure
-                            'danger'
-                      }
+                      title={getCalloutTitle()}
+                      color={getCalloutColor()}
                       iconType={isInitializingNormally ? 'iInCircle' : 'alert'}
                       style={{ marginBottom: '20px' }}
                     >
-                      {isDetectorUpdated ? (
-                        <p>
-                          Restart the detector to see accurate anomalies based
-                          on configuration changes.
-                        </p>
-                      ) : isInitializingNormally ? (
-                        <p>
-                          After the initialization is complete, you will see the
-                          anomaly results based on your latest configuration
-                          changes.
-                        </p>
-                      ) : isInitOvertime ? (
-                        <p>{`${initActionItem}`}</p>
-                      ) : (
-                        // detector has failure
-                        <p>{`${get(
-                          getInitFailureMessageAndActionItem(
-                            //@ts-ignore
-                            detector.stateError
-                          ),
-                          'actionItem',
-                          ''
-                        )}`}</p>
-                      )}
+                      {getCalloutContent()}
                       <EuiButton
                         onClick={props.onSwitchToConfiguration}
                         color={
-                          isInitializingNormally
-                            ? 'primary'
-                            : isInitOvertime || isDetectorUpdated
+                          featureMissingSeverity ===
+                            MISSING_FEATURE_DATA_SEVERITY.RED ||
+                          isDetectorFailed
+                            ? 'danger'
+                            : isInitOvertime ||
+                              isDetectorUpdated ||
+                              featureMissingSeverity ===
+                                MISSING_FEATURE_DATA_SEVERITY.YELLOW
                             ? 'warning'
-                            : // detector has failure
-                              'danger'
+                            : 'primary'
                         }
                         style={{ marginRight: '8px' }}
                       >

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -779,17 +779,21 @@ export const getFeatureDataMissingMessageAndActionItem = (
   switch (featureMissingSev) {
     case MISSING_FEATURE_DATA_SEVERITY.YELLOW:
       return {
-        message: `Recent data is missing for feature ${featuresWithMissingData.join(
+        message: `Recent data is missing for feature${
+          featuresWithMissingData.length > 1 ? 's' : ''
+        }: ${featuresWithMissingData.join(
           ', '
-        )}, anomaly result is missing at the same time because of that.`,
+        )}. So, anomaly result is missing during this time.`,
         actionItem:
           'Make sure your data is ingested correctly. See the feature data shown below for more details.',
       };
     case MISSING_FEATURE_DATA_SEVERITY.RED:
       return {
-        message: `Data ingestion is not going well for feature ${featuresWithMissingData.join(
+        message: `Data is not being ingested correctly for feature${
+          featuresWithMissingData.length > 1 ? 's' : ''
+        }: ${featuresWithMissingData.join(
           ', '
-        )}, anomaly result is missing at the same time because of that.`,
+        )}. So, anomaly result is missing during this time.`,
         actionItem: `${DETECTOR_INIT_FAILURES.NO_TRAINING_DATA.actionItem} See the feature data shown below for more details.`,
       };
     default:

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -123,7 +123,7 @@ const calculateSampleWindowsWithMaxDataPoints = (
   );
   for (
     let currentTime = dateRange.startDate;
-    currentTime < dateRange.endDate - windowSizeinMilliSec;
+    currentTime < dateRange.endDate;
     currentTime += windowSizeinMilliSec
   ) {
     resultSampleWindows.push({
@@ -531,6 +531,8 @@ export type FeatureDataPoint = {
   endTime: number;
 };
 
+export const FEATURE_DATA_CHECK_WINDOW_OFFSET = 2;
+
 export const getFeatureDataPoints = (
   featureData: FeatureAggregationData[],
   interval: number,
@@ -549,7 +551,11 @@ export const getFeatureDataPoints = (
   for (
     let currentTime = getRoundedTimeInMin(dateRange.startDate);
     currentTime <
-    getRoundedTimeInMin(dateRange.endDate - interval * MIN_IN_MILLI_SECS);
+    // skip checking for latest interval as data point for it may not be delivered in time
+    getRoundedTimeInMin(
+      dateRange.endDate -
+        FEATURE_DATA_CHECK_WINDOW_OFFSET * interval * MIN_IN_MILLI_SECS
+    );
     currentTime += interval * MIN_IN_MILLI_SECS
   ) {
     const isExisting = findTimeExistsInWindow(
@@ -702,7 +708,6 @@ export const getFeatureDataPointsForDetector = (
       interval,
       dateRange
     );
-
     featureDataPointsForDetector = {
       ...featureDataPointsForDetector,
       [feature.featureName]: featureDataPoints,

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -546,7 +546,7 @@ export const getFeatureDataPoints = (
   const existingTimes = isEmpty(featureData)
     ? []
     : featureData
-        .map(feature => getFloorPlotTime(feature.startTime))
+        .map(feature => getRoundedTimeInMin(feature.startTime))
         .filter(featureTime => featureTime != undefined);
   for (
     let currentTime = getRoundedTimeInMin(dateRange.startDate);
@@ -579,10 +579,28 @@ const findTimeExistsInWindow = (
   startTime: number,
   endTime: number
 ): boolean => {
-  const result = timestamps.filter(
-    timestamp => timestamp >= startTime && timestamp < endTime
-  );
-  return !isEmpty(result);
+  // timestamps is in desc order
+  let result = false;
+  if (isEmpty(timestamps)) {
+    return result;
+  }
+
+  let left = 0;
+  let right = timestamps.length - 1;
+  while (left <= right) {
+    let middle = Math.floor((right + left) / 2);
+    if (timestamps[middle] >= startTime && timestamps[middle] < endTime) {
+      result = true;
+      break;
+    }
+    if (timestamps[middle] < startTime) {
+      right = middle - 1;
+    }
+    if (timestamps[middle] >= endTime) {
+      left = middle + 1;
+    }
+  }
+  return result;
 };
 
 const getRoundedTimeInMin = (timestamp: number): number => {

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -716,19 +716,19 @@ export const getFeatureMissingSeverities = (featuresDataPoint: {
 }): Map<MISSING_FEATURE_DATA_SEVERITY, string[]> => {
   const featureMissingSeverities = new Map();
 
-  for (const [featureName, featureDatePoints] of Object.entries(
+  for (const [featureName, featureDataPoints] of Object.entries(
     featuresDataPoint
   )) {
     // all feature data points should have same length
     let featuresWithMissingData = [] as string[];
-    if (featureDatePoints.length <= 1) {
+    if (featureDataPoints.length <= 1) {
       // return empty map
       return featureMissingSeverities;
     }
     if (
-      featureDatePoints.length === 2 &&
-      featureDatePoints[0].isMissing &&
-      featureDatePoints[1].isMissing
+      featureDataPoints.length === 2 &&
+      featureDataPoints[0].isMissing &&
+      featureDataPoints[1].isMissing
     ) {
       if (featureMissingSeverities.has(MISSING_FEATURE_DATA_SEVERITY.YELLOW)) {
         featuresWithMissingData = featureMissingSeverities.get(
@@ -744,7 +744,7 @@ export const getFeatureMissingSeverities = (featuresDataPoint: {
     }
 
     const orderedFeatureDataPoints = orderBy(
-      featureDatePoints,
+      featureDataPoints,
       // sort by plot time in desc order
       dataPoint => get(dataPoint, 'plotTime', 0),
       SORT_DIRECTION.DESC

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -603,7 +603,7 @@ const sampleFeatureMissingDataPoints = (
     if (sampledDataPoint) {
       sampledResults.push({
         ...sampledDataPoint,
-        startTime: Math.max(timeWindow.startDate, sampledDataPoint.startTime),
+        startTime: Math.min(timeWindow.startDate, sampledDataPoint.startTime),
         endTime: Math.max(timeWindow.endDate, sampledDataPoint.endTime),
       } as FeatureDataPoint);
     }

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -65,3 +65,14 @@ export const NAME_REGEX = RegExp('^[a-zA-Z0-9._-]+$');
 
 //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java#L186
 export const SHINGLE_SIZE = 8;
+
+export const FEATURE_DATA_POINTS_WINDOW = 3;
+
+export enum MISSING_FEATURE_DATA_SEVERITY {
+  // user attention not needed
+  GREEN = '0',
+  // needs user attention
+  YELLOW = '1',
+  // needs user attention and action
+  RED = '2',
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing feature alert if recent feature data is missing

If latest 2 feature data points of any feature are missing, we show yellow warning like below
![Screen Shot 2020-07-06 at 10 22 20 PM](https://user-images.githubusercontent.com/59710443/86818641-79f62780-c03b-11ea-8915-e77fec124391.png)

If latest 3 feature data points of any feature are missing, we show red alert below:
![Screen Shot 2020-07-07 at 10 21 11 AM](https://user-images.githubusercontent.com/59710443/86818774-a27e2180-c03b-11ea-9872-19b153286663.png)


Regardless of yellow or red alert, as long as there exists missing feature data, there is annotation on the feature chart. 

![Screen Shot 2020-07-06 at 10 25 17 PM](https://user-images.githubusercontent.com/59710443/86818937-dce7be80-c03b-11ea-903b-599a0b94494e.png)

_Meanwhile, I will check with tech writer on wording change_ >> Done

When data point is missing, below is shown:
![Screen Shot 2020-07-09 at 2 44 39 PM](https://user-images.githubusercontent.com/59710443/87103162-20dbee80-c209-11ea-9d54-f63454938735.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
