### PR TITLE
Fix sunburst chart height is 0

### DIFF
--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -170,67 +170,65 @@ export const AnomaliesDistributionChart = (
         <EuiFlexGroup justifyContent="center">
           <EuiFlexItem grow={false}>
             {isEmpty(anomalyDistribution) ? null : (
-              <Chart className="anomalies-distribution-sunburst">
-                <Partition
-                  id="Anomalies by index and detector"
-                  data={anomalyDistribution}
-                  valueAccessor={(d: Datum) => d.count as number}
-                  valueFormatter={(d: number) => d.toString()}
-                  layers={[
-                    {
-                      groupByRollup: (d: Datum) => d.indices,
-                      nodeLabel: (d: Datum) => {
-                        return d;
+              <div className="anomalies-distribution-sunburst">
+                <Chart>
+                  <Partition
+                    id="Anomalies by index and detector"
+                    data={anomalyDistribution}
+                    valueAccessor={(d: Datum) => d.count as number}
+                    valueFormatter={(d: number) => d.toString()}
+                    layers={[
+                      {
+                        groupByRollup: (d: Datum) => d.indices,
+                        nodeLabel: (d: Datum) => {
+                          return d;
+                        },
+                        fillLabel: {
+                          textInvertible: true,
+                        },
+                        shape: {
+                          fillColor: (d) => {
+                            return fillOutColors(
+                              d,
+                              (d.x0 + d.x1) / 2 / (2 * Math.PI),
+                              []
+                            );
+                          },
+                        },
                       },
+                      {
+                        groupByRollup: (d: Datum) => d.name,
+                        nodeLabel: (d: Datum) => {
+                          return d;
+                        },
+                        fillLabel: {
+                          textInvertible: true,
+                        },
+                        shape: {
+                          fillColor: (d) => {
+                            return fillOutColors(
+                              d,
+                              (d.x0 + d.x1) / 2 / (2 * Math.PI),
+                              []
+                            );
+                          },
+                        },
+                      },
+                    ]}
+                    config={{
+                      partitionLayout: PartitionLayout.sunburst,
+                      fontFamily: 'Arial',
+                      outerSizeRatio: 1,
                       fillLabel: {
                         textInvertible: true,
                       },
-                      shape: {
-                        fillColor: (d) => {
-                          return fillOutColors(
-                            d,
-                            (d.x0 + d.x1) / 2 / (2 * Math.PI),
-                            []
-                          );
-                        },
+                      linkLabel: {
+                        maxCount: 0,
                       },
-                    },
-                    {
-                      groupByRollup: (d: Datum) => d.name,
-                      nodeLabel: (d: Datum) => {
-                        return d;
-                      },
-                      fillLabel: {
-                        textInvertible: true,
-                      },
-                      shape: {
-                        fillColor: (d) => {
-                          return fillOutColors(
-                            d,
-                            (d.x0 + d.x1) / 2 / (2 * Math.PI),
-                            []
-                          );
-                        },
-                      },
-                    },
-                  ]}
-                  config={{
-                    partitionLayout: PartitionLayout.sunburst,
-                    fontFamily: 'Arial',
-                    outerSizeRatio: 1,
-                    fillLabel: {
-                      textInvertible: true,
-                    },
-                    linkLabel: {
-                      maxCount: 0,
-                    },
-                    // TODO: Given only 1 detector exists, the inside Index circle will have issue in following scenarios:
-                    // 1: if Linked Label is configured for identifying index, label of Index circle will be invisible;
-                    // 2: if Fill Label is configured for identifying index, label of it will be overlapped with outer Detector circle
-                    // Issue link: https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/24
-                  }}
-                />
-              </Chart>
+                    }}
+                  />
+                </Chart>
+              </div>
             )}
           </EuiFlexItem>
         </EuiFlexGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In 7.10.0, the Elastic chart library is upgraded to [version 23](https://github.com/elastic/kibana/blob/v7.10.0/package.json#L226), while in 7.9.1, it is still [version 19](https://github.com/elastic/kibana/blob/v7.9.1/package.json#L127). In the new version of Elastic chart library, sunburst chart  has class "echChart" [automatically added to it](https://github.com/elastic/elastic-charts/blob/83919ffe294257839d360b589ce10f405e04af5b/src/components/chart.tsx#L164), while [echChart](https://github.com/elastic/elastic-charts/blob/83919ffe294257839d360b589ce10f405e04af5b/src/components/_container.scss#L1) is using `height 100%`, which causes the height of chart is 0 because its parent component has no height value specified.

Thus the fix is to explicitly add sunburst class as its parent.

Before:
![Screen Shot 2020-11-24 at 2 35 34 PM](https://user-images.githubusercontent.com/59710443/100159556-d0d19180-2e62-11eb-9bed-1e2e40dfb8c7.png)

After:
![Screen Shot 2020-11-24 at 2 34 54 PM](https://user-images.githubusercontent.com/59710443/100159568-d6c77280-2e62-11eb-8e4f-05465bd6b60f.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
