### PR TITLE
Updating release notes version to have 1.10.0.0

### DIFF
--- a/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana.release-notes-1.10.0.0.md
@@ -1,4 +1,4 @@
-## Version 1.10.0 Release Notes
+## Version 1.10.0.0 Release Notes
 
 Compatible with Kibana 7.9.0
 ### Enhancements


### PR DESCRIPTION
Release notes was missing the 4th digit in the version. 
Adding that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
