### PR TITLE
Add intermediate callout message during cold start

### DIFF
--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -290,7 +290,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                   ) : detector.enabled &&
                     detector.curState === DETECTOR_STATE.INIT ? (
                     <EuiHealth color={DETECTOR_STATE_COLOR.INIT}>
-                      {detector.initProgress
+                      {detector.initProgress?.estimatedMinutesLeft
                         ? //@ts-ignore
                           `Initializing (${detector.initProgress.percentageStr} complete)`
                         : 'Initializing'}

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -269,7 +269,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               <p>
                 Attempting to initialize the detector with historical data. This
                 will take approximately{' '}
-                {detector.detectionInterval.period.interval} total minutes.
+                {detector.detectionInterval.period.interval} minutes.
               </p>
             </EuiText>
           </EuiFlexGroup>

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -254,7 +254,27 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       );
     }
     if (isPerformingColdStart) {
-      return `Attempting to initialize the detector with historical data. This will take approximately ${detector.detectionInterval.period.interval} total minutes.`;
+      return (
+        <div>
+          <EuiFlexGroup direction="row" gutterSize="s">
+            <EuiLoadingSpinner
+              size="l"
+              style={{
+                marginLeft: '4px',
+                marginRight: '8px',
+                marginBottom: '8px',
+              }}
+            />
+            <EuiText>
+              <p>
+                Attempting to initialize the detector with historical data. This
+                will take approximately{' '}
+                {detector.detectionInterval.period.interval} total minutes.
+              </p>
+            </EuiText>
+          </EuiFlexGroup>
+        </div>
+      );
     }
     if (isInitializingNormally) {
       return 'The detector is being initialized based on the latest configuration changes.';
@@ -355,16 +375,18 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                     <EuiCallOut
                       title={getCalloutTitle()}
                       color={getCalloutColor()}
-                      iconType={isInitializingNormally ? 'iInCircle' : 'alert'}
+                      iconType={
+                        isPerformingColdStart
+                          ? ''
+                          : isInitializingNormally
+                          ? 'iInCircle'
+                          : 'alert'
+                      }
                       style={{ marginBottom: '20px' }}
                     >
                       {getCalloutContent()}
-                      {isPerformingColdStart ? (
-                        <div>
-                          <EuiLoadingSpinner size="l" />
-                          <EuiSpacer size="s" />
-                        </div>
-                      ) : isDetectorInitializing && detector.initProgress ? (
+                      {isPerformingColdStart ? null : isDetectorInitializing &&
+                        detector.initProgress ? (
                         <div>
                           <EuiFlexGroup alignItems="center">
                             <EuiFlexItem


### PR DESCRIPTION
*Issue #, if available:* #271 

*Description of changes:*

This PR adds an intermediate callout to the detector anomaly results page when the detector is still in the middle of the cold start process. This fixes the bug of displaying a (possibly) very incorrect time estimation regarding detector initialization, where the time may be much shorter if sufficient historical data exists.

**NOTES**:
- Backend has been correspondingly changed, and will return undefined for the estimated time if the cold start process has not finished.
- Will confirm with UX on layout/wording.
- Confirmed all UT pass.

Specific changes:
1. Add intermediate callout above anomaly results detail page when cold start process is happening. The estimated time for this to finish is one detector interval, and is the best estimate we can provide.
2. Removing the percentage string in the detector state at the top of the detector details pages if cold start process is happening.

Before:
<img width="1424" alt="Screen Shot 2020-08-23 at 11 18 05 AM" src="https://user-images.githubusercontent.com/62119629/90985678-5f680700-e532-11ea-8d73-5ce6be6e9d0a.png">

After:
<img width="1424" alt="Screen Shot 2020-08-26 at 4 13 26 PM" src="https://user-images.githubusercontent.com/62119629/91366019-72d7d400-e7b7-11ea-93fe-3cb72cbf8490.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
