### PR TITLE
wording change for Preview page in case of no anomalies

### DIFF
--- a/public/pages/EditFeatures/containers/SampleAnomalies.tsx
+++ b/public/pages/EditFeatures/containers/SampleAnomalies.tsx
@@ -223,9 +223,9 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
           <EuiSpacer />
           {previewDone && !anomaliesResult.anomalies.length ? (
             <EuiCallOut
-              title={
-                'No sample anomaly result generated. Please check detector interval and make sure you have >400 data points during preview date range'
-              }
+              title={`No sample anomaly result generated. Please check detector interval and make sure you have >400 data points${
+                isHCDetector ? ' for some entities ' : ' '
+              }during preview date range`}
               color="warning"
               iconType="alert"
             ></EuiCallOut>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
wording change for Preview page in case of no anomalies

Single entity detector: same as before
![Screen Shot 2020-10-20 at 2 50 43 PM](https://user-images.githubusercontent.com/59710443/96648858-e04e3f80-12e4-11eb-97a6-703188007b79.png)

HC detector: add `for some entities`
![Screen Shot 2020-10-20 at 2 51 03 PM](https://user-images.githubusercontent.com/59710443/96648917-f956f080-12e4-11eb-8c18-64699567538f.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
