### PR TITLE
Query anomaly only for HC detector

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -170,10 +170,17 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     try {
       const params = buildParamsForGetAnomalyResultsWithDateRange(
         dateRange.startDate -
-          FEATURE_DATA_CHECK_WINDOW_OFFSET *
-            detectorInterval *
-            MIN_IN_MILLI_SECS,
-        dateRange.endDate
+          // for non HC detector, rawData is used for feature missing check
+          // which needs window offset for time range.
+          // But it is not needed for HC detector
+          (isHCDetector
+            ? 0
+            : FEATURE_DATA_CHECK_WINDOW_OFFSET *
+              detectorInterval *
+              MIN_IN_MILLI_SECS),
+        dateRange.endDate,
+        // get anomaly only data if HC detector
+        isHCDetector
       );
       const detectorResultResponse = await dispatch(
         getDetectorResults(props.detector.id, params)
@@ -241,7 +248,6 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     : bucketizedAnomalyResults
     ? bucketizedAnomalyResults
     : atomicAnomalyResults;
-
   const handleDateRangeChange = useCallback(
     (startDate: number, endDate: number, dateRangeOption?: string) => {
       setDateRange({

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -76,7 +76,8 @@ export const getLiveAnomalyResults = (
 
 export const buildParamsForGetAnomalyResultsWithDateRange = (
   startTime: number,
-  endTime: number
+  endTime: number,
+  anomalyOnly: boolean = false
 ) => {
   return {
     from: 0,
@@ -88,6 +89,7 @@ export const buildParamsForGetAnomalyResultsWithDateRange = (
       endTime: endTime,
       fieldName: AD_DOC_FIELDS.DATA_START_TIME,
     },
+    anomalyThreshold: anomalyOnly ? 0 : -1,
   };
 };
 

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -590,6 +590,7 @@ const getAnomalyResults = async (
       sortDirection = SORT_DIRECTION.DESC,
       sortField = AD_DOC_FIELDS.DATA_START_TIME,
       dateRangeFilter = undefined,
+      anomalyThreshold = -1,
       //@ts-ignore
     } = req.query as {
       from: number;
@@ -597,6 +598,7 @@ const getAnomalyResults = async (
       sortDirection: SORT_DIRECTION;
       sortField?: string;
       dateRangeFilter?: string;
+      anomalyThreshold: number;
     };
     const { detectorId } = req.params;
 
@@ -628,6 +630,14 @@ const getAnomalyResults = async (
             {
               term: {
                 detector_id: detectorId,
+              },
+            },
+
+            {
+              range: {
+                anomaly_grade: {
+                  gt: anomalyThreshold,
+                },
               },
             },
           ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Query anomaly only for HC detector. This is for issue found during performance test: in current implementation, if there are over 10K(our upper limit) anomaly results during query time range, we only get 10K results, including both 0 and >0 result, so that we may miss anomalies with grade > 0. It is easy to get into such case for HC detector. 

And actually HC detector for now only uses anomalyResults with grade > 0, thus I change to only get anomalyResults with grade > 0 for HC detector to avoid above case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
