### PR TITLE
fix tiny odfe login icon

### DIFF
--- a/public/app.scss
+++ b/public/app.scss
@@ -19,4 +19,3 @@
 @import 'pages/DetectorConfig/index.scss';
 @import 'pages/AnomalyCharts/index.scss';
 @import 'pages/DetectorResults/index.scss';
-@import 'images/icon.scss';

--- a/public/images/icon.scss
+++ b/public/images/icon.scss
@@ -1,9 +1,0 @@
-/*
-Fixes the custom plugin icon scaling issue
-*/
-figure {
-  max-width: 16px !important;
-  margin-right: 12px;
-  flex-grow: 0;
-  flex-shrink: 0;
-}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We add custom figure css before to fix plugin icon scaling issue. Now we have no plugin icon. And this css have "!import" which override default style of all images which using `figure` css style. So just remove this to fix. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
