### PR TITLE
Add category field to edit model configuration page

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -112,6 +112,7 @@ export type Detector = {
   curState: DETECTOR_STATE;
   stateError: string;
   initProgress?: InitProgress;
+  categoryField?: string[];
 };
 
 export type DetectorListItem = {

--- a/public/pages/DetectorConfig/components/AdditionalSettings/AdditionalSettings.tsx
+++ b/public/pages/DetectorConfig/components/AdditionalSettings/AdditionalSettings.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { get } from 'lodash';
+import { EuiBasicTable } from '@elastic/eui';
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+
+interface AdditionalSettingsProps {
+  shingleSize: number;
+  categoryField: string[];
+}
+
+export function AdditionalSettings(props: AdditionalSettingsProps) {
+  const tableItems = [
+    {
+      categoryField: get(props.categoryField, 0, '-'),
+      windowSize: props.shingleSize,
+    },
+  ];
+  const tableColumns = [
+    { name: 'Category field', field: 'categoryField' },
+    { name: 'Window size', field: 'windowSize' },
+  ];
+  return (
+    <ContentPanel title="Additional settings" titleSize="s">
+      <EuiBasicTable
+        className="header-single-value-euiBasicTable"
+        items={tableItems}
+        columns={tableColumns}
+      />
+    </ContentPanel>
+  );
+}

--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -32,6 +32,7 @@ import { PLUGIN_NAME, SHINGLE_SIZE } from '../../../utils/constants';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import { CodeModal } from '../components/CodeModal/CodeModal';
 import { getTitleWithCount } from '../../../utils/utils';
+import { AdditionalSettings } from '../components/AdditionalSettings/AdditionalSettings';
 
 interface FeaturesProps {
   detectorId: string;
@@ -186,10 +187,10 @@ export class Features extends Component<FeaturesProps, FeaturesState> {
 
     const setParamsText = `Set the index fields that you want to find anomalies for by defining
                            the model features. You can also set other model parameters such as
-                           window size.`
+                           window size.`;
 
     const previewText = `After you set the model features and other optional parameters, you can
-                         preview your anomalies from a sample feature output.`
+                         preview your anomalies from a sample feature output.`;
 
     return (
       <ContentPanel
@@ -223,8 +224,8 @@ export class Features extends Component<FeaturesProps, FeaturesState> {
             body={
               <EuiText className="emptyFeatureBody">
                 {setParamsText}
-                <br/>
-                <br/>
+                <br />
+                <br />
                 {previewText}
               </EuiText>
             }
@@ -252,18 +253,11 @@ export class Features extends Component<FeaturesProps, FeaturesState> {
                 onChange={this.handleTableChange}
               />
             </ContentPanel>
-            <EuiSpacer size="m"/>
-            <ContentPanel
-              title="Additional settings"
-              titleSize="s"
-            >
-              <EuiBasicTable
-                className="header-single-value-euiBasicTable"
-                items={[{ windowSize: shingleSize }]}
-                columns={[{ field: 'windowSize', name: 'Window size'}]}
-                cellProps={getCellProps}
-              />
-            </ContentPanel>
+            <EuiSpacer size="m" />
+            <AdditionalSettings
+              shingleSize={shingleSize}
+              categoryField={get(this.props.detector, 'categoryField', [])}
+            />
           </div>
         )}
       </ContentPanel>

--- a/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
+++ b/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
@@ -123,7 +123,7 @@ export function CategoryField(props: CategoryFieldProps) {
                       label="Field"
                       isInvalid={isInvalid(field.name, form)}
                       error={getError(field.name, form)}
-                      helpText={`The category field can only be applied to the "ip" and "keyword" elasticsearch data types.`}
+                      helpText={`You can only apply the category field to the 'ip' and 'keyword' Elasticsearch data types.`}
                     >
                       <EuiComboBox
                         data-test-subj="categoryFieldComboBox"

--- a/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
+++ b/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiText,
+  EuiLink,
+  EuiIcon,
+  EuiFormRow,
+  EuiPage,
+  EuiPageBody,
+  EuiComboBox,
+  EuiCheckbox,
+  EuiTitle,
+  EuiCallOut,
+  EuiSpacer,
+} from '@elastic/eui';
+import { Field, FieldProps } from 'formik';
+import { get, isEmpty } from 'lodash';
+import React, { useState, useEffect } from 'react';
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+// @ts-ignore
+import { toastNotifications } from 'ui/notify';
+import {
+  isInvalid,
+  getError,
+  validateCategoryField,
+} from '../../../../utils/utils';
+//@ts-ignore
+import chrome from 'ui/chrome';
+
+interface CategoryFieldProps {
+  isHCDetector: boolean;
+  categoryFieldOptions: string[];
+  setIsHCDetector(isHCDetector: boolean): void;
+}
+
+export function CategoryField(props: CategoryFieldProps) {
+  const [enabled, setEnabled] = useState<boolean>(props.isHCDetector);
+  const noCategoryFields = isEmpty(props.categoryFieldOptions);
+  const convertedOptions = props.categoryFieldOptions.map((option: string) => {
+    return {
+      label: option,
+    };
+  });
+
+  useEffect(() => {
+    setEnabled(props.isHCDetector);
+  }, [props.isHCDetector]);
+
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <ContentPanel
+          title={
+            <EuiTitle size="s">
+              <h2>Category field </h2>
+            </EuiTitle>
+          }
+          subTitle={
+            <EuiText className="content-panel-subTitle">
+              Categorize anomalies based on unique partitions. For example, with
+              clickstream data you can categorize anomalies into a given day,
+              week, or month.{' '}
+              <EuiLink
+                href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                target="_blank"
+              >
+                Learn more <EuiIcon size="s" type="popout" />
+              </EuiLink>
+            </EuiText>
+          }
+        >
+          {noCategoryFields ? (
+            <EuiCallOut
+              data-test-subj="noCategoryFieldsCallout"
+              title="There are no available category fields for the selected index"
+              color="warning"
+              iconType="alert"
+            ></EuiCallOut>
+          ) : null}
+          {noCategoryFields ? <EuiSpacer size="m" /> : null}
+          <Field
+            name="categoryField"
+            validate={enabled ? validateCategoryField : null}
+          >
+            {({ field, form }: FieldProps) => (
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <EuiCheckbox
+                    id={'categoryFieldCheckbox'}
+                    label="Enable category field"
+                    checked={enabled}
+                    disabled={noCategoryFields}
+                    onChange={() => {
+                      if (!enabled) {
+                        props.setIsHCDetector(true);
+                      }
+                      if (enabled) {
+                        props.setIsHCDetector(false);
+                        form.setFieldValue('categoryField', []);
+                      }
+                      setEnabled(!enabled);
+                    }}
+                  />
+                </EuiFlexItem>
+                {enabled && !noCategoryFields ? (
+                  <EuiFlexItem>
+                    <EuiFormRow
+                      label="Field"
+                      isInvalid={isInvalid(field.name, form)}
+                      error={getError(field.name, form)}
+                      helpText={`The category field can only be applied to the "ip" and "keyword" elasticsearch data types.`}
+                    >
+                      <EuiComboBox
+                        data-test-subj="categoryFieldComboBox"
+                        id="categoryField"
+                        placeholder="Select your category field"
+                        options={convertedOptions}
+                        onBlur={() => {
+                          form.setFieldTouched('categoryField', true);
+                        }}
+                        onChange={(options) => {
+                          const selection = get(options, '0.label');
+                          if (selection) {
+                            form.setFieldValue('categoryField', [selection]);
+                          } else {
+                            form.setFieldValue('categoryField', []);
+                          }
+                        }}
+                        selectedOptions={
+                          (field.value[0] && [{ label: field.value[0] }]) || []
+                        }
+                        singleSelection={true}
+                        isClearable={true}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                ) : null}
+              </EuiFlexGroup>
+            )}
+          </Field>
+        </ContentPanel>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
+++ b/public/pages/EditFeatures/components/CategoryField/CategoryField.tsx
@@ -46,6 +46,7 @@ interface CategoryFieldProps {
   isHCDetector: boolean;
   categoryFieldOptions: string[];
   setIsHCDetector(isHCDetector: boolean): void;
+  isLoading: boolean;
 }
 
 export function CategoryField(props: CategoryFieldProps) {
@@ -84,7 +85,7 @@ export function CategoryField(props: CategoryFieldProps) {
             </EuiText>
           }
         >
-          {noCategoryFields ? (
+          {noCategoryFields && !props.isLoading ? (
             <EuiCallOut
               data-test-subj="noCategoryFieldsCallout"
               title="There are no available category fields for the selected index"

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -36,6 +36,7 @@ describe('<CategoryField /> spec', () => {
                 setIsHCDetector={(isHCDetector: boolean) => {
                   return;
                 }}
+                isLoading={false}
               />
             </Form>
           </Fragment>
@@ -64,6 +65,7 @@ describe('<CategoryField /> spec', () => {
                 setIsHCDetector={(isHCDetector: boolean) => {
                   return;
                 }}
+                isLoading={false}
               />
             </Form>
           </Fragment>
@@ -92,6 +94,7 @@ describe('<CategoryField /> spec', () => {
                 setIsHCDetector={(isHCDetector: boolean) => {
                   return;
                 }}
+                isLoading={false}
               />
             </Form>
           </Fragment>
@@ -101,6 +104,34 @@ describe('<CategoryField /> spec', () => {
     expect(container).toMatchSnapshot();
     expect(queryByTestId('noCategoryFieldsCallout')).not.toBeNull();
     expect(queryByTestId('categoryFieldComboBox')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('hides callout if component is loading', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={true}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
     expect(queryByText('Enable category field')).not.toBeNull();
   });
 });

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+import { render } from '@testing-library/react';
+import { Form, Formik } from 'formik';
+import { CategoryField } from '../CategoryField';
+
+describe('<CategoryField /> spec', () => {
+  test('renders the component when disabled', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={false}
+                categoryFieldOptions={['option 1', 'option 2']}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('renders the component when enabled', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={['option 1', 'option 2']}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).not.toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('shows callout when there are no available category fields', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).not.toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+});

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -1,0 +1,488 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CategoryField /> spec renders the component when disabled 1`] = `
+<div>
+  <form>
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoading"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    class="euiCheckbox__input"
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CategoryField /> spec renders the component when enabled 1`] = `
+<div>
+  <form>
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiFormRow"
+                  id="random_html_id-row"
+                >
+                  <div
+                    class="euiFormRow__labelWrapper"
+                  >
+                    <label
+                      aria-invalid="false"
+                      class="euiFormLabel euiFormRow__label"
+                      for="random_html_id"
+                    >
+                      Field
+                    </label>
+                  </div>
+                  <div
+                    class="euiFormRow__fieldWrapper"
+                  >
+                    <div
+                      aria-describedby="random_html_id-help"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="euiComboBox"
+                      data-test-subj="categoryFieldComboBox"
+                      role="combobox"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <div
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                            data-test-subj="comboBoxInput"
+                            tabindex="-1"
+                          >
+                            <p
+                              class="euiComboBoxPlaceholder"
+                            >
+                              Select your category field
+                            </p>
+                            <div
+                              class="euiComboBox__input"
+                              style="font-size: 14px; display: inline-block;"
+                            >
+                              <input
+                                aria-controls=""
+                                data-test-subj="comboBoxSearchInput"
+                                id="random_html_id"
+                                role="textbox"
+                                style="box-sizing: content-box; width: 2px;"
+                                value=""
+                              />
+                              <div
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <button
+                              aria-label="Open list of options"
+                              class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                              data-test-subj="comboBoxToggleListButton"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormHelpText euiFormRow__text"
+                      id="random_html_id-help"
+                    >
+                      The category field can only be applied to the "ip" and "keyword" elasticsearch data types.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CategoryField /> spec shows callout when there are no available category fields 1`] = `
+<div>
+  <form>
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiCallOut euiCallOut--warning"
+              data-test-subj="noCategoryFieldsCallout"
+            >
+              <div
+                class="euiCallOutHeader"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+                <span
+                  class="euiCallOutHeader__title"
+                >
+                  There are no available category fields for the selected index
+                </span>
+              </div>
+            </div>
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    disabled=""
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                       class="euiFormHelpText euiFormRow__text"
                       id="random_html_id-help"
                     >
-                      The category field can only be applied to the "ip" and "keyword" elasticsearch data types.
+                      You can only apply the category field to the 'ip' and 'keyword' Elasticsearch data types.
                     </div>
                   </div>
                 </div>

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -1,5 +1,132 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<CategoryField /> spec hides callout if component is loading 1`] = `
+<div>
+  <form>
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    disabled=""
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
 exports[`<CategoryField /> spec renders the component when disabled 1`] = `
 <div>
   <form>

--- a/public/pages/EditFeatures/containers/EditFeatures.tsx
+++ b/public/pages/EditFeatures/containers/EditFeatures.tsx
@@ -104,6 +104,9 @@ export function EditFeatures(props: EditFeaturesProps) {
     false
   );
   const [isHCDetector, setIsHCDetector] = useState<boolean>(false);
+  const isLoading =
+    useSelector((state: AppState) => state.elasticsearch.requesting) ||
+    firstLoad;
 
   // When detector is loaded: get any category fields (if applicable) and
   // get all index mappings based on detector's selected index
@@ -399,6 +402,7 @@ export function EditFeatures(props: EditFeaturesProps) {
                 isHCDetector={isHCDetector}
                 categoryFieldOptions={getCategoryFields(indexDataTypes)}
                 setIsHCDetector={setIsHCDetector}
+                isLoading={isLoading}
               />
               <EuiPage>
                 <EuiPageBody>

--- a/public/pages/EditFeatures/containers/EditFeatures.tsx
+++ b/public/pages/EditFeatures/containers/EditFeatures.tsx
@@ -32,16 +32,31 @@ import {
   EuiFieldNumber,
   EuiFormRow,
 } from '@elastic/eui';
-import { FieldArray, FieldArrayRenderProps, Form, Formik, Field, FieldProps } from 'formik';
+import {
+  FieldArray,
+  FieldArrayRenderProps,
+  Form,
+  Formik,
+  Field,
+  FieldProps,
+} from 'formik';
 import { get, isEmpty } from 'lodash';
 import React, { Fragment, useState, useEffect, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 // @ts-ignore
 import { toastNotifications } from 'ui/notify';
+import { AppState } from '../../../redux/reducers';
 import { updateDetector, startDetector } from '../../../redux/reducers/ad';
-import { getErrorMessage, validatePositiveInteger, isInvalid, getError } from '../../../utils/utils';
+import { getMappings } from '../../../redux/reducers/elasticsearch';
+import {
+  getErrorMessage,
+  validatePositiveInteger,
+  isInvalid,
+  getError,
+  validateCategoryField,
+} from '../../../utils/utils';
 import { prepareDetector } from './utils/formikToFeatures';
 import { useFetchDetectorInfo } from '../../createDetector/hooks/useFetchDetectorInfo';
 //@ts-ignore
@@ -57,8 +72,11 @@ import {
   generateInitialFeatures,
   validateFeatures,
   focusOnFirstWrongFeature,
+  focusOnCategoryField,
+  getCategoryFields,
 } from '../utils/helpers';
 import { SampleAnomalies } from './SampleAnomalies';
+import { CategoryField } from '../components/CategoryField/CategoryField';
 
 interface FeaturesRouterProps {
   detectorId?: string;
@@ -71,6 +89,9 @@ export function EditFeatures(props: EditFeaturesProps) {
   useHideSideNavBar(true, false);
   const detectorId = get(props, 'match.params.detectorId', '');
   const { detector, hasError } = useFetchDetectorInfo(detectorId);
+  const indexDataTypes = useSelector(
+    (state: AppState) => state.elasticsearch.dataTypes
+  );
   const [showSaveConfirmation, setShowSaveConfirmation] = useState<boolean>(
     false
   );
@@ -79,7 +100,21 @@ export function EditFeatures(props: EditFeaturesProps) {
   >(SAVE_FEATURE_OPTIONS.START_AD_JOB);
   const [firstLoad, setFirstLoad] = useState<boolean>(true);
   const [readyToStartAdJob, setReadyToStartAdJob] = useState<boolean>(true);
-  const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(false);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(
+    false
+  );
+  const [isHCDetector, setIsHCDetector] = useState<boolean>(false);
+
+  // When detector is loaded: get any category fields (if applicable) and
+  // get all index mappings based on detector's selected index
+  useEffect(() => {
+    if (detector && get(detector, 'categoryField', []).length > 0) {
+      setIsHCDetector(true);
+    }
+    if (detector?.indices) {
+      dispatch(getMappings(detector.indices[0]));
+    }
+  }, [detector]);
 
   useEffect(() => {
     chrome.breadcrumbs.set([
@@ -201,6 +236,7 @@ export function EditFeatures(props: EditFeaturesProps) {
       const requestBody = prepareDetector(
         get(values, 'featureList', []),
         get(values, 'shingleSize', SHINGLE_SIZE),
+        get(values, 'categoryField', []),
         detector
       );
       await dispatch(updateDetector(detector.id, requestBody));
@@ -231,11 +267,29 @@ export function EditFeatures(props: EditFeaturesProps) {
       return;
     }
 
+    if (
+      isHCDetector &&
+      validateCategoryField(values.categoryField) !== undefined
+    ) {
+      setFieldTouched('categoryField', true);
+      focusOnCategoryField();
+      return;
+    }
+
     if (!focusOnFirstWrongFeature(errors, setFieldTouched)) {
       if (values.featureList.length == 0) {
         setSaveFeatureOption(SAVE_FEATURE_OPTIONS.KEEP_AD_JOB_STOPPED);
       } else {
         setSaveFeatureOption(SAVE_FEATURE_OPTIONS.START_AD_JOB);
+      }
+      if (errors.categoryField) {
+        focusOnCategoryField();
+        return;
+      }
+      // TODO: refactor advanced settings into separate component
+      // to allow for proper rendering to allow to focus on advanced settings component
+      if (errors.shingleSize) {
+        return;
       }
       setReadyToStartAdJob(values.featureList.length > 0);
       if (values.featureList.length > 0) {
@@ -250,30 +304,27 @@ export function EditFeatures(props: EditFeaturesProps) {
   const renderAdvancedSettingsToggle = () => (
     <EuiText
       className="content-panel-subTitle"
-      onClick={()=>{setShowAdvancedSettings(!showAdvancedSettings);}}
+      onClick={() => {
+        setShowAdvancedSettings(!showAdvancedSettings);
+      }}
     >
-      <EuiLink>
-        {showAdvancedSettings ? 'Hide' : 'Show'}
-      </EuiLink>
+      <EuiLink>{showAdvancedSettings ? 'Hide' : 'Show'}</EuiLink>
     </EuiText>
   );
 
   const renderAdvancedSettings = () => (
-    <Field
-      name="shingleSize"
-      validate={validatePositiveInteger}
-    >
+    <Field name="shingleSize" validate={validatePositiveInteger}>
       {({ field, form }: FieldProps) => (
         <EuiFormRow
           label="Window size"
           helpText={
             <EuiText className="content-panel-subTitle">
-              Set the number of intervals to consider in a detection
-              window. We recommend you choose this value based on your actual
-              data. If you expect missing values in your data or if you want
-              the anomalies based on the current interval, choose 1. If
-              your data is continuously ingested and you want the anomalies
-              based on multiple intervals, choose a larger window size.{' '}
+              Set the number of intervals to consider in a detection window. We
+              recommend you choose this value based on your actual data. If you
+              expect missing values in your data or if you want the anomalies
+              based on the current interval, choose 1. If your data is
+              continuously ingested and you want the anomalies based on multiple
+              intervals, choose a larger window size.{' '}
               <EuiLink
                 href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
                 target="_blank"
@@ -311,7 +362,8 @@ export function EditFeatures(props: EditFeaturesProps) {
         enableReinitialize
         initialValues={{
           featureList: generateInitialFeatures(detector),
-          shingleSize: get(detector, 'shingleSize', SHINGLE_SIZE)
+          shingleSize: get(detector, 'shingleSize', SHINGLE_SIZE),
+          categoryField: get(detector, 'categoryField', []),
         }}
         onSubmit={(values, actions) =>
           handleSubmit(values, actions.setSubmitting)
@@ -343,15 +395,24 @@ export function EditFeatures(props: EditFeaturesProps) {
                   </ContentPanel>
                 </EuiPageBody>
               </EuiPage>
+              <CategoryField
+                isHCDetector={isHCDetector}
+                categoryFieldOptions={getCategoryFields(indexDataTypes)}
+                setIsHCDetector={setIsHCDetector}
+              />
               <EuiPage>
                 <EuiPageBody>
-                  <ContentPanel title="Advanced Settings" subTitle={renderAdvancedSettingsToggle()}>
-                    {!isEmpty(detector) && showAdvancedSettings ? renderAdvancedSettings() : null}
+                  <ContentPanel
+                    title="Advanced Settings"
+                    subTitle={renderAdvancedSettingsToggle()}
+                  >
+                    {!isEmpty(detector) && showAdvancedSettings
+                      ? renderAdvancedSettings()
+                      : null}
                   </ContentPanel>
                 </EuiPageBody>
               </EuiPage>
             </Form>
-
             {!isEmpty(detector) ? (
               <SampleAnomalies
                 detector={detector}

--- a/public/pages/EditFeatures/containers/utils/formikToFeatures.ts
+++ b/public/pages/EditFeatures/containers/utils/formikToFeatures.ts
@@ -37,6 +37,7 @@ export interface FeaturesFormikValues {
 export function prepareDetector(
   featureValues: FeaturesFormikValues[],
   shingleSizeValue: number,
+  categoryFields: string[],
   ad: Detector,
   forPreview: boolean = false
 ): Detector {
@@ -47,6 +48,7 @@ export function prepareDetector(
     ...detector,
     featureAttributes: [...featureAttributes],
     shingleSize: shingleSizeValue,
+    categoryField: categoryFields,
     uiMetadata: {
       ...detector.uiMetadata,
       features: { ...formikToUIMetadata(featureValues) },
@@ -98,7 +100,7 @@ export function formikToUIMetadata(values: FeaturesFormikValues[]) {
   let features: {
     [key: string]: UiFeature;
   } = {};
-  values.forEach(value => {
+  values.forEach((value) => {
     if (value.featureType === FEATURE_TYPE.SIMPLE) {
       features[value.featureName] = {
         featureType: value.featureType,
@@ -121,7 +123,7 @@ function formikToFeatureAttributes(
   values: FeaturesFormikValues[],
   forPreview: boolean
 ): FeatureAttributes[] {
-  return values.map(function(value) {
+  return values.map(function (value) {
     const id = forPreview
       ? value.featureId
       : value.newFeature

--- a/public/pages/EditFeatures/utils/helpers.ts
+++ b/public/pages/EditFeatures/utils/helpers.ts
@@ -22,17 +22,18 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { get, forOwn } from 'lodash';
 import { FeaturesFormikValues } from '../containers/utils/formikToFeatures';
+import { DataTypes } from '../../../redux/reducers/elasticsearch';
 
 export const getFieldOptions = (
   allFields: { [key: string]: string[] },
   validTypes: DATA_TYPES[]
 ) =>
   validTypes
-    .map(dataType =>
+    .map((dataType) =>
       allFields[dataType]
         ? {
             label: dataType,
-            options: allFields[dataType].map(field => ({
+            options: allFields[dataType].map((field) => ({
               label: field,
               type: dataType,
             })),
@@ -56,8 +57,8 @@ export const getCountableFieldOptions = (allFields: {
   return getFieldOptions(
     allFields,
     Object.keys(allFields)
-      .map(field => field as DATA_TYPES)
-      .filter(field => countableDataTypes.includes(field))
+      .map((field) => field as DATA_TYPES)
+      .filter((field) => countableDataTypes.includes(field))
   );
 };
 
@@ -152,12 +153,13 @@ export const generateInitialFeatures = (
 export const focusOnFirstWrongFeature = (errors: any, setFieldTouched: any) => {
   if (
     //@ts-ignore
-    !!get(errors, 'featureList', []).filter(featureError => featureError).length
+    !!get(errors, 'featureList', []).filter((featureError) => featureError)
+      .length
   ) {
     const featureList = get(errors, 'featureList', []);
     for (let i = featureList.length - 1; i >= 0; i--) {
       if (featureList[i]) {
-        forOwn(featureList[i], function(value, key) {
+        forOwn(featureList[i], function (value, key) {
           setFieldTouched(`featureList.${i}.${key}`, true);
         });
         focusOnFeatureAccordion(i);
@@ -184,4 +186,15 @@ export const focusOnFeatureAccordion = (index: number) => {
     //@ts-ignore
     featureAccordion.click();
   }
+};
+
+export const focusOnCategoryField = () => {
+  const component = document.getElementById('categoryFieldCheckbox');
+  component?.focus();
+};
+
+export const getCategoryFields = (dataTypes: DataTypes) => {
+  const keywordFields = get(dataTypes, 'keyword', []);
+  const ipFields = get(dataTypes, 'ip', []);
+  return keywordFields.concat(ipFields);
 };

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -36,6 +36,12 @@ export const validateName = (featureName: string): string | undefined => {
   }
 };
 
+export const validateCategoryField = (val: any): string | undefined => {
+  return !val || val.length === 0
+    ? 'You must select a category field'
+    : undefined;
+};
+
 export const isInvalid = (name: string, form: any) =>
   !!get(form.touched, name, false) && !!get(form.errors, name, false);
 
@@ -89,8 +95,9 @@ export const getAlertingCreateMonitorLink = (
     const navLinks = get(npStart, 'core.chrome.navLinks', undefined);
     const url = `${navLinks.get(ALERTING_PLUGIN_NAME).url}`;
     const alertingRootUrl = getPluginRootPath(url, ALERTING_PLUGIN_NAME);
-    return `${alertingRootUrl}#/create-monitor?searchType=ad&adId=${detectorId}&name=${detectorName}&interval=${2 *
-      detectorInterval}&unit=${unit}`;
+    return `${alertingRootUrl}#/create-monitor?searchType=ad&adId=${detectorId}&name=${detectorName}&interval=${
+      2 * detectorInterval
+    }&unit=${unit}`;
   } catch (e) {
     console.error('unable to get the alerting URL', e);
     return '';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds the category field component on the edit model configuration page. This is an optional field that, when selected, will create and run a high cardinality / multi-entity detector.

Changes include:
- Adds `categoryField` field to the detector interface
- Adds category field component to the edit model config page (including validation & edge case of no eligible fields)
- Refactors and adds the `categoryField` field to the Additional settings component on detector configuration page
- Adds unit tests

All wording has been approved by UX and tech writer.

Screenshots:

1. Category field (unselected):
<img width="1399" alt="Screen Shot 2020-10-12 at 7 53 57 PM" src="https://user-images.githubusercontent.com/62119629/95811088-5b9d6900-0cc7-11eb-85b3-46339b7b97aa.png">

2. Category field (selected):
<img width="1385" alt="Screen Shot 2020-10-12 at 7 58 22 PM" src="https://user-images.githubusercontent.com/62119629/95811110-6952ee80-0cc7-11eb-9b36-281b36e64e27.png">

3. Category field (no eligible fields in index):
<img width="1391" alt="Screen Shot 2020-10-12 at 7 55 31 PM" src="https://user-images.githubusercontent.com/62119629/95811122-7079fc80-0cc7-11eb-9658-147907ebb69c.png">

4. Category field under 'Additional settings':
<img width="1343" alt="Screen Shot 2020-10-12 at 7 55 05 PM" src="https://user-images.githubusercontent.com/62119629/95811142-7a036480-0cc7-11eb-84e4-ccd914cb2df2.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
