### PR TITLE
Add progress bar for initialization

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -86,6 +86,11 @@ export type UiMetaData = {
   };
 };
 
+export type InitProgress = {
+  percentageStr: string;
+  estimatedMinutesLeft: number;
+  neededShingles: number;
+};
 export type Detector = {
   primaryTerm: number;
   seqNo: number;
@@ -105,6 +110,7 @@ export type Detector = {
   disabledTime?: number;
   curState: DETECTOR_STATE;
   stateError: string;
+  initProgress?: InitProgress;
 };
 
 export type DetectorListItem = {

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -290,7 +290,10 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                   ) : detector.enabled &&
                     detector.curState === DETECTOR_STATE.INIT ? (
                     <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>
-                      Initializing
+                      {detector.initProgress
+                        ? //@ts-ignore
+                          `Initializing (${detector.initProgress.percentageStr} complete)`
+                        : 'Initializing'}
                     </EuiHealth>
                   ) : detector.curState === DETECTOR_STATE.INIT_FAILURE ||
                     detector.curState === DETECTOR_STATE.UNEXPECTED_FAILURE ? (
@@ -343,7 +346,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiTabs>
-                {tabs.map(tab => (
+                {tabs.map((tab) => (
                   <EuiTab
                     onClick={() => {
                       handleTabChange(tab.route);
@@ -388,7 +391,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                   <EuiFieldText
                     fullWidth={true}
                     placeholder="delete"
-                    onChange={e => {
+                    onChange={(e) => {
                       if (e.target.value === 'delete') {
                         setDetectorDetailModel({
                           ...detectorDetailModel,
@@ -472,7 +475,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         <Route
           exact
           path="/detectors/:detectorId/results"
-          render={props => (
+          render={(props) => (
             <AnomalyResults
               {...props}
               detectorId={detectorId}
@@ -484,7 +487,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         <Route
           exact
           path="/detectors/:detectorId/configurations"
-          render={props => (
+          render={(props) => (
             <DetectorConfig
               {...props}
               detectorId={detectorId}

--- a/public/pages/DetectorDetail/utils/helpers.ts
+++ b/public/pages/DetectorDetail/utils/helpers.ts
@@ -17,7 +17,7 @@ import { DETECTOR_INIT_FAILURES } from './constants';
 
 export const getInitFailureMessageAndActionItem = (error: string): object => {
   const failureDetails = Object.values(DETECTOR_INIT_FAILURES);
-  const failureDetail = failureDetails.find(failure =>
+  const failureDetail = failureDetails.find((failure) =>
     error.includes(failure.keyword)
   );
   if (!failureDetail) {

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -281,9 +281,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
 
   const getInitProgressMessage = () => {
     return detector && isDetectorInitializing && detector.initProgress
-      ? `The detector needs to capture approximately
-                  ${detector.initProgress.neededShingles} data points for initializing. If your data stream is continuous, this process will take around
-                  ${detector.initProgress.estimatedMinutesLeft} minutes; if not, it may take even longer. `
+      ? `The detector needs ${detector.initProgress.estimatedMinutesLeft} minutes for initializing. If your data stream is not continuous, it may take even longer. `
       : '';
   };
 

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -21,6 +21,10 @@ import {
   EuiSpacer,
   EuiCallOut,
   EuiButton,
+  EuiProgress,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
 } from '@elastic/eui';
 import { get } from 'lodash';
 import React, { useEffect, Fragment, useState } from 'react';
@@ -128,7 +132,6 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     detector && detector.curState === DETECTOR_STATE.INIT;
 
   const initializationInfo = getDetectorInitializationInfo(detector);
-
   const isInitOvertime = get(initializationInfo, IS_INIT_OVERTIME_FIELD, false);
   const initDetails = get(initializationInfo, INIT_DETAILS_FIELD, {});
   const initErrorMessage = get(initDetails, INIT_ERROR_MESSAGE_FIELD, '');
@@ -292,6 +295,17 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       </p>
     ) : isInitializingNormally ? (
       <p>
+        {detector.initProgress
+          ? `The detector needs to capture approximately
+                          ${
+                            //@ts-ignore
+                            detector.initProgress.neededShingles
+                          } data points for initializing. If your data stream is continuous, this process will take around
+                          ${
+                            //@ts-ignore
+                            detector.initProgress.estimatedMinutesLeft
+                          } minutes; if not, it may take even longer. `
+          : ''}
         After the initialization is complete, you will see the anomaly results
         based on your latest configuration changes.
       </p>
@@ -332,6 +346,35 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                       style={{ marginBottom: '20px' }}
                     >
                       {getCalloutContent()}
+                      {isDetectorInitializing && detector.initProgress ? (
+                        <div>
+                          <EuiFlexGroup alignItems="center">
+                            <EuiFlexItem
+                              style={{ maxWidth: '20px', marginRight: '5px' }}
+                            >
+                              <EuiText>
+                                {
+                                  //@ts-ignore
+                                  detector.initProgress.percentageStr
+                                }
+                              </EuiText>
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiProgress
+                                //@ts-ignore
+                                value={detector.initProgress.percentageStr.replace(
+                                  '%',
+                                  ''
+                                )}
+                                max={100}
+                                color="primary"
+                                size="xs"
+                              />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                          <EuiSpacer size="l" />
+                        </div>
+                      ) : null}
                       <EuiButton
                         onClick={props.onSwitchToConfiguration}
                         color={

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -139,6 +139,7 @@ const reducer = handleActions<Detectors>(
             disabledTime: moment().valueOf(),
             curState: DETECTOR_STATE.DISABLED,
             stateError: '',
+            initProgress: undefined,
           },
         },
       }),

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -129,7 +129,7 @@ export default function adPlugin(Client: any, config: any, components: any) {
 
   ad.detectorProfile = ca({
     url: {
-      fmt: `${API.DETECTOR_BASE}/<%=detectorId%>/_profile`,
+      fmt: `${API.DETECTOR_BASE}/<%=detectorId%>/_profile/init_progress,state,error`,
       req: {
         detectorId: {
           type: 'string',

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -196,15 +196,12 @@ const getDetector = async (
       primaryTerm: response._primary_term,
       seqNo: response._seq_no,
       adJob: { ...response.anomaly_detector_job },
-      //@ts-ignore
-      ...(detectorState !== undefined ? { curState: detectorState.state } : {}),
       ...(detectorState !== undefined
-        ? //@ts-ignore
-          { stateError: detectorState.error }
-        : {}),
-      ...(detectorState !== undefined
-        ? //@ts-ignore
-          { initProgress: getDetectorInitProgress(detectorState) }
+        ? {
+            curState: detectorState.state,
+            stateError: detectorState.error,
+            initProgress: getDetectorInitProgress(detectorState),
+          }
         : {}),
     };
     return {

--- a/server/routes/utils/adHelpers.ts
+++ b/server/routes/utils/adHelpers.ts
@@ -18,6 +18,7 @@ import { AnomalyResults } from 'server/models/interfaces';
 import { GetDetectorsQueryParams } from '../../models/types';
 import { mapKeysDeep, toCamel, toSnake } from '../../utils/helpers';
 import { DETECTOR_STATE } from '../../../public/utils/constants';
+import { InitProgress } from 'public/models/interfaces';
 
 export const convertDetectorKeysToSnakeCase = (payload: any) => {
   return {
@@ -151,12 +152,26 @@ export const anomalyResultMapper = (anomalyResults: any[]): AnomalyResults => {
   return resultData;
 };
 
+export const getDetectorInitProgress = (
+  detectorStateResponse: any
+): InitProgress | undefined => {
+  if (detectorStateResponse.init_progress) {
+    return {
+      percentageStr: detectorStateResponse.init_progress.percentage,
+      estimatedMinutesLeft:
+        detectorStateResponse.init_progress.estimated_minutes_left,
+      neededShingles: detectorStateResponse.init_progress.needed_shingles,
+    };
+  }
+  return undefined;
+};
+
 export const getFinalDetectorStates = (
   detectorStateResponses: any[],
   finalDetectors: any[]
 ) => {
   let finalDetectorStates = cloneDeep(detectorStateResponses);
-  finalDetectorStates.forEach(detectorState => {
+  finalDetectorStates.forEach((detectorState) => {
     //@ts-ignore
     detectorState.state = DETECTOR_STATE[detectorState.state];
   });
@@ -198,7 +213,7 @@ export const getDetectorsWithJob = (
 ): any[] => {
   const finalDetectorsWithJobResponses = cloneDeep(detectorsWithJobResponses);
   const resultDetectorWithJobs = [] as any[];
-  finalDetectorsWithJobResponses.forEach(detectorWithJobResponse => {
+  finalDetectorsWithJobResponses.forEach((detectorWithJobResponse) => {
     const resp = {
       ...detectorWithJobResponse.anomaly_detector,
       id: detectorWithJobResponse._id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add progress bar for initialization

**Initializing normally:**
<img width="1275" alt="Screen Shot 2020-07-15 at 3 03 47 PM" src="https://user-images.githubusercontent.com/59710443/87614973-60ea1800-c6c6-11ea-805c-4eb602f69831.png">

**When initializing is overtime:**

![Screen Shot 2020-07-16 at 6 17 26 PM](https://user-images.githubusercontent.com/59710443/87740145-56974f00-c796-11ea-8163-175ad2cfeef8.png)


**When data is missing during initializing:**
![Screen Shot 2020-07-16 at 6 53 58 PM](https://user-images.githubusercontent.com/59710443/87740108-3c5d7100-c796-11ea-90f9-ee91ea76c505.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
