### PR TITLE
Try to fix failed E2E test workflow

### DIFF
--- a/.cypress/integration/ad/workflow/create_detector.spec.ts
+++ b/.cypress/integration/ad/workflow/create_detector.spec.ts
@@ -24,12 +24,16 @@ context('Create detector', () => {
     cy.contains('h1', 'Create detector');
 
     const detectorName = 'detector-name';
-    cy.get('input[name="detectorName"]').type(detectorName, { force: true });
+    cy.get('input[name="detectorName"]')
+      .first()
+      .type(detectorName, { force: true });
 
     cy.mockGetIndexMappingsOnAction('index_mapping_response.json', () => {
-      cy.get('input[role="textbox"]').type('e2e-test-index{enter}', {
-        force: true,
-      });
+      cy.get('input[role="textbox"]')
+        .first()
+        .type('e2e-test-index{enter}', {
+          force: true,
+        });
     });
 
     cy.get('select[name="timeField"]').select('timestamp', { force: true });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Try to fix failed E2E test workflow: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/runs/823355846

The error is: 
```
  1) Create detector
       Create detector - from dashboard:
     CypressError: `cy.type()` can only be called on a single element. Your subject contained 2 elements.
```

I am not able to reproduce it on my local env, but the code change seems to be promising as per [answer](https://stackoverflow.com/a/57804933). 

Test result:
```
  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  ad/dashboard/ad_dashboard.spec.ts        01:46        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/detectorList/detector_list.spec.      02:00       10       10        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/workflow/create_detector.spec.ts      00:55        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        04:41       17       17        -        -        -

✨  Done in 500.10s.
```
Will verify it in CI workflow after change is merged. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
