### PR TITLE
Fix initialization callouts to properly show when first loading anomaly results page

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -88,10 +88,11 @@ export function AnomalyResults(props: AnomalyResultsProps) {
       BREADCRUMBS.DETECTORS,
       { text: detector ? detector.name : '' },
     ]);
+    dispatch(getDetector(detectorId));
   }, []);
 
   const fetchDetector = async () => {
-    await dispatch(getDetector(detectorId));
+    dispatch(getDetector(detectorId));
   };
 
   useEffect(() => {

--- a/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana-plugin.release-notes-1.10.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-anomaly-detection-kibana-plugin.release-notes-1.10.0.0.md
@@ -21,6 +21,7 @@ Compatible with Kibana 7.9.0
 - fix wrong field name when preview ([#277](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/277))
 - parse types in fielddata ([#284](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/284))
 - Add intermediate callout message during cold start ([#283](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/283))
+- Fix initialization callouts to properly show when first loading anomaly results page ([#300](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/300))
 
 ### Infrastructure
 


### PR DESCRIPTION
*Issue #, if available:* #299 

*Description of changes:*

This PR fixes the issue of the anomaly results page not properly showing the callouts relating to init progress (if applicable) when first loading the page after detector creation. Specifically, this fix will re-get the detector details when first rendering the page, to update the redux store with the detector details if they haven't been updated already.

The issue (before): user creates detector -> redux store gets updated with detector info returned by create detector api (which doesn't include any info related to init progress) -> user clicks on anomaly results page -> page uses existing detector info -> assumes no init progress -> renders old callout. Note that this issue only comes up if the store hasn't already been updated by rendering some other page, like detector list or dashboard for example, where getDetectors() is called, which would update the redux store with up-to-date detector details.

Confirmed all UT/IT pass.

Will cherry-pick to opendistro-1.10 branch and push new tag.

Screenshots:

Before:
<img width="1416" alt="Screen Shot 2020-09-03 at 9 14 22 AM" src="https://user-images.githubusercontent.com/62119629/92141599-8098e500-edc7-11ea-996a-7809c43b1bbb.png">


After:
<img width="1410" alt="Screen Shot 2020-09-03 at 9 16 44 AM" src="https://user-images.githubusercontent.com/62119629/92141609-842c6c00-edc7-11ea-8893-a6656451adcc.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
