### PR TITLE
Update lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "brace": "^0.11.1",
     "eslint-plugin-cypress": "^2.11.1",
     "formik": "^1.5.8",
+    "lodash": "^4.17.19",
     "query-string": "^6.8.2",
     "react-redux": "^7.1.0",
     "reselect": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,7 +2882,7 @@ cypress@^4.6.0:
     is-installed-globally "0.1.0"
     lazy-ass "1.6.0"
     listr "0.14.3"
-    lodash "4.17.15"
+    lodash "^4.17.15"
     log-symbols "3.0.0"
     minimist "1.2.5"
     moment "2.24.0"
@@ -5321,10 +5321,10 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@4.17.19, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.10:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates lodash dependency to 4.17.19 to remove security vulnerability. Confirmed basic plugin functionality works and UT/IT are all passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
