### PR TITLE
Fix broken UT when doing duplicate name validation

### DIFF
--- a/public/pages/SampleData/utils/helpers.tsx
+++ b/public/pages/SampleData/utils/helpers.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import { isEmpty } from 'lodash';
 import { EuiDataGrid } from '@elastic/eui';
 import { CatIndex } from '../../../../server/models/types';
 import { Detector, DetectorListItem } from '../../../models/interfaces';
@@ -25,6 +26,9 @@ import {
 } from '../utils/constants';
 
 export const containsDetectorsIndex = (indices: CatIndex[]) => {
+  if (isEmpty(indices)) {
+    return false;
+  }
   return indices.map((index) => index.index).includes(ANOMALY_DETECTORS_INDEX);
 };
 

--- a/public/pages/createDetector/containers/__tests__/CreateDetector.test.tsx
+++ b/public/pages/createDetector/containers/__tests__/CreateDetector.test.tsx
@@ -89,10 +89,10 @@ describe('<CreateDetector /> spec', () => {
 
     test('prevent duplicate detector name', async () => {
       const randomDetector = getRandomDetector();
-      httpClientMock.post = jest.fn().mockResolvedValue({
+      httpClientMock.get = jest.fn().mockResolvedValue({
         data: {
           ok: true,
-          response: { detectors: [randomDetector], totalDetectors: 1 },
+          response: { count: 0, match: true },
         },
       });
       const { getByPlaceholderText, getByText } = renderWithRouter();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the UT that was broken after #324 was merged. Also adds a null/empty check in `containsDetectorIndex()` helper fn.

Confirmed all UT pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
