### PR TITLE
Fix broken cypress test related to new empty dashboard buttons

### DIFF
--- a/.cypress/integration/ad/dashboard/ad_dashboard.spec.ts
+++ b/.cypress/integration/ad/dashboard/ad_dashboard.spec.ts
@@ -49,7 +49,7 @@ context('AD Dashboard', () => {
     });
 
     cy.mockSearchIndexOnAction('search_index_response.json', () => {
-      cy.get('a[data-test-subj="add_detector"]').click({
+      cy.get('a[data-test-subj="createDetectorButton"]').click({
         force: true,
       });
     });

--- a/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana-plugin.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana-plugin.release-notes-1.10.0.0.md
@@ -3,6 +3,7 @@
 Compatible with Kibana 7.9.0
 
 ### Features
+
 - Add sample detectors and indices ([#272](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/272))
 
 ### Enhancements
@@ -30,6 +31,7 @@ Compatible with Kibana 7.9.0
 - Remove elastic charts dependency ([#269](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/269))
 - Add UT for Detector List page ([#279](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/279))
 - Fix UT and remove lower EUI version dependency ([#293](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/293))
+- Fix broken cypress test related to new empty dashboard buttons ([#298](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/298))
 
 ### Documentation
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The sample detectors commit changed the empty dashboard to have multiple buttons, where the data test subj for the create detector button was different, causing the cypress test that clicked that button to fail.

This fixes that so that all IT pass. Confirmed locally.

Will cherry-pick to opendistro-1.10 branch and update the tag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
