### PR TITLE
Handle index not found error

### DIFF
--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -303,10 +303,10 @@ const searchDetector = async (
       },
     };
   } catch (err) {
+    console.log('Anomaly detector - Unable to search detectors', err);
     if (isIndexNotFoundError(err)) {
       return { ok: true, response: { totalDetectors: 0, detectors: [] } };
     }
-    console.log('Anomaly detector - Unable to search detectors', err);
     return { ok: false, error: err.message };
   }
 };
@@ -512,10 +512,10 @@ const getDetectors = async (
       },
     };
   } catch (err) {
+    console.log('Anomaly detector - Unable to search detectors', err);
     if (isIndexNotFoundError(err)) {
       return { ok: true, response: { totalDetectors: 0, detectorList: [] } };
     }
-    console.log('Anomaly detector - Unable to list detectors', err);
     return { ok: false, error: err.message };
   }
 };

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -46,6 +46,7 @@ import {
   getFinalDetectorStates,
   getDetectorsWithJob,
   getDetectorInitProgress,
+  isIndexNotFoundError,
 } from './utils/adHelpers';
 import { set } from 'lodash';
 
@@ -302,10 +303,7 @@ const searchDetector = async (
       },
     };
   } catch (err) {
-    if (
-      err.statusCode === 404 &&
-      get<string>(err, 'body.error.type', '') === 'index_not_found_exception'
-    ) {
+    if (isIndexNotFoundError(err)) {
       return { ok: true, response: { totalDetectors: 0, detectors: [] } };
     }
     console.log('Anomaly detector - Unable to search detectors', err);
@@ -514,6 +512,9 @@ const getDetectors = async (
       },
     };
   } catch (err) {
+    if (isIndexNotFoundError(err)) {
+      return { ok: true, response: { totalDetectors: 0, detectorList: [] } };
+    }
     console.log('Anomaly detector - Unable to list detectors', err);
     return { ok: false, error: err.message };
   }

--- a/server/routes/utils/adHelpers.ts
+++ b/server/routes/utils/adHelpers.ts
@@ -226,3 +226,10 @@ export const getDetectorsWithJob = (
 
   return resultDetectorWithJobs;
 };
+
+export const isIndexNotFoundError = (err: any) => {
+  return (
+    err.statusCode === 404 &&
+    get<string>(err, 'body.error.type', '') === 'index_not_found_exception'
+  );
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#267 propagated a generic message to the user when there was errors retrieving detectors on the dashboard and detector list pages. One of these errors included an `index_not_found_exception`, which is most likely not an error, but is because the housekeeping AD indices are not all created until a user creates and starts a detector.

This fixes that by suppressing that error, similar to how the existing `searchDetector()` was doing it, and consequently doesn't show any errors on the dashboard and detector list pages when those indices don't exist yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
