### PR TITLE
support field search for detector simple filter

### DIFF
--- a/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
@@ -97,7 +97,7 @@ export const SimpleFilter = (props: DataFilterProps) => {
 
         let options = indexFields[i]?.options;
         if (options) {
-          for (let j = 0; j < options?.length; j++) {
+          for (let j = 0; j < options.length; j++) {
             if (includes(options[j].label, searchValue)) {
               selectedOptions.push(options[j]);
             }

--- a/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
+++ b/public/pages/createDetector/components/DataFilters/SimpleFilter.tsx
@@ -34,8 +34,8 @@ import {
   FieldProps,
   FormikProps,
 } from 'formik';
-import { cloneDeep, get } from 'lodash';
-import React, { useEffect, Fragment } from 'react';
+import { cloneDeep, get, debounce, includes } from 'lodash';
+import React, { useEffect, Fragment, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { UIFilter } from '../../../../models/interfaces';
@@ -60,6 +60,16 @@ interface DataFilterProps {
 
 export const SimpleFilter = (props: DataFilterProps) => {
   const indexFields = getIndexFields(useSelector(getAllFields));
+  const [searchedIndexFields, setSearchedIndexFields] = useState<
+    ({
+      label: DATA_TYPES;
+      options: {
+        label: string;
+        type: DATA_TYPES;
+      }[];
+    } | null)[]
+  >();
+
   const darkMode = darkModeEnabled();
   const selectedIndices = get(props, 'formikProps.values.index[0].label', '');
   //Reset, if selectedIndices change filter could become invalid
@@ -76,6 +86,36 @@ export const SimpleFilter = (props: DataFilterProps) => {
   const lightModeStyles = {
     backgroundColor: '#F6F6F6',
   };
+
+  //If user search field name, filter filed names which include user's input word
+  //So user can only need to select from the filtered fileds.
+  const handleSearchFieldChange = debounce(async (searchValue: string) => {
+    let selectedFields: any = [];
+    if (searchValue) {
+      for (let i = 0; i < indexFields.length; i++) {
+        let selectedOptions: any = [];
+
+        let options = indexFields[i]?.options;
+        if (options) {
+          for (let j = 0; j < options?.length; j++) {
+            if (includes(options[j].label, searchValue)) {
+              selectedOptions.push(options[j]);
+            }
+          }
+          if (selectedOptions.length > 0) {
+            selectedFields.push({
+              label: indexFields[i]?.label,
+              options: selectedOptions,
+            });
+          }
+        }
+      }
+      setSearchedIndexFields(selectedFields);
+    } else {
+      setSearchedIndexFields(undefined);
+    }
+  }, 300);
+
   return (
     <FieldArray name="filters" validateOnChange={true}>
       {({
@@ -152,7 +192,11 @@ export const SimpleFilter = (props: DataFilterProps) => {
                                     async
                                     isClearable
                                     //@ts-ignore
-                                    options={indexFields}
+                                    options={
+                                      searchedIndexFields
+                                        ? searchedIndexFields
+                                        : indexFields
+                                    }
                                     onCreateOption={(createdOption: string) => {
                                       const normalizedOptions = createdOption.trim();
                                       if (!normalizedOptions) return;
@@ -177,6 +221,7 @@ export const SimpleFilter = (props: DataFilterProps) => {
                                         options
                                       );
                                     }}
+                                    onSearchChange={handleSearchFieldChange}
                                     isInvalid={isInvalid(field.name, form)}
                                   />
                                 </EuiFormRow>


### PR DESCRIPTION
**Issue** #275

## Description of changes
When typing field name on detector creation page, we should filter all fields contain the input string and show only the matched fields.

### Before
![Screen Shot 2020-08-11 at 11 26 58 AM](https://user-images.githubusercontent.com/49084640/89934602-add9e500-dbc5-11ea-891a-5b8e56e56785.png)


### After
![Screen Shot 2020-08-11 at 11 25 28 AM](https://user-images.githubusercontent.com/49084640/89934484-7f5c0a00-dbc5-11ea-9067-d2d88efbe3ec.png)


## Test
Unit test passed locally
```
Test Suites: 1 skipped, 45 passed, 45 of 46 total
Tests:       4 skipped, 200 passed, 204 total
Snapshots:   35 passed, 35 total
Time:        219.553s
Ran all test suites.
✨  Done in 222.71s.
```
Integration test passed locally
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  ad/dashboard/ad_dashboard.spec.ts        00:53        6        6        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/detectorList/detector_list.spec.      01:11       10       10        -        -        - │
  │    ts                                                                                          │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  ad/workflow/create_detector.spec.ts      00:34        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        02:39       17       17        -        -        -
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
