### PR TITLE
Fix bug where undefined is shown on UI for estimatedMins in case of ingestion data missing

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -315,9 +315,11 @@ export function AnomalyResults(props: AnomalyResultsProps) {
   const getInitProgressMessage = () => {
     return detector &&
       isDetectorInitializing &&
-      detector.initProgress &&
-      detector.initProgress.estimatedMinutesLeft
-      ? `The detector needs ${detector.initProgress.estimatedMinutesLeft} minutes for initializing. If your data stream is not continuous, it may take even longer. `
+      get(detector, 'initProgress.estimatedMinutesLeft')
+      ? `The detector needs ${get(
+          detector,
+          'initProgress.estimatedMinutesLeft'
+        )} minutes for initializing. If your data stream is not continuous, it may take even longer. `
       : '';
   };
 

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -313,7 +313,10 @@ export function AnomalyResults(props: AnomalyResultsProps) {
   };
 
   const getInitProgressMessage = () => {
-    return detector && isDetectorInitializing && detector.initProgress
+    return detector &&
+      isDetectorInitializing &&
+      detector.initProgress &&
+      detector.initProgress.estimatedMinutesLeft
       ? `The detector needs ${detector.initProgress.estimatedMinutesLeft} minutes for initializing. If your data stream is not continuous, it may take even longer. `
       : '';
   };


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Fix bug where undefined is shown on UI for estimatedMins in case of ingestion data missing

**Before**
![Screen Shot 2020-09-03 at 1 26 39 PM](https://user-images.githubusercontent.com/59710443/92163838-2e68bb80-ede9-11ea-85aa-085809e67c93.png)
![Screen Shot 2020-09-03 at 1 27 34 PM](https://user-images.githubusercontent.com/59710443/92163902-4c362080-ede9-11ea-917c-6bc638ca3fcb.png)

**After**
![Screen Shot 2020-09-03 at 1 15 33 PM](https://user-images.githubusercontent.com/59710443/92163931-59530f80-ede9-11ea-97d0-469e06fa9295.png)
![Screen Shot 2020-09-03 at 1 16 26 PM](https://user-images.githubusercontent.com/59710443/92163940-5ce69680-ede9-11ea-8662-3826e29573be.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
