### PR TITLE
Fix e2e test caused by new EuiComboBox added on CreateDetector page

### DIFF
--- a/.cypress/integration/ad/workflow/create_detector.spec.ts
+++ b/.cypress/integration/ad/workflow/create_detector.spec.ts
@@ -27,12 +27,14 @@ context('Create detector', () => {
     cy.get('input[name="detectorName"]').type(detectorName, { force: true });
 
     cy.mockGetIndexMappingsOnAction('index_mapping_response.json', () => {
-      cy.get('input[role="textbox"]').type('e2e-test-index{enter}', {
+      cy.get('input[role="textbox"]').first().type('e2e-test-index{enter}', {
         force: true,
       });
     });
 
-    cy.get('select[name="timeField"]').select('timestamp', { force: true });
+    cy.get('input[role="textbox"]').last().type('timestamp{enter}', {
+      force: true,
+    });
 
     cy.mockCreateDetectorOnAction('post_detector_response.json', () => {
       cy.get('.euiButton--primary.euiButton--fill').click({ force: true });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix e2e test caused by new EuiComboBox added on CreateDetector page

This is caused by this [change](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/commit/118dad23213bdb88b0e433e16f0e98c38489f71d#diff-e312f37a83fde2469b33c96b0094e45fR158), which introduces another EuiComboBox and adds another <input> element with `role="textbox"`

After investigation, those 2 ComboxBox has same attributes for <input> element, and ComboBox customized attributes have no impact on its child <input> element. So, I have to use `first()`, `last()` to distinguish those 2 ComboxBox. 

Attributes of <input> for index field:
```
<input aria-controls="" data-test-subj="comboBoxSearchInput" id="m6n1wr2p" role="textbox" value="" style="box-sizing: content-box; width: 2px;">
```
Attributes of <input> for timeField field:
```
<input aria-controls="" data-test-subj="comboBoxSearchInput" id="eorn89cl" role="textbox" value="" style="box-sizing: content-box; width: 2px;">
```

Result:
```
  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  ad/dashboard/ad_dashboard.spec.ts        01:08        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/detectorList/detector_list.spec.      01:20       10       10        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/workflow/create_detector.spec.ts      00:38        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        03:07       17       17        -        -        -

✨  Done in 241.64s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
