### PR TITLE
Automate release notes to unified standard

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,17 +1,23 @@
 # The overall template of the release notes
 template: |
-  Compatible with Kibana (**set version here**) and Open Distro for Elasticsearch (**set version here**).
+  Compatible with Kibana (**set version here**).
   $CHANGES
 
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: '- $TITLE (PR #$NUMBER)'
+change-template: '* $TITLE (#$NUMBER)'
 sort-by: merged_at
 sort-direction: ascending
+replacers:
+  - search: '##'
+    replace: '###'
 
-# Organizing the tagged PRs into categories
+# Organizing the tagged PRs into unified ODFE categories
 categories:
-  - title: 'Major changes'
+  - title: 'Breaking changes'
+    labels:
+      - 'breaking change'
+  - title: 'Features'
     labels:
       - 'feature'
   - title: 'Enhancements'
@@ -21,13 +27,20 @@ categories:
     labels:
       - 'bug'
       - 'bug fix'
-  - title: 'Infra Changes'
+  - title: 'Infrastructure'
     labels:
       - 'infra'
       - 'test'
-      - 'documentation'
       - 'dependencies'
-  - title: 'Version Upgrades'
+      - 'github actions'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+  - title: 'Maintenance'
     labels:
       - 'version upgrade'
-      - 'odfe-release'
+      - 'odfe release'
+  - title: 'Refactoring'
+    labels:
+      - 'refactor'
+      - 'code quality'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR changes the draft release notes format to match the unified ODFE format.
Specifically:
- changes the `-` to a `*` for each change
- removes the `PR ` prefix for each change
- changes header size of categories from header 2 -> header 3
- sets categories to be the standard set of 8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
