### PR TITLE
Add match and count APIs

### DIFF
--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -154,13 +154,8 @@ export function CreateDetector(props: CreateADProps) {
         `/detectors/${detectorResp.data.response.id}/configurations/`
       );
     } catch (err) {
-      const resp = await dispatch(
-        getDetectorCount()
-        // searchDetector({
-        //   query: { bool: { must_not: { match: { name: '' } } } },
-        // })
-      );
-      const totalDetectors = resp.data.response.totalDetectors;
+      const resp = await dispatch(getDetectorCount());
+      const totalDetectors = resp.data.response.count;
       if (totalDetectors === MAX_DETECTORS) {
         toastNotifications.addDanger(
           'Cannot create detector - limit of ' +
@@ -198,12 +193,6 @@ export function CreateDetector(props: CreateADProps) {
   };
 
   const handleValidateName = async (detectorName: string) => {
-    const {
-      isEdit,
-      match: {
-        params: { detectorId },
-      },
-    } = props;
     if (isEmpty(detectorName)) {
       throw 'Detector name cannot be empty';
     } else {
@@ -212,24 +201,17 @@ export function CreateDetector(props: CreateADProps) {
         throw error;
       }
       //TODO::Avoid making call if value is same
-      const resp = await dispatch(
-        matchDetector(detectorName)
-        //searchDetector({ query: { term: { 'name.keyword': detectorName } } })
-      );
-      const totalDetectors = resp.data.response.totalDetectors;
-      if (totalDetectors === 0) {
+      const resp = await dispatch(matchDetector(detectorName));
+      const match = resp.data.response.match;
+      if (!match) {
         return undefined;
       }
       //If more than one detectors found, duplicate exists.
-      if (!isEdit && totalDetectors > 0) {
+      if (!props.isEdit && match) {
         throw 'Duplicate detector name';
       }
       // if it is in edit mode
-      if (
-        isEdit &&
-        (totalDetectors > 1 ||
-          get(resp, 'data.response.detectors.0.id', '') !== detectorId)
-      ) {
+      if (props.isEdit && detectorName !== detector?.name) {
         throw 'Duplicate detector name';
       }
     }

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -40,6 +40,8 @@ import {
   createDetector,
   searchDetector,
   updateDetector,
+  matchDetector,
+  getDetectorCount,
 } from '../../../redux/reducers/ad';
 import { getIndices } from '../../../redux/reducers/elasticsearch';
 import { AppState } from '../../../redux/reducers';
@@ -153,9 +155,10 @@ export function CreateDetector(props: CreateADProps) {
       );
     } catch (err) {
       const resp = await dispatch(
-        searchDetector({
-          query: { bool: { must_not: { match: { name: '' } } } },
-        })
+        getDetectorCount()
+        // searchDetector({
+        //   query: { bool: { must_not: { match: { name: '' } } } },
+        // })
       );
       const totalDetectors = resp.data.response.totalDetectors;
       if (totalDetectors === MAX_DETECTORS) {
@@ -210,7 +213,8 @@ export function CreateDetector(props: CreateADProps) {
       }
       //TODO::Avoid making call if value is same
       const resp = await dispatch(
-        searchDetector({ query: { term: { 'name.keyword': detectorName } } })
+        matchDetector(detectorName)
+        //searchDetector({ query: { term: { 'name.keyword': detectorName } } })
       );
       const totalDetectors = resp.data.response.totalDetectors;
       if (totalDetectors === 0) {

--- a/public/pages/createDetector/containers/CreateDetector.tsx
+++ b/public/pages/createDetector/containers/CreateDetector.tsx
@@ -38,7 +38,6 @@ import { toastNotifications } from 'ui/notify';
 import { APIAction } from '../../../redux/middleware/types';
 import {
   createDetector,
-  searchDetector,
   updateDetector,
   matchDetector,
   getDetectorCount,
@@ -155,7 +154,7 @@ export function CreateDetector(props: CreateADProps) {
       );
     } catch (err) {
       const resp = await dispatch(getDetectorCount());
-      const totalDetectors = resp.data.response.count;
+      const totalDetectors = get(resp, 'data.response.count', 0);
       if (totalDetectors === MAX_DETECTORS) {
         toastNotifications.addDanger(
           'Cannot create detector - limit of ' +
@@ -202,7 +201,7 @@ export function CreateDetector(props: CreateADProps) {
       }
       //TODO::Avoid making call if value is same
       const resp = await dispatch(matchDetector(detectorName));
-      const match = resp.data.response.match;
+      const match = get(resp, 'data.response.match', false);
       if (!match) {
         return undefined;
       }

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ const DELETE_DETECTOR = 'ad/DELETE_DETECTOR';
 const START_DETECTOR = 'ad/START_DETECTOR';
 const STOP_DETECTOR = 'ad/STOP_DETECTOR';
 const GET_DETECTOR_PROFILE = 'ad/GET_DETECTOR_PROFILE';
+const MATCH_DETECTOR = 'ad/MATCH_DETECTOR';
+const GET_DETECTOR_COUNT = 'ad/GET_DETECTOR_COUNT';
 
 export interface Detectors {
   requesting: boolean;
@@ -264,6 +266,40 @@ const reducer = handleActions<Detectors>(
         errorMessage: action.error,
       }),
     },
+    [MATCH_DETECTOR]: {
+      REQUEST: (state: Detectors): Detectors => ({
+        ...state,
+        requesting: true,
+        errorMessage: '',
+      }),
+      SUCCESS: (state: Detectors): Detectors => ({
+        ...state,
+        requesting: false,
+        errorMessage: '',
+      }),
+      FAILURE: (state: Detectors, action: APIResponseAction): Detectors => ({
+        ...state,
+        requesting: false,
+        errorMessage: action.error,
+      }),
+    },
+    [GET_DETECTOR_COUNT]: {
+      REQUEST: (state: Detectors): Detectors => ({
+        ...state,
+        requesting: true,
+        errorMessage: '',
+      }),
+      SUCCESS: (state: Detectors): Detectors => ({
+        ...state,
+        requesting: false,
+        errorMessage: '',
+      }),
+      FAILURE: (state: Detectors, action: APIResponseAction): Detectors => ({
+        ...state,
+        requesting: false,
+        errorMessage: action.error,
+      }),
+    },
   },
   initialDetectorsState
 );
@@ -342,6 +378,21 @@ export const getDetectorProfile = (detectorId: string): APIAction => ({
       params: detectorId,
     }),
   detectorId,
+});
+
+export const matchDetector = (detectorName: string): APIAction => ({
+  type: MATCH_DETECTOR,
+  request: (client: IHttpService) =>
+    client.get(`..${AD_NODE_API.DETECTOR}/${detectorName}/_match`, {
+      params: detectorName,
+    }),
+  detectorName,
+});
+
+export const getDetectorCount = (): APIAction => ({
+  type: GET_DETECTOR_COUNT,
+  request: (client: IHttpService) =>
+    client.get(`..${AD_NODE_API.DETECTOR}/_count`, {}),
 });
 
 export default reducer;

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -136,6 +136,25 @@ export default function adPlugin(Client: any, config: any, components: any) {
           required: true,
         },
       },
+    },
+    method: 'GET',
+  });
+  ad.matchDetector = ca({
+    url: {
+      fmt: `${API.DETECTOR_BASE}/_match?name=<%=detectorName%>`,
+      req: {
+        detectorName: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: 'GET',
+  });
+  ad.detectorCount = ca({
+    url: {
+      fmt: `${API.DETECTOR_BASE}/_count`,
     },
     method: 'GET',
   });

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -141,7 +141,7 @@ export default function adPlugin(Client: any, config: any, components: any) {
   });
   ad.matchDetector = ca({
     url: {
-      fmt: `${API.DETECTOR_BASE}/_match?name=<%=detectorName%>`,
+      fmt: `${API.DETECTOR_BASE}/match?name=<%=detectorName%>`,
       req: {
         detectorName: {
           type: 'string',
@@ -154,7 +154,7 @@ export default function adPlugin(Client: any, config: any, components: any) {
   });
   ad.detectorCount = ca({
     url: {
-      fmt: `${API.DETECTOR_BASE}/_count`,
+      fmt: `${API.DETECTOR_BASE}/count`,
     },
     method: 'GET',
   });

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -71,6 +71,8 @@ export default function (apiRouter: Router) {
   apiRouter.post('/detectors/{detectorId}/start', startDetector);
   apiRouter.post('/detectors/{detectorId}/stop', stopDetector);
   apiRouter.get('/detectors/{detectorId}/_profile', getDetectorProfile);
+  apiRouter.get('/detectors/{detectorName}/_match', matchDetector);
+  apiRouter.get('/detectors/_count', getDetectorCount);
 }
 
 const deleteDetector = async (
@@ -742,6 +744,45 @@ const getAnomalyResults = async (
       ok: false,
       error: getErrorMessage(err),
     };
+  }
+};
+
+const matchDetector = async (
+  req: Request,
+  h: ResponseToolkit,
+  callWithRequest: CallClusterWithRequest
+): Promise<ServerResponse<AnomalyResults>> => {
+  try {
+    const { detectorName } = req.params;
+    console.log('calling matchDetector() w/ detector name: ', detectorName);
+    const response = await callWithRequest(req, 'ad.matchDetector', {
+      detectorName,
+    });
+    return {
+      ok: true,
+      response: response,
+    };
+  } catch (err) {
+    console.log('Anomaly detector - matchDetector', err);
+    return { ok: false, error: err.message };
+  }
+};
+
+const getDetectorCount = async (
+  req: Request,
+  h: ResponseToolkit,
+  callWithRequest: CallClusterWithRequest
+): Promise<ServerResponse<AnomalyResults>> => {
+  console.log('calling getDetectorCount():');
+  try {
+    const response = await callWithRequest(req, 'ad.detectorCount');
+    return {
+      ok: true,
+      response: response,
+    };
+  } catch (err) {
+    console.log('Anomaly detector - getDetectorCount', err);
+    return { ok: false, error: err.message };
   }
 };
 

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -754,7 +754,6 @@ const matchDetector = async (
 ): Promise<ServerResponse<AnomalyResults>> => {
   try {
     const { detectorName } = req.params;
-    console.log('calling matchDetector() w/ detector name: ', detectorName);
     const response = await callWithRequest(req, 'ad.matchDetector', {
       detectorName,
     });
@@ -764,7 +763,7 @@ const matchDetector = async (
     };
   } catch (err) {
     console.log('Anomaly detector - matchDetector', err);
-    return { ok: false, error: err.message };
+    return { ok: false, error: getErrorMessage(err) };
   }
 };
 
@@ -773,7 +772,6 @@ const getDetectorCount = async (
   h: ResponseToolkit,
   callWithRequest: CallClusterWithRequest
 ): Promise<ServerResponse<AnomalyResults>> => {
-  console.log('calling getDetectorCount():');
   try {
     const response = await callWithRequest(req, 'ad.detectorCount');
     return {
@@ -782,7 +780,7 @@ const getDetectorCount = async (
     };
   } catch (err) {
     console.log('Anomaly detector - getDetectorCount', err);
-    return { ok: false, error: err.message };
+    return { ok: false, error: getErrorMessage(err) };
   }
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds frontend support for the implemented `match` and `count` APIs (see [here](https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/286)).

These apis are used in 2 different parts for validation on the create/edit detector page, replacing the search API which caused a security leak by returning extra detector information for a user which they may not be supposed to have access to.

Notes:
- confirmed no UT breaks
- confirmed both APIs return correct information
- tested on edit and create to confirm the validation for duplicate name worked appropriately

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
