### PR TITLE
Change CI workflow back to run on master

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -2,7 +2,7 @@ name: E2E tests workflow
 on:
   push:
     branches:
-      - securityCI
+      - master
 env:
   KIBANA_VERSION: 7.8.0
   ODFE_VERSION: 1.9.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

After last CI PR (#263) forgot to change test branch back to master before merging, this fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
