### PR TITLE
Clear model configuration if detector index is changed

### DIFF
--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -230,7 +230,6 @@ export function CreateDetector(props: CreateADProps) {
     setSampleCalloutVisible(false);
   };
 
-  console.log('newIndexSelected: ', newIndexSelected);
   return (
     <EuiPage>
       <EuiPageBody>
@@ -264,6 +263,7 @@ export function CreateDetector(props: CreateADProps) {
                 formikProps={formikProps}
                 origIndex={props.isEdit ? get(detector, 'indices.0', '') : null}
                 setNewIndexSelected={setNewIndexSelected}
+                isEdit={props.isEdit}
               />
               <EuiSpacer />
               <Settings />

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -57,6 +57,7 @@ import { useHideSideNavBar } from '../../main/hooks/useHideSideNavBar';
 import { CatIndex } from '../../../../server/models/types';
 import { SampleDataCallout } from '../../SampleData/components/SampleDataCallout/SampleDataCallout';
 import { containsDetectorsIndex } from '../../SampleData/utils/helpers';
+import { clearModelConfiguration } from './utils/helpers';
 
 interface CreateRouterProps {
   detectorId?: string;
@@ -79,6 +80,7 @@ export function CreateDetector(props: CreateADProps) {
   const visibleIndices = useSelector(
     (state: AppState) => state.elasticsearch.indices
   ) as CatIndex[];
+  const [newIndexSelected, setNewIndexSelected] = useState<boolean>(false);
 
   // Getting all initial indices
   useEffect(() => {
@@ -122,9 +124,13 @@ export function CreateDetector(props: CreateADProps) {
 
   const handleUpdate = async (detectorToBeUpdated: Detector) => {
     try {
-      await dispatch(updateDetector(detectorId, detectorToBeUpdated));
+      // If a new index was selected: clear any existing features and category fields
+      const preparedDetector = newIndexSelected
+        ? clearModelConfiguration(detectorToBeUpdated)
+        : detectorToBeUpdated;
+      await dispatch(updateDetector(detectorId, preparedDetector));
       toastNotifications.addSuccess(
-        `Detector updated: ${detectorToBeUpdated.name}`
+        `Detector updated: ${preparedDetector.name}`
       );
       props.history.push(`/detectors/${detectorId}/configurations/`);
     } catch (err) {
@@ -224,6 +230,7 @@ export function CreateDetector(props: CreateADProps) {
     setSampleCalloutVisible(false);
   };
 
+  console.log('newIndexSelected: ', newIndexSelected);
   return (
     <EuiPage>
       <EuiPageBody>
@@ -253,7 +260,11 @@ export function CreateDetector(props: CreateADProps) {
             <Fragment>
               <DetectorInfo onValidateDetectorName={handleValidateName} />
               <EuiSpacer />
-              <DataSource formikProps={formikProps} />
+              <DataSource
+                formikProps={formikProps}
+                origIndex={props.isEdit ? get(detector, 'indices.0', '') : null}
+                setNewIndexSelected={setNewIndexSelected}
+              />
               <EuiSpacer />
               <Settings />
               <EuiSpacer />

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -14,7 +14,7 @@
  */
 
 import { EuiComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
-import { Field, FieldProps } from 'formik';
+import { Field, FieldProps, FormikProps } from 'formik';
 import { debounce, get, isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -30,16 +30,22 @@ import { getError, isInvalid, required } from '../../../../utils/utils';
 import { IndexOption } from '../../components/Datasource/IndexOption';
 import { getVisibleOptions, sanitizeSearchText } from '../../../utils/helpers';
 import { validateIndex } from '../../../utils/validate';
-import {
-  DataFilterProps,
-  DataFilter,
-} from '../../components/DataFilters/DataFilter';
+import { DataFilter } from '../../components/DataFilters/DataFilter';
 import { FormattedFormRow } from '../../components/FormattedFormRow/FormattedFormRow';
+import { ADFormikValues } from '../../containers/models/interfaces';
 
-function DataSource(props: DataFilterProps) {
+interface DataSourceProps {
+  formikProps: FormikProps<ADFormikValues>;
+  origIndex: string;
+  setNewIndexSelected: (isNew: boolean) => void;
+}
+
+function DataSource(props: DataSourceProps) {
   const dispatch = useDispatch();
   const [queryText, setQueryText] = useState('');
-  const [indexName, setIndexName] = useState(undefined);
+  const [indexName, setIndexName] = useState<string>(
+    props.formikProps.values.index[0]?.label
+  );
   const elasticsearchState = useSelector(
     (state: AppState) => state.elasticsearch
   );
@@ -49,6 +55,10 @@ function DataSource(props: DataFilterProps) {
     };
     getInitialIndices();
   }, []);
+
+  useEffect(() => {
+    setIndexName(props.formikProps.values.index[0]?.label);
+  }, [props.formikProps]);
 
   const handleSearchChange = debounce(async (searchValue: string) => {
     if (searchValue !== queryText) {
@@ -64,6 +74,11 @@ function DataSource(props: DataFilterProps) {
     if (indexName !== '') {
       dispatch(getMappings(indexName));
     }
+    if (indexName !== props.origIndex) {
+      props.setNewIndexSelected(true);
+    } else {
+      props.setNewIndexSelected(false);
+    }
   };
 
   const dateFields = Array.from(
@@ -72,7 +87,7 @@ function DataSource(props: DataFilterProps) {
 
   const timeStampFieldOptions = isEmpty(dateFields)
     ? []
-    : dateFields.map(dateField => ({ label: dateField }));
+    : dateFields.map((dateField) => ({ label: dateField }));
 
   const visibleIndices = get(elasticsearchState, 'indices', []) as CatIndex[];
   const visibleAliases = get(elasticsearchState, 'aliases', []) as IndexAlias[];
@@ -88,8 +103,22 @@ function DataSource(props: DataFilterProps) {
       : initialIndex.includes(':');
   };
 
+  const isDifferentIndex = () => {
+    return !isEmpty(props.origIndex) && indexName !== props.origIndex;
+  };
+
   return (
     <ContentPanel title="Data Source" titleSize="s">
+      {isDifferentIndex() ? (
+        <div>
+          <EuiCallOut
+            title="Selecting a new index will delete the existing model configuration."
+            color="warning"
+            iconType="alert"
+          />
+          <EuiSpacer size="m" />
+        </div>
+      ) : null}
       {isRemoteIndex() ? (
         <div>
           <EuiCallOut
@@ -127,7 +156,7 @@ function DataSource(props: DataFilterProps) {
                 onBlur={() => {
                   form.setFieldTouched('index', true);
                 }}
-                onChange={options => {
+                onChange={(options) => {
                   form.setFieldValue('index', options);
                   form.setFieldValue('timeField', undefined);
                   handleIndexNameChange(options);
@@ -168,7 +197,7 @@ function DataSource(props: DataFilterProps) {
               onBlur={() => {
                 form.setFieldTouched('timeField', true);
               }}
-              onChange={options => {
+              onChange={(options) => {
                 form.setFieldValue('timeField', get(options, '0.label'));
               }}
               selectedOptions={(field.value && [{ label: field.value }]) || []}

--- a/public/pages/createDetector/containers/DataSource/DataSource.tsx
+++ b/public/pages/createDetector/containers/DataSource/DataSource.tsx
@@ -38,6 +38,7 @@ interface DataSourceProps {
   formikProps: FormikProps<ADFormikValues>;
   origIndex: string;
   setNewIndexSelected: (isNew: boolean) => void;
+  isEdit: boolean;
 }
 
 function DataSource(props: DataSourceProps) {
@@ -104,7 +105,7 @@ function DataSource(props: DataSourceProps) {
   };
 
   const isDifferentIndex = () => {
-    return !isEmpty(props.origIndex) && indexName !== props.origIndex;
+    return props.isEdit && indexName !== props.origIndex;
   };
 
   return (

--- a/public/pages/createDetector/containers/utils/helpers.tsx
+++ b/public/pages/createDetector/containers/utils/helpers.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { Detector } from '../../../../models/interfaces';
+import { SHINGLE_SIZE } from '../../../../utils/constants';
+
+export function clearModelConfiguration(ad: Detector): Detector {
+  return {
+    ...ad,
+    featureAttributes: [],
+    uiMetadata: {
+      ...ad.uiMetadata,
+      features: {},
+    },
+    categoryField: undefined,
+    shingleSize: SHINGLE_SIZE,
+  };
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds validation in the edit detector page, where if a user is editing an existing detector, the corresponding model configuration will be cleared if a new index is selected. The warning goes away and nothing is cleared if the user selects back to the originally selected index.

Screenshot (existing index):
<img width="1032" alt="Screen Shot 2020-10-19 at 2 19 00 PM" src="https://user-images.githubusercontent.com/62119629/96512959-27213400-1216-11eb-8e9c-68fc4274b6d6.png">

Screenshot (new index w/ warning callout):
<img width="1043" alt="Screen Shot 2020-10-19 at 2 19 13 PM" src="https://user-images.githubusercontent.com/62119629/96512964-29838e00-1216-11eb-9de3-5fc1389bbc82.png">


Notes:
- Confirmed with UX on wording and design
- Confirmed no UT break
- Confirmed this callout never shows up if creating a detector

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
