### PR TITLE
Add action item and message for init failue case due to invalid search query. 

### DIFF
--- a/public/pages/DetectorDetail/utils/constants.ts
+++ b/public/pages/DetectorDetail/utils/constants.ts
@@ -71,8 +71,9 @@ export const DETECTOR_INIT_FAILURES = Object.freeze({
     // TODO: https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/218
     //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java#L28
     keyword: 'Invalid search query',
-    cause: 'there exists invalid custom feature aggregation query',
-    actionItem: 'Revise your custom feature aggregation query and try again.',
+    cause: 'the custom query caused an invalid feature aggregation',
+    actionItem:
+      'Revise the custom query in your feature aggregations and try again.',
   },
   UNKNOWN_EXCEPTION: {
     //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L438

--- a/public/pages/DetectorDetail/utils/constants.ts
+++ b/public/pages/DetectorDetail/utils/constants.ts
@@ -67,6 +67,13 @@ export const DETECTOR_INIT_FAILURES = Object.freeze({
     cause: 'the detector is not defined',
     actionItem: 'Define your detector and try again.',
   },
+  INVALID_FEATURE_QUERY: {
+    // TODO: https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/218
+    //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java#L28
+    keyword: 'Invalid search query',
+    cause: 'there exists invalid custom feature aggregation query',
+    actionItem: 'Revise your custom feature aggregation query and try again.',
+  },
   UNKNOWN_EXCEPTION: {
     //https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/development/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L438
     keyword: 'We might have bugs',


### PR DESCRIPTION
Issue:#281

*Issue #, if available:*

*Description of changes:*
Add frontend error handling for new failure message introduced by backend change: https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/184

The limitation for now is that the returned exception does not have the problematic feature name, the message on UI can be confusing. I created issue on backend for solving it: https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/218

![Screen Shot 2020-08-24 at 6 22 21 PM](https://user-images.githubusercontent.com/59710443/91123205-23779380-e651-11ea-819b-eafbe30bb87d.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
