### PR TITLE
added the order for the plugin placement in revised kibana side menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export default (kibana) => {
         icon:
           'plugins/opendistro-anomaly-detection-kibana/images/anomaly_detection_icon.svg',
         category: DEFAULT_APP_CATEGORIES.kibana,
+        order:8030,
       },
       styleSheetPaths: [
         resolve(__dirname, 'public/app.scss'),


### PR DESCRIPTION
*[Issue](https://issues.amazon.com/issues/Kibana-1000)*

*As per the new Kibana side menu requirement, Anomaly Detection should come after Alerting*
Order value of Visualize according to this [file](https://github.com/elastic/kibana/blob/master/src/plugins/visualize/public/plugin.ts) is 8000
So, in order to maintain Kibana plugins after Visualize order can be:
​Plugin | Order value​
-- | --
​Query Workbench | ​8010
​Alerting | ​8020
​Anomaly Detection | ​8030
​Notebooks | ​8040




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
