### PR TITLE
Add historical detector list page

### DIFF
--- a/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
+++ b/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
@@ -17,10 +17,10 @@ import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import React from 'react';
 import { APP_PATH, PLUGIN_NAME } from '../../../../utils/constants';
 
-const filterText =
+const FILTER_TEXT =
   'There are no historical detectors matching your applied filters. Reset your filters to view all historical detectors.';
-const emptyText =
-  'Historical detectors allow you to detect anomalies on your historical data. You may also use them to pre-train or tune your model by using your index history to train an anomaly detector.';
+const EMPTY_TEXT =
+  'Use historical detectors to detect anomalies on a selected time range of your historic data.';
 
 interface EmptyHistoricalDetectorMessageProps {
   isFilterApplied: boolean;
@@ -34,7 +34,7 @@ export const EmptyHistoricalDetectorMessage = (
     style={{ maxWidth: '45em' }}
     body={
       <EuiText>
-        <p>{props.isFilterApplied ? filterText : emptyText}</p>
+        <p>{props.isFilterApplied ? FILTER_TEXT : EMPTY_TEXT}</p>
       </EuiText>
     }
     actions={

--- a/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
+++ b/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import React from 'react';
+import { APP_PATH, PLUGIN_NAME } from '../../../../utils/constants';
+
+const filterText =
+  'There are no historical detectors matching your applied filters. Reset your filters to view all historical detectors.';
+const emptyText =
+  'Historical detectors allow you to detect anomalies on your historical data. You may also use them to pre-train or tune your model by using your index history to train an anomaly detector.';
+
+interface EmptyHistoricalDetectorMessageProps {
+  isFilterApplied: boolean;
+  onResetFilters: () => void;
+}
+
+export const EmptyHistoricalDetectorMessage = (
+  props: EmptyHistoricalDetectorMessageProps
+) => (
+  <EuiEmptyPrompt
+    style={{ maxWidth: '45em' }}
+    body={
+      <EuiText>
+        <p>{props.isFilterApplied ? filterText : emptyText}</p>
+      </EuiText>
+    }
+    actions={
+      props.isFilterApplied ? (
+        <EuiButton
+          fill
+          onClick={props.onResetFilters}
+          data-test-subj="resetHistoricalDetectorListFilters"
+        >
+          Reset filters
+        </EuiButton>
+      ) : (
+        <EuiButton
+          style={{ width: '225px' }}
+          fill
+          href={`${PLUGIN_NAME}#${APP_PATH.CREATE_HISTORICAL_DETECTOR}`}
+          data-test-subj="createHistoricalDetectorButton"
+        >
+          Create historical detector
+        </EuiButton>
+      )
+    }
+  />
+);

--- a/public/pages/HistoricalDetectorList/components/HistoricalDetectorFilters/HistoricalDetectorFilters.tsx
+++ b/public/pages/HistoricalDetectorList/components/HistoricalDetectorFilters/HistoricalDetectorFilters.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiComboBox,
+  EuiComboBoxOptionProps,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPagination,
+} from '@elastic/eui';
+import React from 'react';
+import { getHistoricalDetectorStateOptions } from '../../utils/helpers';
+import { DETECTOR_STATE } from '../../../../../server/utils/constants';
+
+interface HistoricalDetectorFiltersProps {
+  activePage: number;
+  pageCount: number;
+  search: string;
+  selectedDetectorStates: DETECTOR_STATE[];
+  onSearchDetectorChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onDetectorStateChange: (options: EuiComboBoxOptionProps[]) => void;
+  onPageClick: (pageNumber: number) => void;
+}
+export function HistoricalDetectorFilters(
+  props: HistoricalDetectorFiltersProps
+) {
+  return (
+    <EuiFlexGroup gutterSize="s">
+      <EuiFlexItem grow={false} style={{ width: '70%' }}>
+        <EuiFieldSearch
+          fullWidth={true}
+          value={props.search}
+          placeholder="Search"
+          onChange={props.onSearchDetectorChange}
+          data-test-subj="historicalDetectorListSearch"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiComboBox
+          id="selectedDetectorStates"
+          data-test-subj="historicalDetectorStateFilter"
+          placeholder="All historical detector states"
+          isClearable={true}
+          singleSelection={false}
+          options={getHistoricalDetectorStateOptions()}
+          onChange={props.onDetectorStateChange}
+          selectedOptions={
+            props.selectedDetectorStates.length > 0
+              ? props.selectedDetectorStates.map((state) => ({ label: state }))
+              : []
+          }
+          fullWidth={true}
+        />
+      </EuiFlexItem>
+      {props.pageCount > 1 ? (
+        <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
+          <EuiPagination
+            pageCount={props.pageCount}
+            activePage={props.activePage}
+            onPageClick={props.onPageClick}
+            data-test-subj="historicalDetectorListPageControls"
+          />
+        </EuiFlexItem>
+      ) : null}
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
+++ b/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
@@ -304,7 +304,6 @@ export function HistoricalDetectorList(props: HistoricalDetectorListProps) {
             columns={historicalDetectorListColumns}
             onChange={handleTableChange}
             isSelectable={true}
-            //selection={selection}
             sorting={sorting}
             pagination={pagination}
             noItemsMessage={

--- a/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
+++ b/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import {
+  //@ts-ignore
+  EuiBasicTable,
+  EuiButton,
+  EuiComboBoxOptionProps,
+  EuiHorizontalRule,
+  EuiPage,
+  EuiPageBody,
+  EuiSpacer,
+} from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import queryString from 'query-string';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
+import { HistoricalDetectorListItem } from '../../../models/interfaces';
+import { SORT_DIRECTION } from '../../../../server/utils/constants';
+import ContentPanel from '../../../components/ContentPanel/ContentPanel';
+import { AppState } from '../../../redux/reducers';
+import { getHistoricalDetectorList } from '../../../redux/reducers/ad';
+import {
+  BREADCRUMBS,
+  APP_PATH,
+  PLUGIN_NAME,
+  MAX_DETECTORS,
+} from '../../../utils/constants';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+import { getTitleWithCount } from '../../../utils/utils';
+import { ALL_DETECTOR_STATES } from '../../utils/constants';
+import { getURLQueryParams } from '../utils/helpers';
+import {
+  filterAndSortHistoricalDetectors,
+  getHistoricalDetectorsToDisplay,
+} from '../../utils/helpers';
+import { EmptyHistoricalDetectorMessage } from '../components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage';
+import { historicalDetectorListColumns } from '../utils/constants';
+import { HistoricalDetectorFilters } from '../components/HistoricalDetectorFilters/HistoricalDetectorFilters';
+import { GET_ALL_DETECTORS_QUERY_PARAMS } from '../../utils/constants';
+import { CoreStart } from '../../../../../../src/core/public';
+import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+import {
+  NO_PERMISSIONS_KEY_WORD,
+  prettifyErrorMessage,
+} from '../../../../server/utils/helpers';
+
+export interface HistoricalDetectorListRouterParams {
+  from: string;
+  size: string;
+  search: string;
+  sortDirection: SORT_DIRECTION;
+  sortField: string;
+}
+interface HistoricalDetectorListProps
+  extends RouteComponentProps<HistoricalDetectorListRouterParams> {}
+interface HistoricalDetectorListState {
+  page: number;
+  queryParams: any;
+  selectedDetectorStates: DETECTOR_STATE[];
+}
+
+export function HistoricalDetectorList(props: HistoricalDetectorListProps) {
+  const core = React.useContext(CoreServicesContext) as CoreStart;
+  const dispatch = useDispatch();
+
+  // get historical detector store
+  const adState = useSelector((state: AppState) => state.ad);
+  const allDetectors = adState.historicalDetectorList;
+  const errorGettingDetectors = adState.errorMessage;
+  const isRequestingDetectors = adState.requesting;
+
+  const [selectedDetectors, setSelectedDetectors] = useState(
+    [] as HistoricalDetectorListItem[]
+  );
+  const [detectorsToDisplay, setDetectorsToDisplay] = useState(
+    [] as HistoricalDetectorListItem[]
+  );
+  const [isLoadingFinalDetectors, setIsLoadingFinalDetectors] = useState<
+    boolean
+  >(true);
+
+  // if loading detectors or sorting/filtering: set whole page in loading state
+  const isLoading = isRequestingDetectors || isLoadingFinalDetectors;
+
+  const [state, setState] = useState<HistoricalDetectorListState>({
+    page: 0,
+    queryParams: getURLQueryParams(props.location),
+    selectedDetectorStates: ALL_DETECTOR_STATES,
+  });
+
+  // Set breadcrumbs on page initialization
+  useEffect(() => {
+    core.chrome.setBreadcrumbs([
+      BREADCRUMBS.ANOMALY_DETECTOR,
+      BREADCRUMBS.HISTORICAL_DETECTORS,
+    ]);
+  }, []);
+
+  useEffect(() => {
+    if (errorGettingDetectors) {
+      console.error(errorGettingDetectors);
+      core.notifications.toasts.addDanger(
+        typeof errorGettingDetectors === 'string' &&
+          errorGettingDetectors.includes(NO_PERMISSIONS_KEY_WORD)
+          ? prettifyErrorMessage(errorGettingDetectors)
+          : 'Unable to get all detectors'
+      );
+      setIsLoadingFinalDetectors(false);
+    }
+  }, [errorGettingDetectors]);
+
+  // Refresh data if user change any parameters / filter / sort
+  useEffect(() => {
+    const { history, location } = props;
+    const updatedParams = {
+      ...state.queryParams,
+      from: state.page * state.queryParams.size,
+    };
+
+    history.replace({
+      ...location,
+      search: queryString.stringify(updatedParams),
+    });
+
+    setIsLoadingFinalDetectors(true);
+    getUpdatedDetectors();
+  }, [state.page, state.queryParams, state.selectedDetectorStates]);
+
+  // Handle all filtering / sorting of historical detectors
+  useEffect(() => {
+    const curSelectedDetectors = filterAndSortHistoricalDetectors(
+      Object.values(allDetectors),
+      state.queryParams.search,
+      state.selectedDetectorStates,
+      state.queryParams.sortField,
+      state.queryParams.sortDirection
+    );
+    setSelectedDetectors(curSelectedDetectors);
+
+    const detectorsToDisplay = getHistoricalDetectorsToDisplay(
+      curSelectedDetectors,
+      state.page,
+      state.queryParams.size
+    );
+
+    setDetectorsToDisplay(detectorsToDisplay);
+
+    if (!isRequestingDetectors) {
+      setIsLoadingFinalDetectors(false);
+    }
+  }, [allDetectors]);
+
+  const getUpdatedDetectors = async () => {
+    dispatch(getHistoricalDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
+  };
+
+  const handlePageChange = (pageNumber: number) => {
+    setState({ ...state, page: pageNumber });
+  };
+
+  const handleTableChange = ({ page: tablePage = {}, sort = {} }: any) => {
+    const { index: page, size } = tablePage;
+    const { field: sortField, direction: sortDirection } = sort;
+    setState({
+      ...state,
+      page,
+      queryParams: {
+        ...state.queryParams,
+        size,
+        sortField,
+        sortDirection,
+      },
+    });
+  };
+
+  // Refresh data is user is typing in the search bar
+  const handleSearchDetectorChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    const searchText = e.target.value;
+    setState({
+      ...state,
+      page: 0,
+      queryParams: {
+        ...state.queryParams,
+        search: searchText,
+      },
+    });
+  };
+
+  // Refresh data if user is selecting a historical detector state filter
+  const handleDetectorStateChange = (
+    options: EuiComboBoxOptionProps[]
+  ): void => {
+    let states: DETECTOR_STATE[];
+    states =
+      options.length == 0
+        ? ALL_DETECTOR_STATES
+        : options.map((option) => option.label as DETECTOR_STATE);
+    setState((state) => ({
+      ...state,
+      page: 0,
+      selectedDetectorStates: states,
+    }));
+  };
+
+  const handleResetFilter = () => {
+    setState((state) => ({
+      ...state,
+      queryParams: {
+        ...state.queryParams,
+        search: '',
+      },
+      selectedDetectorStates: ALL_DETECTOR_STATES,
+    }));
+  };
+
+  const getItemId = (item: any) => {
+    return `${item.id}-${item.currentTime}`;
+  };
+
+  const sorting = {
+    sort: {
+      direction: state.queryParams.sortDirection,
+      field: state.queryParams.sortField,
+    },
+  };
+
+  const isFilterApplied =
+    !isEmpty(state.queryParams.search) ||
+    !isEmpty(state.selectedDetectorStates);
+
+  const pagination = {
+    pageIndex: state.page,
+    pageSize: state.queryParams.size,
+    totalItemCount: Math.min(MAX_DETECTORS, selectedDetectors.length),
+    pageSizeOptions: [5, 10, 20, 50],
+  };
+
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <ContentPanel
+          title={
+            isLoading
+              ? getTitleWithCount('Historical detectors', '...')
+              : getTitleWithCount(
+                  'Historical detectors',
+                  selectedDetectors.length
+                )
+          }
+          actions={[
+            <EuiButton
+              style={{ width: '225px' }}
+              data-test-subj="createDetectorButton"
+              fill
+              href={`${PLUGIN_NAME}#${APP_PATH.CREATE_HISTORICAL_DETECTOR}`}
+            >
+              Create historical detector
+            </EuiButton>,
+          ]}
+        >
+          {/* {getActionModal()} */}
+          <HistoricalDetectorFilters
+            activePage={state.page}
+            pageCount={
+              isLoading
+                ? 0
+                : Math.ceil(
+                    selectedDetectors.length / state.queryParams.size
+                  ) || 1
+            }
+            search={state.queryParams.search}
+            selectedDetectorStates={state.selectedDetectorStates}
+            onDetectorStateChange={handleDetectorStateChange}
+            onSearchDetectorChange={handleSearchDetectorChange}
+            onPageClick={handlePageChange}
+          />
+          <EuiSpacer size="s" />
+          <EuiHorizontalRule margin="s" style={{ marginBottom: '0px' }} />
+          <EuiBasicTable<any>
+            items={isLoading ? [] : detectorsToDisplay}
+            /*
+                itemId here is used to keep track of the selected detectors and render appropriately.
+                Because the item id is dependent on the current time (see getItemID() above), all selected
+                detectors will be deselected once new detectors are retrieved because the page will
+                re-render with a new timestamp. This logic is borrowed from Alerting Kibana plugins'
+                monitors list page.
+              */
+            itemId={getItemId}
+            columns={historicalDetectorListColumns}
+            onChange={handleTableChange}
+            isSelectable={true}
+            //selection={selection}
+            sorting={sorting}
+            pagination={pagination}
+            noItemsMessage={
+              isLoading ? (
+                'Loading historical detectors...'
+              ) : (
+                <EmptyHistoricalDetectorMessage
+                  isFilterApplied={isFilterApplied}
+                  onResetFilters={handleResetFilter}
+                />
+              )
+            }
+          />
+        </ContentPanel>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
+++ b/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
@@ -89,7 +89,7 @@ describe('<HistoricalDetectorList /> spec', () => {
       });
       await wait();
       getByText(
-        'Historical detectors allow you to detect anomalies on your historical data. You may also use them to pre-train or tune your model by using your index history to train an anomaly detector.'
+        'Use historical detectors to detect anomalies on a selected time range of your historic data.'
       );
     });
   });

--- a/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
+++ b/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { render, wait } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import {
+  MemoryRouter as Router,
+  Redirect,
+  Route,
+  RouteComponentProps,
+  Switch,
+} from 'react-router-dom';
+import { httpClientMock, coreServicesMock } from '../../../../../test/mocks';
+import configureStore from '../../../../redux/configureStore';
+import {
+  Detectors,
+  initialDetectorsState,
+} from '../../../../redux/reducers/ad';
+import {
+  HistoricalDetectorList,
+  HistoricalDetectorListRouterParams,
+} from '../HistoricalDetectorList';
+import { DETECTOR_STATE } from '../../../../../server/utils/constants';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+
+const renderWithRouter = (
+  initialAdState: Detectors = initialDetectorsState
+) => ({
+  ...render(
+    <Provider store={configureStore(httpClientMock)}>
+      <Router>
+        <Switch>
+          <Route
+            exact
+            path="/historical-detectors"
+            render={(
+              props: RouteComponentProps<HistoricalDetectorListRouterParams>
+            ) => (
+              <CoreServicesContext.Provider value={coreServicesMock}>
+                <HistoricalDetectorList {...props} />
+              </CoreServicesContext.Provider>
+            )}
+          />
+          <Redirect from="/" to="/historical-detectors" />
+        </Switch>
+      </Router>
+    </Provider>
+  ),
+});
+
+describe('<HistoricalDetectorList /> spec', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('Empty results', () => {
+    test('renders in loading state if detectors are being fetched', async () => {
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { detectorList: [], totalDetectors: 0 },
+      });
+      const { getByText } = renderWithRouter({
+        ...initialDetectorsState,
+        requesting: true,
+      });
+      getByText('Loading historical detectors...');
+    });
+    test('should display empty message when list is empty', async () => {
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { detectorList: [], totalDetectors: 0 },
+      });
+      const { getByText } = renderWithRouter({
+        ...initialDetectorsState,
+        requesting: true,
+      });
+      await wait();
+      getByText(
+        'Historical detectors allow you to detect anomalies on your historical data. You may also use them to pre-train or tune your model by using your index history to train an anomaly detector.'
+      );
+    });
+  });
+  describe('Populated results', () => {
+    test('pagination functionality', async () => {
+      const randomDetectors = new Array(40).fill(null).map((_, index) => {
+        const hasAnomaly = Math.random() > 0.5;
+        return {
+          id: `detector_id_${index}`,
+          name: `detector_name_${index}`,
+          indices: [`index_${index}`],
+          totalAnomalies: hasAnomaly ? Math.floor(Math.random() * 10) : 0,
+          dataStartTime: 0,
+          dataEndTime: 10,
+        };
+      });
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: {
+          detectorList: randomDetectors,
+          totalDetectors: randomDetectors.length,
+        },
+      });
+
+      const { getByText, getAllByTestId, queryByText } = renderWithRouter({
+        ...initialDetectorsState,
+        requesting: true,
+      });
+      // Default view 20 items per page
+      await wait(() => getByText('detector_name_0'));
+      getByText('index_0');
+      expect(queryByText('detector_name_30')).toBeNull();
+      expect(queryByText('index_30')).toBeNull();
+
+      // Navigate to next page
+      userEvent.click(getAllByTestId('pagination-button-next')[0]);
+      await wait();
+      getByText('detector_name_30');
+      getByText('index_30');
+      expect(queryByText('detector_name_0')).toBeNull();
+      expect(queryByText('index_0')).toBeNull();
+
+      // Navigate to previous page
+      userEvent.click(getAllByTestId('pagination-button-previous')[0]);
+      await wait();
+      getByText('detector_name_0');
+      expect(queryByText('detector_name_30')).toBeNull();
+    });
+    test('sorting functionality', async () => {
+      const randomDetectors = new Array(40).fill(null).map((_, index) => {
+        return {
+          id: `detector_id_${index}`,
+          name: `detector_name_${index}`,
+          indices: [`index_${index}`],
+          curState: DETECTOR_STATE.DISABLED,
+          featureAttributes: [`feature_${index}`],
+          totalAnomalies: index,
+          dataStartTime: 0,
+          dataEndTime: 5,
+        };
+      });
+
+      // Set the first detector to be in a running state
+      randomDetectors[0].curState = DETECTOR_STATE.RUNNING;
+
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: {
+          detectorList: randomDetectors,
+          totalDetectors: randomDetectors.length,
+        },
+      });
+
+      const { getByText, getAllByTestId, queryByText } = renderWithRouter({
+        ...initialDetectorsState,
+        requesting: true,
+      });
+      // Default view 20 items per page
+      await wait();
+      getByText('detector_name_0');
+      expect(queryByText('detector_name_30')).toBeNull();
+
+      // Sort by name (string sorting)
+      userEvent.click(getAllByTestId('tableHeaderSortButton')[0]);
+      await wait();
+      getByText('detector_name_30');
+      expect(queryByText('detector_name_0')).toBeNull();
+
+      // Sort by indices (string sorting)
+      userEvent.click(getAllByTestId('tableHeaderSortButton')[2]);
+      await wait();
+      getByText('index_0');
+      expect(queryByText('index_30')).toBeNull();
+      userEvent.click(getAllByTestId('tableHeaderSortButton')[2]);
+      await wait();
+      getByText('index_30');
+      expect(queryByText('index_0')).toBeNull();
+    }, 20000);
+    test('should be able to search', async () => {
+      const randomDetectors = new Array(40).fill(null).map((_, index) => {
+        const hasAnomaly = Math.random() > 0.5;
+        return {
+          id: `detector_id_${index}`,
+          indices: [`index_${index}`],
+          name: `detector_name_${index}`,
+          totalAnomalies: hasAnomaly ? Math.floor(Math.random() * 10) : 0,
+          dataStartTime: 0,
+          dataEndTime: 5,
+        };
+      });
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: {
+          detectorList: randomDetectors,
+          totalDetectors: randomDetectors.length,
+        },
+      });
+
+      const { getByText, getByPlaceholderText, queryByText } = renderWithRouter(
+        {
+          ...initialDetectorsState,
+          requesting: true,
+        }
+      );
+      // Initial load, only first 20 items
+      await wait(() => getByText('detector_name_0'));
+      getByText('index_0');
+      expect(queryByText('detector_name_38')).toBeNull();
+      expect(queryByText('index_38')).toBeNull();
+
+      //Input search event
+      userEvent.type(getByPlaceholderText('Search'), 'detector_name_38');
+      await wait();
+      getByText('detector_name_38');
+      getByText('index_38');
+      expect(queryByText('detector_name_39')).toBeNull();
+      expect(queryByText('index_39')).toBeNull();
+      expect(queryByText('detector_name_0')).toBeNull();
+      expect(queryByText('index_0')).toBeNull();
+    });
+    test('should reset to first page when filtering', async () => {
+      const randomDetectors = new Array(40).fill(null).map((_, index) => {
+        const hasAnomaly = Math.random() > 0.5;
+        return {
+          id: `detector_id_${index}`,
+          indices: [`index_${index}`],
+          name: `detector_name_${index}`,
+          totalAnomalies: hasAnomaly ? Math.floor(Math.random() * 10) : 0,
+          dataStartTime: 0,
+          dataEndTime: 5,
+        };
+      });
+      httpClientMock.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: {
+          detectorList: randomDetectors,
+          totalDetectors: randomDetectors.length,
+        },
+      });
+
+      const {
+        getByText,
+        getByPlaceholderText,
+        queryByText,
+        getAllByTestId,
+      } = renderWithRouter({
+        ...initialDetectorsState,
+        requesting: true,
+      });
+      // Initial load, only first 20 items
+      await wait();
+      getByText('detector_name_0');
+
+      // Go to next page
+      userEvent.click(getAllByTestId('pagination-button-next')[0]);
+      await wait();
+
+      // Search for detector which is on prev page
+      userEvent.type(getByPlaceholderText('Search'), 'detector_name_0');
+      await wait();
+      getByText('detector_name_0');
+      expect(queryByText('detector_name_30')).toBeNull();
+    });
+  });
+});

--- a/public/pages/HistoricalDetectorList/index.ts
+++ b/public/pages/HistoricalDetectorList/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { HistoricalDetectorList } from './containers/HistoricalDetectorList';

--- a/public/pages/HistoricalDetectorList/utils/constants.tsx
+++ b/public/pages/HistoricalDetectorList/utils/constants.tsx
@@ -13,42 +13,18 @@
  * permissions and limitations under the License.
  */
 
-import {
-  EuiLink,
-  EuiText,
-  EuiToolTip,
-  EuiHealth,
-  EuiBasicTableColumn,
-} from '@elastic/eui';
+import { EuiLink, EuiToolTip, EuiBasicTableColumn } from '@elastic/eui';
 //@ts-ignore
 import moment from 'moment';
 import React from 'react';
-import { get } from 'lodash';
 import { Detector } from '../../../models/interfaces';
 import { PLUGIN_NAME } from '../../../utils/constants';
-import { DETECTOR_STATE } from '../../../../server/utils/constants';
-import { stateToColorMap } from '../../utils/constants';
-
-const DEFAULT_EMPTY_DATA = '-';
-const columnStyle = {
-  overflow: 'visible',
-  whiteSpace: 'normal',
-  wordBreak: 'break-word',
-} as React.CSSProperties;
-
-const renderTime = (time: number) => {
-  const momentTime = moment(time);
-  if (time && momentTime.isValid())
-    return momentTime.format('MM/DD/YYYY h:mm A');
-  return DEFAULT_EMPTY_DATA;
-};
-
-const renderState = (state: DETECTOR_STATE) => {
-  return (
-    //@ts-ignore
-    <EuiHealth color={stateToColorMap.get(state)}>{state}</EuiHealth>
-  );
-};
+import {
+  columnStyle,
+  renderTime,
+  renderState,
+  renderIndices,
+} from '../../DetectorsList/utils/tableUtils';
 
 export const historicalDetectorListColumns = [
   {
@@ -94,7 +70,7 @@ export const historicalDetectorListColumns = [
     dataType: 'string',
     align: 'left',
     truncateText: false,
-    render: (indices: string[]) => get(indices, '0', '-'),
+    render: renderIndices,
   },
   {
     field: 'totalAnomalies',

--- a/public/pages/HistoricalDetectorList/utils/constants.tsx
+++ b/public/pages/HistoricalDetectorList/utils/constants.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiLink,
+  EuiText,
+  EuiToolTip,
+  EuiHealth,
+  EuiBasicTableColumn,
+} from '@elastic/eui';
+//@ts-ignore
+import moment from 'moment';
+import React from 'react';
+import { get } from 'lodash';
+import { Detector } from '../../../models/interfaces';
+import { PLUGIN_NAME } from '../../../utils/constants';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+import { stateToColorMap } from '../../utils/constants';
+
+const DEFAULT_EMPTY_DATA = '-';
+const columnStyle = {
+  overflow: 'visible',
+  whiteSpace: 'normal',
+  wordBreak: 'break-word',
+} as React.CSSProperties;
+
+const renderTime = (time: number) => {
+  const momentTime = moment(time);
+  if (time && momentTime.isValid())
+    return momentTime.format('MM/DD/YYYY h:mm A');
+  return DEFAULT_EMPTY_DATA;
+};
+
+const renderState = (state: DETECTOR_STATE) => {
+  return (
+    //@ts-ignore
+    <EuiHealth color={stateToColorMap.get(state)}>{state}</EuiHealth>
+  );
+};
+
+export const historicalDetectorListColumns = [
+  {
+    field: 'name',
+    name: (
+      <EuiToolTip content="The name of the historical detector">
+        <span style={columnStyle}>Detector{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    truncateText: false,
+    textOnly: true,
+    align: 'left',
+    render: (name: string, detector: Detector) => (
+      <EuiLink
+        href={`${PLUGIN_NAME}#/historical-detectors/${detector.id}/details`}
+      >
+        {name}
+      </EuiLink>
+    ),
+  },
+  {
+    field: 'curState',
+    name: (
+      <EuiToolTip content="The current state of the detector">
+        <span style={columnStyle}>State{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    dataType: 'string',
+    align: 'left',
+    truncateText: false,
+    render: renderState,
+  },
+  {
+    field: 'indices',
+    name: (
+      <EuiToolTip content="The index used by the detector">
+        <span style={columnStyle}>Index{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    dataType: 'string',
+    align: 'left',
+    truncateText: false,
+    render: (indices: string[]) => get(indices, '0', '-'),
+  },
+  {
+    field: 'totalAnomalies',
+    name: (
+      <EuiToolTip content="The total number of anomalies found">
+        <span style={columnStyle}>No. of anomalies{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    dataType: 'string',
+    align: 'left',
+    truncateText: false,
+  },
+  {
+    field: 'dataStartTime',
+    name: (
+      <EuiToolTip content="The detection start time">
+        <span style={columnStyle}>Start time{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    dataType: 'date',
+    truncateText: false,
+    align: 'left',
+    render: renderTime,
+  },
+  {
+    field: 'dataEndTime',
+    name: (
+      <EuiToolTip content="The detection end time">
+        <span style={columnStyle}>End time{''}</span>
+      </EuiToolTip>
+    ),
+    sortable: true,
+    dataType: 'date',
+    truncateText: false,
+    align: 'left',
+    render: renderTime,
+  },
+] as EuiBasicTableColumn<any>[];

--- a/public/pages/HistoricalDetectorList/utils/helpers.tsx
+++ b/public/pages/HistoricalDetectorList/utils/helpers.tsx
@@ -40,7 +40,7 @@ export const getURLQueryParams = (location: { search: string }): any => {
   };
 };
 
-// For historical detectors: can only be stopped/running/completed/failed
+// For historical detectors: can't have feature required state or init failure
 export const getHistoricalDetectorStateOptions = () => {
   return Object.values(DETECTOR_STATE)
     .map((detectorState) => ({
@@ -49,7 +49,6 @@ export const getHistoricalDetectorStateOptions = () => {
     }))
     .filter(
       (option) =>
-        option.label !== DETECTOR_STATE.INIT &&
         option.label !== DETECTOR_STATE.FEATURE_REQUIRED &&
         option.label !== DETECTOR_STATE.INIT_FAILURE
     );

--- a/public/pages/HistoricalDetectorList/utils/helpers.tsx
+++ b/public/pages/HistoricalDetectorList/utils/helpers.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import queryString from 'querystring';
+import { SORT_DIRECTION } from '../../../../server/utils/constants';
+import { DEFAULT_QUERY_PARAMS } from '../../utils/constants';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+
+export const getURLQueryParams = (location: { search: string }): any => {
+  const { from, size, search, sortField, sortDirection } = queryString.parse(
+    location.search
+  ) as { [key: string]: string };
+  return {
+    // @ts-ignore
+    from: isNaN(parseInt(from, 10))
+      ? DEFAULT_QUERY_PARAMS.from
+      : parseInt(from, 10),
+    // @ts-ignore
+    size: isNaN(parseInt(size, 10))
+      ? DEFAULT_QUERY_PARAMS.size
+      : parseInt(size, 10),
+    search: typeof search !== 'string' ? DEFAULT_QUERY_PARAMS.search : search,
+    sortField: typeof sortField !== 'string' ? 'name' : sortField,
+    sortDirection:
+      typeof sortDirection !== 'string'
+        ? DEFAULT_QUERY_PARAMS.sortDirection
+        : (sortDirection as SORT_DIRECTION),
+  };
+};
+
+// For historical detectors: can only be stopped/running/completed/failed
+export const getHistoricalDetectorStateOptions = () => {
+  return Object.values(DETECTOR_STATE)
+    .map((detectorState) => ({
+      label: detectorState,
+      text: detectorState,
+    }))
+    .filter(
+      (option) =>
+        option.label !== DETECTOR_STATE.INIT &&
+        option.label !== DETECTOR_STATE.FEATURE_REQUIRED &&
+        option.label !== DETECTOR_STATE.INIT_FAILURE
+    );
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**This PR is 1 of 4 related to adding the historical detectors to the plugin. Once all 4 PRs are merged into the development branch, there will be a follow up PR to merge the development branch into master.**

This PR adds the historical detector list page (and related UT).

Screenshots:
Empty (no filter):
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2020-11-25-16_37_42](https://user-images.githubusercontent.com/62119629/102144805-f971f900-3e1a-11eb-89ef-41a54dec15a3.png)

Empty (filters don't match anything):
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2020-11-25-16_37_23](https://user-images.githubusercontent.com/62119629/102144813-fc6ce980-3e1a-11eb-82b0-67cdc6f24a0a.png)

Populated:
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2020-11-25-16_37_07](https://user-images.githubusercontent.com/62119629/102144819-ff67da00-3e1a-11eb-83fe-9acce1a3295d.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
