### PR TITLE
parse types in fielddata

### DIFF
--- a/public/redux/reducers/__tests__/mapper.test.ts
+++ b/public/redux/reducers/__tests__/mapper.test.ts
@@ -1,0 +1,49 @@
+import { getPathsPerDataType } from '../mapper';
+
+describe('mapper', () => {
+  describe('getPathsPerDataType', () => {
+    test('has fields', async () => {
+      const mappings = {
+        test_index: {
+          mappings: {
+            properties: {
+              test: {
+                properties: {
+                  a: {
+                    properties: {
+                      b: {
+                        type: 'keyword',
+                        eager_global_ordinals: true,
+                        fields: {
+                          raw: {
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              timestamp: {
+                type: 'date',
+                format: 'strict_date_time||epoch_millis',
+              },
+              value: {
+                type: 'float',
+              },
+            },
+          },
+        },
+      };
+      const pathsPerDataType = getPathsPerDataType(mappings);
+      console.log(pathsPerDataType);
+
+      expect(pathsPerDataType).toEqual({
+        keyword: ['test.a.b'],
+        integer: ['test.a.b.raw'],
+        date: ['timestamp'],
+        float: ['value'],
+      });
+    });
+  });
+});

--- a/public/redux/reducers/mapper.ts
+++ b/public/redux/reducers/mapper.ts
@@ -63,7 +63,6 @@ export function getTypeFromMappings(
         resolvePath(path, field)
       );
     });
-    return currentDataTypes;
   }
 
   return currentDataTypes;

--- a/public/redux/reducers/mapper.ts
+++ b/public/redux/reducers/mapper.ts
@@ -54,6 +54,18 @@ export function getTypeFromMappings(
   } else {
     currentDataTypes[type] = [path];
   }
+
+  if (mappings.fields) {
+    Object.entries(mappings.fields).forEach(([field, value]) => {
+      currentDataTypes = getTypeFromMappings(
+        value as Mappings,
+        currentDataTypes,
+        resolvePath(path, field)
+      );
+    });
+    return currentDataTypes;
+  }
+
   return currentDataTypes;
 }
 


### PR DESCRIPTION
*Issue #282 *

## Description of changes:

We don't parse types in `fielddata` currently, so if user choose averge/sum/max/min on edit feature page, some number fields will not show up on edit feature page.

Create test index
```
PUT test_index_num_filed
{
  "mappings": {
    "properties": {
      "test": {
        "properties": {
          "a": {
            "properties": {
              "b": {
                "type": "keyword",
                "eager_global_ordinals": true,
                "fields": {
                  "raw": {
                    "type": "integer"
                  }
                }
              }
            }
          }
        }
      },
      "timestamp": {
        "type": "date",
        "format": "strict_date_time||epoch_millis"
      },
      "value": {
        "type": "float"
      }
    }
  }
}

PUT test_index_num_filed/_doc/1
{
  "test": {
    "a": {
      "b": 1
    }
  },
  "timestamp": 1587344356869,
  "value": 1
}
```
Create detector with test index `test_index_num_filed`. The edit feature page can show more number fields after change.
### Before

![Screen Shot 2020-08-23 at 11 20 36 AM](https://user-images.githubusercontent.com/49084640/90985747-c5548e80-e532-11ea-9f9d-2f0232cf47f5.png)

### After
![Screen Shot 2020-08-23 at 11 26 22 AM](https://user-images.githubusercontent.com/49084640/90985892-a86c8b00-e533-11ea-9875-b63791ff940c.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
