### PR TITLE
Show second for heatmap cell hover timestamp

### DIFF
--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
@@ -197,7 +197,7 @@ const getHeatmapColorByValue = (value: number) => {
 
 const NUM_CELLS = 20;
 
-export const HEATMAP_X_AXIS_DATE_FORMAT = 'MM-DD HH:mm YYYY';
+export const HEATMAP_X_AXIS_DATE_FORMAT = 'MM-DD HH:mm:ss YYYY';
 
 const buildBlankStringWithLength = (length: number) => {
   let result = '';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Show second for heatmap cell hover timestamp. This is fix to make sure number of anomalies in each heatmap cell is consistent with Anomaly Result table and anomaly details chart.

Currently the date range for heatmap cell is determined by splitting overall date change into 20 windows evenly, and it is precise to milliseconds, and then convert it to `HH:mm` for heatmap cell. Number of anomalies in each heatmap cell is calculated with time range in milliseconds, but its timestamp shown in heatmap chart is in minutes. And when heatmap cell is selected, we convert timestamp in heatmap chart(in minutes) to specified date range (in milliseconds), and it is used to filter out result for Anomaly Result table and anomaly details chart.

The issue in above process is conversion from date range in milliseconds to timestamp for heatmap in minutes, and then convert it to timestamp in milliseconds. It will cause some anomalies which are in original date range, but are considered as outside of timestamp in minutes, and then number of anomalies are inconsistent with result of Anomaly Result table and anomaly details chart.

For example, if anomaly happens at time 10:00:04, and its timestamp will be 10:00:00, it might be in the cell of from 09:58:00 to 10:00:00, but when the cell is selected, the date range we got is then 09:58:00 to 10:00:00, which is also used in filtering in Anomaly Result table and anomaly details chart, and then that anomaly won't show up in Anomaly Result table and anomaly details chart.

Changing timestamp in heatmap chart to seconds will make sure it is precise in seconds, and won't cause above issue again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
