### PR TITLE
Improve error handling when retrieving all detectors

### DIFF
--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -32,6 +32,8 @@ import {
 } from '@elastic/eui';
 //@ts-ignore
 import chrome from 'ui/chrome';
+// @ts-ignore
+import { toastNotifications } from 'ui/notify';
 import { AnomalousDetectorsList } from '../Components/AnomalousDetectorsList';
 import {
   GET_ALL_DETECTORS_QUERY_PARAMS,
@@ -54,6 +56,8 @@ export function DashboardOverview() {
 
   const allDetectorList = adState.detectorList;
 
+  const errorGettingDetectors = adState.errorMessage;
+
   const [isLoadingDetectors, setIsLoadingDetectors] = useState(true);
 
   const [currentDetectors, setCurrentDetectors] = useState(
@@ -69,7 +73,7 @@ export function DashboardOverview() {
     [key: string]: DetectorListItem;
   }) => {
     const detectorNames = Object.values(detectorsIdMap).map(
-      detectorListItem => {
+      (detectorListItem) => {
         return detectorListItem.name;
       }
     );
@@ -85,7 +89,7 @@ export function DashboardOverview() {
   const handleDetectorsFilterChange = (
     options: EuiComboBoxOptionProps[]
   ): void => {
-    const selectedNames = options.map(option => option.label);
+    const selectedNames = options.map((option) => option.label);
 
     setSelectedDetectorsName(selectedNames);
     setAllDetectorsSelected(isEmpty(selectedNames));
@@ -103,7 +107,7 @@ export function DashboardOverview() {
     options: EuiComboBoxOptionProps[]
   ): void => {
     const selectedStates = options.map(
-      option => option.label as DETECTOR_STATE
+      (option) => option.label as DETECTOR_STATE
     );
     setSelectedDetectorStates(selectedStates);
     setAllDetectorStatesSelected(isEmpty(selectedStates));
@@ -122,7 +126,7 @@ export function DashboardOverview() {
   const handleIndicesFilterChange = (
     options: EuiComboBoxOptionProps[]
   ): void => {
-    const selectedIndices = options.map(option => option.label);
+    const selectedIndices = options.map((option) => option.label);
     setSelectedIndices(selectedIndices);
     setAllIndicesSelected(isEmpty(selectedIndices));
   };
@@ -138,13 +142,13 @@ export function DashboardOverview() {
     } else {
       detectorsToFilter = cloneDeep(
         Object.values(allDetectorList)
-      ).filter(detectorItem => selectedNameList.includes(detectorItem.name));
+      ).filter((detectorItem) => selectedNameList.includes(detectorItem.name));
     }
 
     let filteredDetectorItemsByNamesAndIndex = detectorsToFilter;
     if (!allIndicesSelected) {
       filteredDetectorItemsByNamesAndIndex = detectorsToFilter.filter(
-        detectorItem =>
+        (detectorItem) =>
           selectedIndexList.includes(detectorItem.indices.toString())
       );
     }
@@ -152,7 +156,7 @@ export function DashboardOverview() {
     let finalFilteredDetectors = filteredDetectorItemsByNamesAndIndex;
     if (!allDetectorStatesSelected) {
       finalFilteredDetectors = filteredDetectorItemsByNamesAndIndex.filter(
-        detectorItem => selectedStateList.includes(detectorItem.curState)
+        (detectorItem) => selectedStateList.includes(detectorItem.curState)
       );
     }
 
@@ -161,12 +165,7 @@ export function DashboardOverview() {
 
   const intializeDetectors = async () => {
     setIsLoadingDetectors(true);
-    try {
-      await dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
-    } catch (error) {
-      console.log('Error is found during getting detector list', error);
-    }
-    setIsLoadingDetectors(false);
+    dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
     dispatch(getIndices(''));
     dispatch(getAliases(''));
   };
@@ -174,6 +173,13 @@ export function DashboardOverview() {
   useEffect(() => {
     intializeDetectors();
   }, []);
+
+  useEffect(() => {
+    if (errorGettingDetectors) {
+      toastNotifications.addDanger('Unable to get all detectors');
+      setIsLoadingDetectors(false);
+    }
+  }, [errorGettingDetectors]);
 
   useEffect(() => {
     chrome.breadcrumbs.set([
@@ -184,6 +190,7 @@ export function DashboardOverview() {
 
   useEffect(() => {
     setCurrentDetectors(Object.values(allDetectorList));
+    setIsLoadingDetectors(false);
   }, [allDetectorList]);
 
   useEffect(() => {

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -176,6 +176,7 @@ export function DashboardOverview() {
 
   useEffect(() => {
     if (errorGettingDetectors) {
+      console.error(errorGettingDetectors);
       toastNotifications.addDanger('Unable to get all detectors');
       setIsLoadingDetectors(false);
     }

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -75,7 +75,7 @@ import {
   getDetectorsToDisplay,
 } from '../../../utils/helpers';
 import { staticColumn } from '../../utils/tableUtils';
-import { DETECTOR_ACTION } from '../../utils/constants';
+import { DETECTOR_ACTION, singleDetectorErrorMsg } from '../../utils/constants';
 import { getTitleWithCount, Listener } from '../../../../utils/utils';
 import { ListActions } from '../../components/ListActions/ListActions';
 import { searchMonitors } from '../../../../redux/reducers/alerting';
@@ -117,6 +117,9 @@ export const DetectorList = (props: ListProps) => {
   const dispatch = useDispatch();
   const allDetectors = useSelector((state: AppState) => state.ad.detectorList);
   const allMonitors = useSelector((state: AppState) => state.alerting.monitors);
+  const errorGettingDetectors = useSelector(
+    (state: AppState) => state.ad.errorMessage
+  );
   const elasticsearchState = useSelector(
     (state: AppState) => state.elasticsearch
   );
@@ -170,6 +173,16 @@ export const DetectorList = (props: ListProps) => {
     };
     getInitialMonitors();
   }, []);
+
+  useEffect(() => {
+    if (
+      errorGettingDetectors &&
+      errorGettingDetectors !== singleDetectorErrorMsg
+    ) {
+      toastNotifications.addDanger('Unable to get all detectors');
+      setIsLoadingFinalDetectors(false);
+    }
+  }, [errorGettingDetectors]);
 
   // Updating displayed indices (initializing to first 20 for now)
   const visibleIndices = get(elasticsearchState, 'indices', []) as CatIndex[];
@@ -256,14 +269,7 @@ export const DetectorList = (props: ListProps) => {
   }, [confirmModalState.isRequestingToClose, isLoading]);
 
   const getUpdatedDetectors = async () => {
-    try {
-      dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
-    } catch (error) {
-      toastNotifications.addDanger(
-        `Error is found while getting detector list: ${error}`
-      );
-      setIsLoadingFinalDetectors(false);
-    }
+    dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
   };
 
   const handlePageChange = (pageNumber: number) => {
@@ -306,7 +312,7 @@ export const DetectorList = (props: ListProps) => {
       const sanitizedQuery = sanitizeSearchText(searchValue);
       setIndexQuery(sanitizedQuery);
       await dispatch(getPrioritizedIndices(sanitizedQuery));
-      setState(state => ({
+      setState((state) => ({
         ...state,
         page: 0,
       }));
@@ -321,8 +327,8 @@ export const DetectorList = (props: ListProps) => {
     states =
       options.length == 0
         ? ALL_DETECTOR_STATES
-        : options.map(option => option.label as DETECTOR_STATE);
-    setState(state => ({
+        : options.map((option) => option.label as DETECTOR_STATE);
+    setState((state) => ({
       ...state,
       page: 0,
       selectedDetectorStates: states,
@@ -335,7 +341,7 @@ export const DetectorList = (props: ListProps) => {
     indices =
       options.length == 0
         ? ALL_INDICES
-        : options.map(option => option.label).slice(0, MAX_SELECTED_INDICES);
+        : options.map((option) => option.label).slice(0, MAX_SELECTED_INDICES);
 
     setState({
       ...state,
@@ -345,7 +351,7 @@ export const DetectorList = (props: ListProps) => {
   };
 
   const handleResetFilter = () => {
-    setState(state => ({
+    setState((state) => ({
       ...state,
       queryParams: {
         ...state.queryParams,
@@ -443,7 +449,7 @@ export const DetectorList = (props: ListProps) => {
     const validIds = getDetectorsForAction(
       selectedDetectorsForAction,
       DETECTOR_ACTION.START
-    ).map(detector => detector.id);
+    ).map((detector) => detector.id);
     const promises = validIds.map(async (id: string) => {
       return dispatch(startDetector(id));
     });
@@ -453,7 +459,7 @@ export const DetectorList = (props: ListProps) => {
           'All selected detectors have been started successfully'
         );
       })
-      .catch(error => {
+      .catch((error) => {
         toastNotifications.addDanger(
           `Error starting all selected detectors: ${error}`
         );
@@ -468,7 +474,7 @@ export const DetectorList = (props: ListProps) => {
     const validIds = getDetectorsForAction(
       selectedDetectorsForAction,
       DETECTOR_ACTION.STOP
-    ).map(detector => detector.id);
+    ).map((detector) => detector.id);
     const promises = validIds.map(async (id: string) => {
       return dispatch(stopDetector(id));
     });
@@ -479,7 +485,7 @@ export const DetectorList = (props: ListProps) => {
         );
         if (listener) listener.onSuccess();
       })
-      .catch(error => {
+      .catch((error) => {
         toastNotifications.addDanger(
           `Error stopping all selected detectors: ${error}`
         );
@@ -498,7 +504,7 @@ export const DetectorList = (props: ListProps) => {
     const validIds = getDetectorsForAction(
       selectedDetectorsForAction,
       DETECTOR_ACTION.DELETE
-    ).map(detector => detector.id);
+    ).map((detector) => detector.id);
     const promises = validIds.map(async (id: string) => {
       return dispatch(deleteDetector(id));
     });
@@ -508,7 +514,7 @@ export const DetectorList = (props: ListProps) => {
           'All selected detectors have been deleted successfully'
         );
       })
-      .catch(error => {
+      .catch((error) => {
         toastNotifications.addDanger(
           `Error deleting all selected detectors: ${error}`
         );

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -75,7 +75,10 @@ import {
   getDetectorsToDisplay,
 } from '../../../utils/helpers';
 import { staticColumn } from '../../utils/tableUtils';
-import { DETECTOR_ACTION, singleDetectorErrorMsg } from '../../utils/constants';
+import {
+  DETECTOR_ACTION,
+  SINGLE_DETECTOR_ERROR_MSG,
+} from '../../utils/constants';
 import { getTitleWithCount, Listener } from '../../../../utils/utils';
 import { ListActions } from '../../components/ListActions/ListActions';
 import { searchMonitors } from '../../../../redux/reducers/alerting';
@@ -177,8 +180,9 @@ export const DetectorList = (props: ListProps) => {
   useEffect(() => {
     if (
       errorGettingDetectors &&
-      errorGettingDetectors !== singleDetectorErrorMsg
+      errorGettingDetectors !== SINGLE_DETECTOR_ERROR_MSG
     ) {
+      console.error(errorGettingDetectors);
       toastNotifications.addDanger('Unable to get all detectors');
       setIsLoadingFinalDetectors(false);
     }

--- a/public/pages/DetectorsList/utils/constants.ts
+++ b/public/pages/DetectorsList/utils/constants.ts
@@ -19,4 +19,4 @@ export enum DETECTOR_ACTION {
   DELETE,
 }
 
-export const singleDetectorErrorMsg = 'Not Found';
+export const SINGLE_DETECTOR_ERROR_MSG = 'Not Found';

--- a/public/pages/DetectorsList/utils/constants.ts
+++ b/public/pages/DetectorsList/utils/constants.ts
@@ -18,3 +18,5 @@ export enum DETECTOR_ACTION {
   STOP,
   DELETE,
 }
+
+export const singleDetectorErrorMsg = 'Not Found';

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -192,9 +192,10 @@ const reducer = handleActions<Detectors>(
         ),
         totalDetectors: action.result.data.response.totalDetectors,
       }),
-      FAILURE: (state: Detectors): Detectors => ({
+      FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
+        errorMessage: action.error,
       }),
     },
     [UPDATE_DETECTOR]: {
@@ -214,9 +215,10 @@ const reducer = handleActions<Detectors>(
           },
         },
       }),
-      FAILURE: (state: Detectors): Detectors => ({
+      FAILURE: (state: Detectors, action: APIErrorAction): Detectors => ({
         ...state,
         requesting: false,
+        errorMessage: action.error,
       }),
     },
 

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -460,6 +460,7 @@ const getDetectors = async (
         );
         return detectorStateResp;
       } catch (err) {
+        console.log('Error getting detector profile ', err);
         return Promise.reject(
           new Error('Error retrieving all detector states')
         );
@@ -487,6 +488,7 @@ const getDetectors = async (
         });
         return detectorResp;
       } catch (err) {
+        console.log('Error getting detector ', err);
         return Promise.reject(new Error('Error retrieving all detectors'));
       }
     });

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -460,13 +460,16 @@ const getDetectors = async (
         );
         return detectorStateResp;
       } catch (err) {
-        console.log(
-          'Anomaly detector - Unable to retrieve detector state',
-          err
+        return Promise.reject(
+          new Error('Error retrieving all detector states')
         );
       }
     });
-    const detectorStateResponses = await Promise.all(detectorStatePromises);
+    const detectorStateResponses = await Promise.all(
+      detectorStatePromises
+    ).catch((err) => {
+      throw err;
+    });
     const finalDetectorStates = getFinalDetectorStates(
       detectorStateResponses,
       finalDetectors
@@ -484,12 +487,14 @@ const getDetectors = async (
         });
         return detectorResp;
       } catch (err) {
-        console.log('Anomaly detector - Unable to get detector job', err);
+        return Promise.reject(new Error('Error retrieving all detectors'));
       }
     });
     const detectorsWithJobResponses = await Promise.all(
       detectorsWithJobPromises
-    );
+    ).catch((err) => {
+      throw err;
+    });
     const finalDetectorsWithJob = getDetectorsWithJob(
       detectorsWithJobResponses
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR improves error handling in a few different places regarding retrieving all detectors from ES. Specifically:
1. Displays a toast notification on dashboard and detector list pages if there was errors retrieving detectors
2. Fixes issue of infinite loading state on detector list page when errors retrieving detectors
3. Change to use AD redux store to identify if there was errors
4. Properly handles rejected Promises on server side to prevent the plugin from getting in a bad state (e.g., `could not retrieve property state from undefined`).


Confirmed basic functionality of plugin works, and all UT/IT pass.

Screenshots:

<img width="1312" alt="Screen Shot 2020-07-31 at 9 13 52 AM" src="https://user-images.githubusercontent.com/62119629/89054779-3b881b80-d30e-11ea-9522-9a322dc2cd9e.png">

<img width="1312" alt="Screen Shot 2020-07-31 at 9 13 29 AM" src="https://user-images.githubusercontent.com/62119629/89054784-3d51df00-d30e-11ea-9d8e-158b30a5570a.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
