### PR TITLE
fix wrong field name when preview

### DIFF
--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -42,6 +42,7 @@ import {
   anomalyResultMapper,
   convertDetectorKeysToCamelCase,
   convertDetectorKeysToSnakeCase,
+  convertPreviewInputKeysToSnakeCase,
   getResultAggregationQuery,
   getFinalDetectorStates,
   getDetectorsWithJob,
@@ -98,7 +99,7 @@ const previewDetector = async (
   try {
     const { detectorId } = req.params;
     //@ts-ignore
-    const requestBody = JSON.stringify(mapKeysDeep(req.payload, toSnake));
+    const requestBody = JSON.stringify(convertPreviewInputKeysToSnakeCase(req.payload));
     const response = await callWithRequest(req, 'ad.previewDetector', {
       detectorId,
       body: requestBody,

--- a/server/routes/utils/__tests__/adHelpers.test.ts
+++ b/server/routes/utils/__tests__/adHelpers.test.ts
@@ -18,9 +18,163 @@ import {
   convertDetectorKeysToCamelCase,
   convertDetectorKeysToSnakeCase,
   getResultAggregationQuery,
+  convertPreviewInputKeysToSnakeCase,
 } from '../adHelpers';
 
 describe('adHelpers', () => {
+  describe('convertPreviewInputKeysToSnakeCase', () => {
+    test('should not convert field name to snake_case', () => {
+      const snake = convertPreviewInputKeysToSnakeCase({
+        periodStart: 1596309273336,
+        periodEnd: 1596914073336,
+        detector: {
+          name: "test2",
+          description: "test",
+          timeField: "@timestamp",
+          indices: [
+            "metricbeat-7.8.1"
+          ],
+          detectionInterval: {
+            period: {
+              interval: 1,
+              unit: "Minutes"
+            }
+          },
+          windowDelay: {
+            period: {
+              interval: 1,
+              unit: "Minutes"
+            }
+          },
+          filterQuery: {
+            bool: {
+              filter: [
+                {
+                  term: {
+                    "host.name": {
+                      value: "myserver"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          featureAttributes: [
+            {
+              featureId: "9lAlx3MBdAn13oNrKKPk",
+              featureName: "F1",
+              featureEnabled: true,
+              importance: 1,
+              aggregationQuery: {
+                f_1: {
+                  avg: {
+                    field: "system.cpu.total.pct"
+                  }
+                }
+              }
+            }
+          ],
+          uiMetadata: {
+            features: {
+              F1: {
+                featureType: "simple_aggs",
+                aggregationBy: "avg",
+                aggregationOf: "system.cpu.total.pct"
+              }
+            },
+            filters: [
+              {
+                fieldInfo: [
+                  {
+                    label: "host.name",
+                    type: "keyword"
+                  }
+                ],
+                fieldValue: "myserver",
+                operator: "is"
+              }
+            ],
+            filterType: "simple_filter"
+          },
+        },
+      });
+      expect(snake).toEqual({
+        period_start: 1596309273336,
+        period_end: 1596914073336,
+        detector: {
+          name: "test2",
+          description: "test",
+          time_field: "@timestamp",
+          indices: [
+            "metricbeat-7.8.1"
+          ],
+          detection_interval: {
+            period: {
+              interval: 1,
+              unit: "Minutes"
+            }
+          },
+          window_delay: {
+            period: {
+              interval: 1,
+              unit: "Minutes"
+            }
+          },
+          filter_query: {
+            bool: {
+              filter: [
+                {
+                  term: {
+                    "host.name": {
+                      value: "myserver"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          feature_attributes: [
+            {
+              feature_id: "9lAlx3MBdAn13oNrKKPk",
+              feature_name: "F1",
+              feature_enabled: true,
+              importance: 1,
+              aggregation_query: {
+                f_1: {
+                  avg: {
+                    field: "system.cpu.total.pct"
+                  }
+                }
+              }
+            }
+          ],
+          ui_metadata: {
+            features: {
+              F1: {
+                featureType: "simple_aggs",
+                aggregationBy: "avg",
+                aggregationOf: "system.cpu.total.pct"
+              }
+            },
+            filters: [
+              {
+                fieldInfo: [
+                  {
+                    label: "host.name",
+                    type: "keyword"
+                  }
+                ],
+                fieldValue: "myserver",
+                operator: "is"
+              }
+            ],
+            filterType: "simple_filter"
+          },
+        }
+      });
+    });
+  });
+
   describe('convertDetectorKeysToSnakeCase', () => {
     test('should convert keys to snake_case', () => {
       const snake = convertDetectorKeysToSnakeCase({ helloWorld: 'value' });
@@ -73,6 +227,66 @@ describe('adHelpers', () => {
         filter_query: {
           query: {
             aggs: { sum_aggregation: { sum: { field: 'totalSales' } } },
+          },
+        },
+        ui_metadata: {},
+      });
+    });
+
+    test('should not replace dot in filterQuery and features aggregation query', () => {
+      const snake = convertDetectorKeysToSnakeCase({
+        helloWorld: 'value',
+        filterQuery: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  'host.name': { value: 'myserver' },
+                },
+              },
+            ],
+          },
+        },
+        featureAttributes: [
+          {
+            featureId: 'WDO-lm0BL33kEAPF5moe',
+            featureName: 'Hello World',
+            featureEnabled: true,
+            aggregationQuery: {
+              hello_world: {
+                avg: {
+                  field: 'system.cpu.total.pct',
+                },
+              },
+            },
+          },
+        ],
+      });
+      expect(snake).toEqual({
+        hello_world: 'value',
+        feature_attributes: [
+          {
+            feature_id: 'WDO-lm0BL33kEAPF5moe',
+            feature_name: 'Hello World',
+            feature_enabled: true,
+            aggregation_query: {
+              hello_world: {
+                avg: {
+                  field: 'system.cpu.total.pct',
+                },
+              },
+            },
+          },
+        ],
+        filter_query: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  'host.name': { value: 'myserver' },
+                },
+              },
+            ],
           },
         },
         ui_metadata: {},

--- a/server/routes/utils/adHelpers.ts
+++ b/server/routes/utils/adHelpers.ts
@@ -39,6 +39,18 @@ export const convertDetectorKeysToSnakeCase = (payload: any) => {
   };
 };
 
+export const convertPreviewInputKeysToSnakeCase = (payload: any) => {
+  return {
+    ...mapKeysDeep(
+      {
+        ...omit(payload, ['detector']), // Exclude the detector,
+      },
+      toSnake
+    ),
+    detector: convertDetectorKeysToSnakeCase(get(payload, 'detector', {})),
+  };
+};
+
 export const convertDetectorKeysToCamelCase = (response: object) => {
   return {
     ...mapKeysDeep(


### PR DESCRIPTION
**Issue** #258 

## Description of changes:
snakeCase will replace "." with "_", that may make preview not work when the field name contains "."
User reported preview can't work: https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/192. 
User used field name "host.name" in filter query, but snakeCase will transform it into "host_name" which is an invalid field name. So preview function can't get any data.

We need to exclude detector in preview input when convert keys to snake case, and use `convertDetectorKeysToSnakeCase` to convert detector keys.

## Before
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2020-08-08-13_03_50](https://user-images.githubusercontent.com/49084640/89718882-b1782c80-d977-11ea-9c76-7df527d50cb8.png)


## After

### 1. metricbeat data with field name "host.name" in filter query
![wrong_field_bug](https://user-images.githubusercontent.com/49084640/89718816-023b5580-d977-11ea-9eda-34072ed682b0.png)

### 2. NAB data with field name "value" in filter query
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2020-08-08-12_48_24](https://user-images.githubusercontent.com/49084640/89718824-1aab7000-d977-11ea-99fa-23e1488fee0f.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
