### PR TITLE
Refactor AnomalyHistory Chart to improve performance for HC detector

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -24,6 +24,7 @@ import {
 import { get } from 'lodash';
 import moment, { DurationInputArg2 } from 'moment';
 import React, { useState } from 'react';
+import { EntityAnomalySummaries } from '../../../../server/models/interfaces';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import { useDelayedLoader } from '../../../hooks/useDelayedLoader';
 import {
@@ -38,6 +39,7 @@ import { AnomalyDetailsChart } from '../containers/AnomalyDetailsChart';
 import {
   AnomalyHeatmapChart,
   HeatmapCell,
+  HeatmapDisplayOption,
 } from '../containers/AnomalyHeatmapChart';
 import {
   getAnomalyGradeWording,
@@ -71,10 +73,13 @@ interface AnomaliesChartProps {
   isHCDetector?: boolean;
   detectorCategoryField?: string[];
   onHeatmapCellSelected?(heatmapCell: HeatmapCell): void;
+  onDisplayOptionChanged?(heatmapDisplayOption: HeatmapDisplayOption): void;
   selectedHeatmapCell?: HeatmapCell;
   newDetector?: Detector;
   zoomRange?: DateRange;
   anomaliesResult: Anomalies | undefined;
+  heatmapDisplayOption?: HeatmapDisplayOption;
+  entityAnomalySummaries?: EntityAnomalySummaries[];
 }
 
 export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
@@ -183,7 +188,9 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
         <EuiFlexGroup direction="column">
           {props.isHCDetector &&
           props.onHeatmapCellSelected &&
-          props.detectorCategoryField ? (
+          props.detectorCategoryField &&
+          props.onDisplayOptionChanged &&
+          props.entityAnomalySummaries ? (
             <EuiFlexGroup style={{ padding: '20px' }}>
               <EuiFlexItem style={{ margin: '0px' }}>
                 <div
@@ -222,6 +229,10 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                           'detectionInterval.period.unit'
                         )}
                         onHeatmapCellSelected={props.onHeatmapCellSelected}
+                        entityAnomalySummaries={props.entityAnomalySummaries}
+                        onDisplayOptionChanged={props.onDisplayOptionChanged}
+                        //@ts-ignore
+                        heatmapDisplayOption={props.heatmapDisplayOption}
                       />,
                       props.showAlerts !== true
                         ? [

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -189,8 +189,8 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
           {props.isHCDetector &&
           props.onHeatmapCellSelected &&
           props.detectorCategoryField &&
-          props.onDisplayOptionChanged &&
-          props.entityAnomalySummaries ? (
+          (props.showAlerts !== true ||
+            (props.onDisplayOptionChanged && props.entityAnomalySummaries)) ? (
             <EuiFlexGroup style={{ padding: '20px' }}>
               <EuiFlexItem style={{ margin: '0px' }}>
                 <div
@@ -231,7 +231,6 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                         onHeatmapCellSelected={props.onHeatmapCellSelected}
                         entityAnomalySummaries={props.entityAnomalySummaries}
                         onDisplayOptionChanged={props.onDisplayOptionChanged}
-                        //@ts-ignore
                         heatmapDisplayOption={props.heatmapDisplayOption}
                       />,
                       props.showAlerts !== true

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -177,6 +177,17 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
     );
   };
 
+  const hasValidHCProps = () => {
+    return (
+      props.isHCDetector &&
+      props.onHeatmapCellSelected &&
+      props.detectorCategoryField &&
+      (props.showAlerts !== true ||
+        (props.showAlerts &&
+          props.onDisplayOptionChanged &&
+          props.entityAnomalySummaries))
+    );
+  };
   return (
     <React.Fragment>
       <ContentPanel
@@ -186,13 +197,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
         }
       >
         <EuiFlexGroup direction="column">
-          {props.isHCDetector &&
-          props.onHeatmapCellSelected &&
-          props.detectorCategoryField &&
-          (props.showAlerts !== true ||
-            (props.showAlerts &&
-              props.onDisplayOptionChanged &&
-              props.entityAnomalySummaries)) ? (
+          {hasValidHCProps() ? (
             <EuiFlexGroup style={{ padding: '20px' }}>
               <EuiFlexItem style={{ margin: '0px' }}>
                 <div
@@ -230,10 +235,14 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                           props.detector,
                           'detectionInterval.period.unit'
                         )}
+                        //@ts-ignore
                         onHeatmapCellSelected={props.onHeatmapCellSelected}
                         entityAnomalySummaries={props.entityAnomalySummaries}
                         onDisplayOptionChanged={props.onDisplayOptionChanged}
                         heatmapDisplayOption={props.heatmapDisplayOption}
+                        // TODO use props.isNotSample after Tyler's change is merged
+                        // https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/350#discussion_r547009140
+                        isNotSample={props.showAlerts === true}
                       />,
                       props.showAlerts !== true
                         ? [

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -190,7 +190,9 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
           props.onHeatmapCellSelected &&
           props.detectorCategoryField &&
           (props.showAlerts !== true ||
-            (props.onDisplayOptionChanged && props.entityAnomalySummaries)) ? (
+            (props.showAlerts &&
+              props.onDisplayOptionChanged &&
+              props.entityAnomalySummaries)) ? (
             <EuiFlexGroup style={{ padding: '20px' }}>
               <EuiFlexItem style={{ margin: '0px' }}>
                 <div

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -182,6 +182,10 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
       props.isHCDetector &&
       props.onHeatmapCellSelected &&
       props.detectorCategoryField &&
+      // For Non-Sample HC detector case, aka realtime HC detector(showAlert == true),
+      // we use anomaly summaries data to render heatmap
+      // we must have function onDisplayOptionChanged and entityAnomalySummaries defined
+      // so that heatmap can work as expected.
       (props.showAlerts !== true ||
         (props.showAlerts &&
           props.onDisplayOptionChanged &&

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -41,7 +41,7 @@ import {
   AnomalyHeatmapSortType,
   sortHeatmapPlotData,
   filterHeatmapPlotDataByY,
-  getEnitytAnomaliesHeatmapData,
+  getEntitytAnomaliesHeatmapData,
 } from '../utils/anomalyChartUtils';
 import { MIN_IN_MILLI_SECS } from '../../../../server/utils/constants';
 import { EntityAnomalySummaries } from '../../../../server/models/interfaces';
@@ -61,6 +61,7 @@ interface AnomalyHeatmapChartProps {
   onDisplayOptionChanged?(option: HeatmapDisplayOption | undefined): void;
   heatmapDisplayOption?: HeatmapDisplayOption;
   entityAnomalySummaries?: EntityAnomalySummaries[];
+  isNotSample: boolean;
 }
 
 export interface HeatmapCell {
@@ -124,7 +125,7 @@ export const AnomalyHeatmapChart = React.memo(
       });
 
       return [
-        getCombindeOptions(
+        getViewableCombinedOptions(
           COMBINED_OPTIONS,
           props.heatmapDisplayOption?.entityOption
         ),
@@ -135,7 +136,7 @@ export const AnomalyHeatmapChart = React.memo(
       ];
     };
 
-    const getCombindeOptions = (
+    const getViewableCombinedOptions = (
       existingOptions: any,
       selectedCombinedOption: any | undefined
     ) => {
@@ -149,9 +150,9 @@ export const AnomalyHeatmapChart = React.memo(
     };
 
     const [originalHeatmapData, setOriginalHeatmapData] = useState(
-      props.showAlerts
+      props.isNotSample
         ? // use anomaly summary data in case of realtime result
-          getEnitytAnomaliesHeatmapData(
+          getEntitytAnomaliesHeatmapData(
             props.dateRange,
             props.entityAnomalySummaries,
             props.heatmapDisplayOption.entityOption.value
@@ -172,7 +173,7 @@ export const AnomalyHeatmapChart = React.memo(
     const [sortByFieldValue, setSortByFieldValue] = useState<
       AnomalyHeatmapSortType
     >(
-      props.showAlerts
+      props.isNotSample
         ? props.heatmapDisplayOption.sortType
         : SORT_BY_FIELD_OPTIONS[0].value
     );
@@ -273,7 +274,7 @@ export const AnomalyHeatmapChart = React.memo(
         // when `clear` is hit for combo box
         setCurrentViewOptions([COMBINED_OPTIONS.options[0]]);
 
-        if (props.showAlerts && props.onDisplayOptionChanged) {
+        if (props.isNotSample && props.onDisplayOptionChanged) {
           props.onDisplayOptionChanged({
             sortType: sortByFieldValue,
             entityOption: COMBINED_OPTIONS.options[0],
@@ -304,7 +305,7 @@ export const AnomalyHeatmapChart = React.memo(
         if (isCombinedViewEntityOption(option)) {
           // only allow 1 combined option
           setCurrentViewOptions([option]);
-          if (props.showAlerts && props.onDisplayOptionChanged) {
+          if (props.isNotSample && props.onDisplayOptionChanged) {
             props.onDisplayOptionChanged({
               sortType: sortByFieldValue,
               entityOption: option,
@@ -358,7 +359,7 @@ export const AnomalyHeatmapChart = React.memo(
       setSortByFieldValue(value);
       props.onHeatmapCellSelected(undefined);
       if (
-        props.showAlerts &&
+        props.isNotSample &&
         props.onDisplayOptionChanged &&
         currentViewOptions.length === 1 &&
         isCombinedViewEntityOption(currentViewOptions[0])

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -50,7 +50,7 @@ interface AnomalyHeatmapChartProps {
   title: string;
   detectorId: string;
   detectorName: string;
-  anomalies: any[];
+  anomalies?: any[];
   dateRange: DateRange;
   isLoading: boolean;
   showAlerts?: boolean;

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -61,7 +61,7 @@ interface AnomalyHeatmapChartProps {
   onDisplayOptionChanged?(option: HeatmapDisplayOption | undefined): void;
   heatmapDisplayOption?: HeatmapDisplayOption;
   entityAnomalySummaries?: EntityAnomalySummaries[];
-  isNotSample: boolean;
+  isNotSample?: boolean;
 }
 
 export interface HeatmapCell {

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -53,7 +53,6 @@ interface AnomalyHeatmapChartProps {
   anomalies?: any[];
   dateRange: DateRange;
   isLoading: boolean;
-  showAlerts?: boolean;
   monitor?: Monitor;
   detectorInterval?: number;
   unit?: string;

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 import moment from 'moment';
 import Plotly, { PlotData } from 'plotly.js-dist';
 import plotComponentFactory from 'react-plotly.js/factory';
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, uniq } from 'lodash';
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -124,12 +124,28 @@ export const AnomalyHeatmapChart = React.memo(
       });
 
       return [
-        COMBINED_OPTIONS,
+        getCombindeOptions(
+          COMBINED_OPTIONS,
+          props.heatmapDisplayOption?.entityOption
+        ),
         {
           label: 'Individual entities',
           options: individualEntityOptions.reverse(),
         },
       ];
+    };
+
+    const getCombindeOptions = (
+      existingOptions: any,
+      selectedCombinedOption: any | undefined
+    ) => {
+      if (!selectedCombinedOption) {
+        return existingOptions;
+      }
+      return {
+        label: existingOptions.label,
+        options: uniq([selectedCombinedOption, ...existingOptions.options]),
+      };
     };
 
     const [originalHeatmapData, setOriginalHeatmapData] = useState(
@@ -257,7 +273,7 @@ export const AnomalyHeatmapChart = React.memo(
         // when `clear` is hit for combo box
         setCurrentViewOptions([COMBINED_OPTIONS.options[0]]);
 
-        if (props.showAlerts) {
+        if (props.showAlerts && props.onDisplayOptionChanged) {
           props.onDisplayOptionChanged({
             sortType: sortByFieldValue,
             entityOption: COMBINED_OPTIONS.options[0],
@@ -288,7 +304,7 @@ export const AnomalyHeatmapChart = React.memo(
         if (isCombinedViewEntityOption(option)) {
           // only allow 1 combined option
           setCurrentViewOptions([option]);
-          if (props.showAlerts) {
+          if (props.showAlerts && props.onDisplayOptionChanged) {
             props.onDisplayOptionChanged({
               sortType: sortByFieldValue,
               entityOption: option,
@@ -343,6 +359,7 @@ export const AnomalyHeatmapChart = React.memo(
       props.onHeatmapCellSelected(undefined);
       if (
         props.showAlerts &&
+        props.onDisplayOptionChanged &&
         currentViewOptions.length === 1 &&
         isCombinedViewEntityOption(currentViewOptions[0])
       ) {

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
@@ -16,58 +16,20 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { AnomaliesChart } from '../AnomaliesChart';
-import moment from 'moment';
 import { initialState, mockedStore } from '../../../../redux/utils/testUtils';
 import { Provider } from 'react-redux';
 import { INITIAL_ANOMALY_SUMMARY } from '../../utils/constants';
 import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
 import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
 import { coreServicesMock } from '../../../../../test/mocks';
-
-const initialStartTime = moment('2019-10-10T09:00:00');
-const initialEndTime = initialStartTime.clone().add(2, 'd');
-const dateRange = {
-  startDate: initialStartTime.valueOf(),
-  endDate: initialEndTime.valueOf(),
-};
-const anomalies = [
-  {
-    anomalyGrade: 0.3,
-    confidence: 0.8,
-    startTime: initialStartTime.add(1, 'minutes').valueOf(),
-    endTime: initialStartTime.add(2, 'minutes').valueOf(),
-    plotTime: initialStartTime.add(90, 'seconds').valueOf(),
-  },
-];
-const anomaliesResult = {
-  anomalies: anomalies,
-  featureData: {
-    testFeatureId: [
-      {
-        data: 10,
-        endTime: anomalies[0].endTime,
-        startTime: anomalies[0].startTime,
-        plotTime: anomalies[0].plotTime,
-      },
-    ],
-  },
-};
+import {
+  FAKE_ANOMALIES_RESULT,
+  FAKE_DATE_RANGE,
+} from '../../../../pages/utils/__tests__/constants';
 
 const renderDataFilter = () => ({
   ...render(
-    <Provider
-      store={mockedStore({
-        ...initialState,
-        elasticsearch: {
-          ...initialState.elasticsearch,
-          dataTypes: {
-            keyword: ['cityName.keyword'],
-            integer: ['age'],
-            text: ['cityName'],
-          },
-        },
-      })}
-    >
+    <Provider store={mockedStore()}>
       <CoreServicesContext.Provider value={coreServicesMock}>
         <AnomaliesChart
           onDateRangeChange={jest.fn()}
@@ -75,9 +37,9 @@ const renderDataFilter = () => ({
           title="test"
           bucketizedAnomalies={true}
           anomalySummary={INITIAL_ANOMALY_SUMMARY}
-          dateRange={dateRange}
+          dateRange={FAKE_DATE_RANGE}
           isLoading={false}
-          anomaliesResult={anomaliesResult}
+          anomaliesResult={FAKE_ANOMALIES_RESULT}
           detector={getRandomDetector(true)}
         />
       </CoreServicesContext.Provider>

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomalyDetailsChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomalyDetailsChart.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { mockedStore } from '../../../../redux/utils/testUtils';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { coreServicesMock } from '../../../../../test/mocks';
+import { AnomalyDetailsChart } from '../AnomalyDetailsChart';
+import {
+  FAKE_ANOMALY_DATA,
+  FAKE_DATE_RANGE,
+} from '../../../../pages/utils/__tests__/constants';
+import { INITIAL_ANOMALY_SUMMARY } from '../../utils/constants';
+import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
+
+const renderAnomalyOccurenceChart = (
+  isNotSample: boolean,
+  isHCDetector: boolean
+) => ({
+  ...render(
+    <Provider store={mockedStore()}>
+      <CoreServicesContext.Provider value={coreServicesMock}>
+        <AnomalyDetailsChart
+          onDateRangeChange={jest.fn()}
+          onZoomRangeChange={jest.fn()}
+          bucketizedAnomalies={false}
+          anomalySummary={INITIAL_ANOMALY_SUMMARY}
+          anomalies={FAKE_ANOMALY_DATA}
+          detector={getRandomDetector()}
+          dateRange={FAKE_DATE_RANGE}
+          isLoading={false}
+          showAlerts={isNotSample}
+          isHCDetector={isHCDetector}
+          anomalyGradeSeriesName={'testAnomalyGradeSeriesName'}
+          confidenceSeriesName={'testConfidenceSeriesName'}
+        />
+      </CoreServicesContext.Provider>
+    </Provider>
+  ),
+});
+
+describe('<AnomalyDetailsChart /> spec', () => {
+  test('renders the component in case of Sample Anomaly', () => {
+    console.error = jest.fn();
+    const { getByText } = renderAnomalyOccurenceChart(false, false);
+    expect(getByText('Sample anomaly grade')).not.toBeNull();
+  });
+
+  test('renders the component in case of Realtime Anomaly', () => {
+    console.error = jest.fn();
+    const { getByText, queryByText } = renderAnomalyOccurenceChart(true, false);
+    expect(getByText('Anomaly grade')).not.toBeNull();
+    expect(queryByText('Sample anomaly grade')).toBeNull();
+    expect(getByText('Alert')).not.toBeNull();
+  });
+
+  test('renders the component in case of HC Detector', () => {
+    console.error = jest.fn();
+    const { getByText, queryByText } = renderAnomalyOccurenceChart(true, true);
+    expect(getByText('Anomaly grade')).not.toBeNull();
+    expect(queryByText('Sample anomaly grade')).toBeNull();
+    expect(queryByText('Alert')).toBeNull();
+  });
+});

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomalyHeatmapChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomalyHeatmapChart.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import {
+  AnomalyHeatmapChart,
+  INITIAL_HEATMAP_DISPLAY_OPTION,
+} from '../AnomalyHeatmapChart';
+import {
+  FAKE_ANOMALY_DATA,
+  FAKE_DATE_RANGE,
+  FAKE_ENTITY_ANOMALY_SUMMARIES,
+} from '../../../../pages/utils/__tests__/constants';
+
+describe('<AnomalyHeatmapChart /> spec', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('AnomalyHeatmapChart with Sample anomaly data', () => {
+    const { container } = render(
+      <AnomalyHeatmapChart
+        title={'test-tile'}
+        detectorId="test-detector-id"
+        detectorName="test-detector-name"
+        detectorInterval={1}
+        unit="Minutes"
+        dateRange={FAKE_DATE_RANGE}
+        isLoading={false}
+        anomalies={FAKE_ANOMALY_DATA}
+        onHeatmapCellSelected={jest.fn()}
+        onDisplayOptionChanged={jest.fn()}
+        isNotSample={false}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('AnomalyHeatmapChart with anomaly summaries data', () => {
+    const { container } = render(
+      <AnomalyHeatmapChart
+        title={'test-tile'}
+        detectorId="test-detector-id"
+        detectorName="test-detector-name"
+        detectorInterval={1}
+        unit="Minutes"
+        dateRange={FAKE_DATE_RANGE}
+        isLoading={false}
+        onHeatmapCellSelected={jest.fn()}
+        onDisplayOptionChanged={jest.fn()}
+        isNotSample={true}
+        entityAnomalySummaries={[FAKE_ENTITY_ANOMALY_SUMMARIES]}
+        heatmapDisplayOption={INITIAL_HEATMAP_DISPLAY_OPTION}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomalyOccurrenceChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomalyOccurrenceChart.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { mockedStore } from '../../../../redux/utils/testUtils';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { coreServicesMock } from '../../../../../test/mocks';
+import { AnomalyOccurrenceChart } from '../AnomalyOccurrenceChart';
+import {
+  FAKE_ANOMALY_DATA,
+  FAKE_DATE_RANGE,
+} from '../../../../pages/utils/__tests__/constants';
+import { INITIAL_ANOMALY_SUMMARY } from '../../utils/constants';
+import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
+
+const renderAnomalyOccurenceChart = (
+  isNotSample: boolean,
+  isHCDetector: boolean
+) => ({
+  ...render(
+    <Provider store={mockedStore()}>
+      <CoreServicesContext.Provider value={coreServicesMock}>
+        <AnomalyOccurrenceChart
+          onDateRangeChange={jest.fn()}
+          onZoomRangeChange={jest.fn()}
+          title="test"
+          bucketizedAnomalies={false}
+          anomalySummary={INITIAL_ANOMALY_SUMMARY}
+          anomalies={FAKE_ANOMALY_DATA}
+          detector={getRandomDetector()}
+          dateRange={FAKE_DATE_RANGE}
+          isLoading={false}
+          showAlerts={isNotSample}
+          isHCDetector={isHCDetector}
+          anomalyGradeSeriesName={'testAnomalyGradeSeriesName'}
+          confidenceSeriesName={'testConfidenceSeriesName'}
+        />
+      </CoreServicesContext.Provider>
+    </Provider>
+  ),
+});
+
+describe('<AnomalyOccurrenceChart /> spec', () => {
+  test('renders the component in case of Sample Anomaly', () => {
+    console.error = jest.fn();
+    const { getByText } = renderAnomalyOccurenceChart(false, false);
+    expect(getByText('Sample anomaly grade')).not.toBeNull();
+  });
+
+  test('renders the component in case of Realtime Anomaly', () => {
+    console.error = jest.fn();
+    const { getByText, queryByText } = renderAnomalyOccurenceChart(true, false);
+    expect(getByText('Anomaly grade')).not.toBeNull();
+    expect(queryByText('Sample anomaly grade')).toBeNull();
+  });
+
+  test('renders the component in case of HC Detector', () => {
+    console.error = jest.fn();
+    const { getByText, queryByText } = renderAnomalyOccurenceChart(true, true);
+    expect(getByText('Anomaly grade')).not.toBeNull();
+    expect(queryByText('Sample anomaly grade')).toBeNull();
+    expect(getByText('Click on an anomaly entity to view data')).not.toBeNull();
+  });
+});

--- a/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
+++ b/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
@@ -1,0 +1,826 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly data 1`] = `
+<div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 5px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <div
+        class="euiCallOut euiCallOut--primary euiCallOut--small"
+      >
+        <div
+          class="euiCallOutHeader"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiCallOutHeader__title"
+          >
+            Choose a filled rectangle in the heat map for a more detailed view of anomalies within that entity.
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px;"
+  >
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="min-width: 80px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiText euiText--medium"
+        >
+          <div
+            class="euiTextAlign euiTextAlign--right"
+          >
+            <h4>
+              test-tile
+            </h4>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem"
+      style="padding-left: 5px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+          style="margin-left: 0px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+              style="min-width: 300px;"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox"
+                role="combobox"
+              >
+                <div
+                  class="euiFormControlLayout"
+                >
+                  <div
+                    class="euiFormControlLayout__childrenWrapper"
+                  >
+                    <div
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                        title="Top 10"
+                        value="10"
+                      >
+                        <span
+                          class="euiBadge__content"
+                        >
+                          <span
+                            class="euiBadge__text"
+                          >
+                            Top 10
+                          </span>
+                          <button
+                            aria-label="Remove Top 10 from selection in this group"
+                            class="euiBadge__iconButton"
+                            title="Remove Top 10 from selection in this group"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--small euiIcon-isLoading euiBadge__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              tabindex="-1"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </button>
+                        </span>
+                      </span>
+                      <div
+                        class="euiComboBox__input"
+                        style="font-size: 14px; display: inline-block;"
+                      >
+                        <input
+                          aria-controls=""
+                          data-test-subj="comboBoxSearchInput"
+                          role="textbox"
+                          style="box-sizing: content-box; width: 2px;"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <button
+                        aria-label="Clear input"
+                        class="euiFormControlLayoutClearButton"
+                        data-test-subj="comboBoxClearButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutClearButton__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </button>
+                      <button
+                        aria-label="Open list of options"
+                        class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                        data-test-subj="comboBoxToggleListButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+              style="min-width: 150px;"
+            >
+              <div
+                class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+              >
+                <div
+                  class="euiPopover__anchor"
+                >
+                  <input
+                    type="hidden"
+                    value="by_severity"
+                  />
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Select an option: By severity, is selected
+                      </span>
+                      <button
+                        aria-haspopup="true"
+                        aria-labelledby="undefined random_html_id"
+                        class="euiSuperSelectControl"
+                        type="button"
+                      >
+                        By severity
+                      </button>
+                      <div
+                        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <span
+                          class="euiFormControlLayoutCustomIcon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+                style="padding-right: 15px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px;"
+                  >
+                    <div
+                      class="euiText euiText--extraSmall"
+                      style="margin: 0px;"
+                    >
+                      Anomaly grade
+                       
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Info"
+                          class="euiIcon euiIcon--medium euiIcon-isLoading"
+                          focusable="true"
+                          height="16"
+                          role="img"
+                          tabindex="0"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px; padding-left: 12px;"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(247, 224, 184); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(242, 197, 150); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(236, 169, 118); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(231, 140, 91); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(231, 102, 76); width: 35px; height: 8px;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px; padding-left: 12px;"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <strong>
+                            0.0
+                          </strong>
+                           (None)
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          (Critical) 
+                          <strong>
+                            1.0
+                          </strong>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px 0px 0px 0px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <div
+        style="width: 100%; opacity: 1;"
+      >
+        <div
+          id="HEATMAP_DIV_ID"
+          style="position: relative;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries data 1`] = `
+<div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 5px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <div
+        class="euiCallOut euiCallOut--primary euiCallOut--small"
+      >
+        <div
+          class="euiCallOutHeader"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiCallOutHeader__icon"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.5 11.508L7.468 8H6.25V7h2.401l.03 3.508H9.8v1H7.5zm-.25-6.202a.83.83 0 01.207-.577c.137-.153.334-.229.59-.229.256 0 .454.076.594.23.14.152.209.345.209.576 0 .228-.07.417-.21.568-.14.15-.337.226-.593.226-.256 0-.453-.075-.59-.226a.81.81 0 01-.207-.568zM8 13A5 5 0 108 3a5 5 0 000 10zm0 1A6 6 0 118 2a6 6 0 010 12z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="euiCallOutHeader__title"
+          >
+            No anomalies found in the specified date range.
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px;"
+  >
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="min-width: 80px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiText euiText--medium"
+        >
+          <div
+            class="euiTextAlign euiTextAlign--right"
+          >
+            <h4>
+              test-tile
+            </h4>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem"
+      style="padding-left: 5px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+          style="margin-left: 0px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+              style="min-width: 300px;"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox"
+                role="combobox"
+              >
+                <div
+                  class="euiFormControlLayout"
+                >
+                  <div
+                    class="euiFormControlLayout__childrenWrapper"
+                  >
+                    <div
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                        title="Top 10"
+                        value="10"
+                      >
+                        <span
+                          class="euiBadge__content"
+                        >
+                          <span
+                            class="euiBadge__text"
+                          >
+                            Top 10
+                          </span>
+                          <button
+                            aria-label="Remove Top 10 from selection in this group"
+                            class="euiBadge__iconButton"
+                            title="Remove Top 10 from selection in this group"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--small euiBadge__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              tabindex="-1"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                              />
+                            </svg>
+                          </button>
+                        </span>
+                      </span>
+                      <div
+                        class="euiComboBox__input"
+                        style="font-size: 14px; display: inline-block;"
+                      >
+                        <input
+                          aria-controls=""
+                          data-test-subj="comboBoxSearchInput"
+                          role="textbox"
+                          style="box-sizing: content-box; width: 2px;"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <button
+                        aria-label="Clear input"
+                        class="euiFormControlLayoutClearButton"
+                        data-test-subj="comboBoxClearButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                          />
+                        </svg>
+                      </button>
+                      <button
+                        aria-label="Open list of options"
+                        class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                        data-test-subj="comboBoxToggleListButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                            fill-rule="non-zero"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+              style="min-width: 150px;"
+            >
+              <div
+                class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+              >
+                <div
+                  class="euiPopover__anchor"
+                >
+                  <input
+                    type="hidden"
+                    value="by_severity"
+                  />
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Select an option: By severity, is selected
+                      </span>
+                      <button
+                        aria-haspopup="true"
+                        aria-labelledby="undefined random_html_id"
+                        class="euiSuperSelectControl"
+                        type="button"
+                      >
+                        By severity
+                      </button>
+                      <div
+                        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <span
+                          class="euiFormControlLayoutCustomIcon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                              fill-rule="non-zero"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+                style="padding-right: 15px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px;"
+                  >
+                    <div
+                      class="euiText euiText--extraSmall"
+                      style="margin: 0px;"
+                    >
+                      Anomaly grade
+                       
+                      <span
+                        class="euiToolTipAnchor"
+                      >
+                        <svg
+                          aria-label="Info"
+                          class="euiIcon euiIcon--medium"
+                          focusable="true"
+                          height="16"
+                          role="img"
+                          tabindex="0"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.5 11.508L7.468 8H6.25V7h2.401l.03 3.508H9.8v1H7.5zm-.25-6.202a.83.83 0 01.207-.577c.137-.153.334-.229.59-.229.256 0 .454.076.594.23.14.152.209.345.209.576 0 .228-.07.417-.21.568-.14.15-.337.226-.593.226-.256 0-.453-.075-.59-.226a.81.81 0 01-.207-.568zM8 13A5 5 0 108 3a5 5 0 000 10zm0 1A6 6 0 118 2a6 6 0 010 12z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px; padding-left: 12px;"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(247, 224, 184); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(242, 197, 150); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(236, 169, 118); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(231, 140, 91); width: 35px; height: 8px;"
+                        />
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <span
+                          style="background-color: rgb(231, 102, 76); width: 35px; height: 8px;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiFlexItem"
+                    style="margin: 0px; height: 20px; padding-left: 12px;"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <strong>
+                            0.0
+                          </strong>
+                           (None)
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        style="margin: 0px;"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          (Critical) 
+                          <strong>
+                            1.0
+                          </strong>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding: 0px 0px 0px 0px;"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <div
+        style="width: 100%; opacity: 1;"
+      >
+        <div
+          id="HEATMAP_DIV_ID"
+          style="position: relative;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
@@ -214,7 +214,7 @@ const buildBlankStringWithLength = (length: number) => {
 };
 
 export const getAnomaliesHeatmapData = (
-  anomalies: any[],
+  anomalies: any[] | undefined,
   dateRange: DateRange,
   sortType: AnomalyHeatmapSortType = AnomalyHeatmapSortType.SEVERITY,
   displayTopNum: number
@@ -346,7 +346,7 @@ export const getEntitytAnomaliesHeatmapData = (
       } as EntityAnomalySummaries);
     }
   } else {
-    entitiesAnomalySummaries = cloneDeep(entitiesAnomalySummaryResult);
+    entitiesAnomalySummaries = entitiesAnomalySummaryResult;
   }
 
   entitiesAnomalySummaries.forEach((entityAnomalySummaries) => {
@@ -357,7 +357,7 @@ export const getEntitytAnomaliesHeatmapData = (
       entityAnomalySummaries,
       ENTITY_VALUE_PATH_FIELD,
       ''
-    );
+    ) as string;
     const anomaliesSummary = get(
       entityAnomalySummaries,
       'anomalySummaries',
@@ -413,8 +413,13 @@ export const getEntitytAnomaliesHeatmapData = (
   return [plotData];
 };
 
-const getEntityAnomaliesMap = (anomalies: any[]): Map<string, any[]> => {
+const getEntityAnomaliesMap = (
+  anomalies: any[] | undefined
+): Map<string, any[]> => {
   const entityAnomaliesMap = new Map<string, any[]>();
+  if (anomalies == undefined) {
+    return entityAnomaliesMap;
+  }
   anomalies.forEach((anomaly) => {
     const entity = get(anomaly, 'entity', [] as EntityData[]);
     if (isEmpty(entity)) {

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
@@ -32,6 +32,7 @@ import {
   EntityAnomalySummaries,
   EntityAnomalySummary,
 } from '../../../../server/models/interfaces';
+import { toFixedNumberForAnomaly } from '../../../../server/utils/helpers';
 
 export const convertAlerts = (response: any): MonitorAlert[] => {
   const alerts = get(response, 'response.alerts', []);
@@ -269,7 +270,7 @@ export const getAnomaliesHeatmapData = (
     numAnomalyGrades.push(numAnomalyGradesForEntity);
   });
 
-  const plotTimes = timeWindows.map((timeWindow) => timeWindow.endDate);
+  const plotTimes = timeWindows.map((timeWindow) => timeWindow.startDate);
   const plotData =
     //@ts-ignore
     {
@@ -357,7 +358,7 @@ export const getEnitytAnomaliesHeatmapData = (
       }
 
       const maxAnomalies = anomalySummaryInTimeRange.map((anomalySummary) => {
-        return get(anomalySummary, 'maxAnomaly', 0);
+        return toFixedNumberForAnomaly(get(anomalySummary, 'maxAnomaly', 0));
       });
       const countAnomalies = anomalySummaryInTimeRange.map((anomalySummary) => {
         return get(anomalySummary, 'anomalyCount', 0);

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import { cloneDeep, get, isEmpty, orderBy } from 'lodash';
+import { cloneDeep, defaultTo, get, isEmpty, orderBy } from 'lodash';
 import {
   DateRange,
   Detector,
@@ -358,10 +358,12 @@ export const getEnitytAnomaliesHeatmapData = (
       }
 
       const maxAnomalies = anomalySummaryInTimeRange.map((anomalySummary) => {
-        return toFixedNumberForAnomaly(get(anomalySummary, 'maxAnomaly', 0));
+        return toFixedNumberForAnomaly(
+          defaultTo(get(anomalySummary, 'maxAnomaly'), 0)
+        );
       });
       const countAnomalies = anomalySummaryInTimeRange.map((anomalySummary) => {
-        return get(anomalySummary, 'anomalyCount', 0);
+        return defaultTo(get(anomalySummary, 'anomalyCount'), 0);
       });
 
       maxAnomalyGradesForEntity.push(Math.max(...maxAnomalies));

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -19,6 +19,8 @@ import {
   AD_DOC_FIELDS,
   SORT_DIRECTION,
   MIN_IN_MILLI_SECS,
+  KEY_FIELD,
+  DOC_COUNT_FIELD,
 } from '../../../../server/utils/constants';
 import {
   Detector,
@@ -625,7 +627,7 @@ export const getAnomalyDistributionForDetectorsByTimeRange = async (
 
   const finalDetectorDistributionResult = [] as object[];
   for (let detectorResult of detectorsAggResults) {
-    const detectorId = get(detectorResult, 'key', '');
+    const detectorId = get(detectorResult, KEY_FIELD, '');
     if (detectorAndIdMap.has(detectorId)) {
       const detector = detectorAndIdMap.get(detectorId);
       finalDetectorDistributionResult.push({
@@ -640,7 +642,7 @@ export const getAnomalyDistributionForDetectorsByTimeRange = async (
           AD_DOC_FIELDS.INDICES,
           ''
         ).toString(),
-        count: get(detectorResult, 'doc_count', 0),
+        count: get(detectorResult, DOC_COUNT_FIELD, 0),
       });
     }
   }

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -158,7 +158,6 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           getBucketizedAnomalyResultsQuery(
             dateRange.startDate,
             dateRange.endDate,
-            1,
             props.detector.id,
             entity
           )

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -65,7 +65,6 @@ import {
   HeatmapCell,
   HeatmapDisplayOption,
   INITIAL_HEATMAP_DISPLAY_OPTION,
-  isCombinedViewEntityOption,
 } from '../../AnomalyCharts/containers/AnomalyHeatmapChart';
 import {
   getAnomalyHistoryWording,
@@ -131,54 +130,58 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   const isHCDetector = !isEmpty(detectorCategoryField);
   const backgroundColor = darkModeEnabled() ? '#29017' : '#F7F7F7';
 
-  useEffect(() => {
-    // We load at most 10k AD result data points for one call. If user choose
-    // a big time range which may have more than 10k AD results, will use bucket
-    // aggregation to load data points in whole time range with larger interval.
-    async function getBucketizedAnomalyResults() {
-      try {
-        setIsLoadingAnomalyResults(true);
-        const anomalySummaryResult = await dispatch(
-          searchResults(
-            getAnomalySummaryQuery(
-              dateRange.startDate,
-              dateRange.endDate,
-              props.detector.id
-            )
+  // We load at most 10k AD result data points for one call. If user choose
+  // a big time range which may have more than 10k AD results, will use bucket
+  // aggregation to load data points in whole time range with larger interval.
+  // If entity is specified, we only query AD result data points for this entity.
+  async function getBucketizedAnomalyResults(
+    entity: Entity | undefined = undefined
+  ) {
+    try {
+      setIsLoadingAnomalyResults(true);
+      const anomalySummaryResult = await dispatch(
+        searchResults(
+          getAnomalySummaryQuery(
+            dateRange.startDate,
+            dateRange.endDate,
+            props.detector.id,
+            entity
           )
-        );
+        )
+      );
 
-        setPureAnomalies(parsePureAnomalies(anomalySummaryResult));
-        setBucketizedAnomalySummary(parseAnomalySummary(anomalySummaryResult));
+      setPureAnomalies(parsePureAnomalies(anomalySummaryResult));
+      setBucketizedAnomalySummary(parseAnomalySummary(anomalySummaryResult));
 
-        const result = await dispatch(
-          searchResults(
-            getBucketizedAnomalyResultsQuery(
-              dateRange.startDate,
-              dateRange.endDate,
-              1,
-              props.detector.id
-            )
+      const result = await dispatch(
+        searchResults(
+          getBucketizedAnomalyResultsQuery(
+            dateRange.startDate,
+            dateRange.endDate,
+            1,
+            props.detector.id,
+            entity
           )
-        );
+        )
+      );
 
-        setBucketizedAnomalyResults(parseBucketizedAnomalyResults(result));
-      } catch (err) {
-        console.error(
-          `Failed to get anomaly results for ${props.detector.id}`,
-          err
-        );
-      } finally {
-        setIsLoadingAnomalyResults(false);
-      }
+      setBucketizedAnomalyResults(parseBucketizedAnomalyResults(result));
+    } catch (err) {
+      console.error(
+        `Failed to get anomaly results for ${props.detector.id}`,
+        err
+      );
+    } finally {
+      setIsLoadingAnomalyResults(false);
     }
+  }
 
+  useEffect(() => {
     fetchRawAnomalyResults(isHCDetector);
 
     if (
       !isHCDetector &&
-      dateRange.endDate - dateRange.startDate >
-        detectorInterval * MIN_IN_MILLI_SECS * MAX_ANOMALIES
+      isDateRangeOversize(dateRange, detectorInterval, MAX_ANOMALIES)
     ) {
       getBucketizedAnomalyResults();
     } else {
@@ -191,6 +194,16 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     'detectionInterval.period.interval',
     1
   );
+  const isDateRangeOversize = (
+    dateRange: DateRange,
+    intervalInMinute: number,
+    maxSize: number
+  ) => {
+    return (
+      dateRange.endDate - dateRange.startDate >
+      intervalInMinute * MIN_IN_MILLI_SECS * maxSize
+    );
+  };
 
   const fetchRawAnomalyResults = async (showLoading: boolean) => {
     if (showLoading) {
@@ -221,8 +234,11 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         featureData: get(rawAnomaliesData, 'featureResults', []),
       } as Anomalies;
       setAtomicAnomalyResults(rawAnomaliesResult);
-      setRawAnomalyResults(rawAnomaliesResult);
-      setHCDetectorAnomalyResults(getAnomalyResultForHC(rawAnomaliesResult));
+      if (isHCDetector) {
+        setHCDetectorAnomalyResults(rawAnomaliesResult);
+      } else {
+        setRawAnomalyResults(rawAnomaliesResult);
+      }
     } catch (err) {
       console.error(
         `Failed to get atomic anomaly results for ${props.detector.id}`,
@@ -235,51 +251,22 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     }
   };
 
-  //TODO current implementation can bring in performance issue, will work issue below
-  // https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/313
-  const getAnomalyResultForHC = (rawAnomalyResults: Anomalies) => {
-    const resultAnomaly = rawAnomalyResults.anomalies.filter(
-      (anomaly) => get(anomaly, 'anomalyGrade', 0) > 0
-    );
-
-    const anomaliesFeatureData = resultAnomaly.map(
-      (anomaly) => anomaly.features
-    );
-
-    const resultAnomalyFeatureData: {
-      [key: string]: FeatureAggregationData[];
-    } = {};
-    anomaliesFeatureData.forEach((anomalyFeatureData) => {
-      if (anomalyFeatureData) {
-        for (const [featureId, featureAggData] of Object.entries(
-          anomalyFeatureData
-        )) {
-          if (!resultAnomalyFeatureData[featureId]) {
-            resultAnomalyFeatureData[featureId] = [];
-          }
-          resultAnomalyFeatureData[featureId].push(featureAggData);
-        }
-      }
-    });
-    return {
-      anomalies: resultAnomaly,
-      featureData: resultAnomalyFeatureData,
-    } as Anomalies;
-  };
-
   useEffect(() => {
     if (isHCDetector) {
       fetchHCAnomalySummaries();
     }
   }, [dateRange, heatmapDisplayOption]);
 
+  useEffect(() => {
+    if (selectedHeatmapCell) {
+      fetchEntityAnomalyData(selectedHeatmapCell);
+    } else {
+      setAtomicAnomalyResults(hcDetectorAnomalyResults);
+    }
+  }, [selectedHeatmapCell]);
+
   const fetchHCAnomalySummaries = async () => {
-    // if (
-    //   // query backend only when combined option is selected
-    //   heatmapDisplayOption.entityOption.length == 1 &&
-    //   isCombinedViewEntityOption(heatmapDisplayOption.entityOption[0])
-    // ) {
-    console.log('heatmapDisplayOption is ', heatmapDisplayOption);
+    setIsLoadingAnomalyResults(true);
     const query = getTopAnomalousEntitiesQuery(
       dateRange.startDate,
       dateRange.endDate,
@@ -288,13 +275,10 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       heatmapDisplayOption.sortType
     );
     const result = await dispatch(searchResults(query));
-    console.log('HC Anomaly Summary result', result);
     const topEnityAnomalySummaries = parseTopEntityAnomalySummaryResults(
       result
     );
-    console.log('HC topEnityAnomaliSummaries', topEnityAnomalySummaries);
     const entities = topEnityAnomalySummaries.map((summary) => summary.entity);
-    console.log('HC entities found', entities);
 
     const promises = entities.map(async (entity: Entity) => {
       const entityResultQuery = getEntityAnomalySummariesQuery(
@@ -305,43 +289,100 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         get(props.detector, 'categoryField[0]', ''),
         entity.value
       );
-      console.log(`entityResultQuery for entity ${entity}`, entityResultQuery);
       return dispatch(searchResults(entityResultQuery));
     });
 
     const allEntityAnomalySummaries = await Promise.all(promises).catch(
       (error) => {
-        core.notifications.toasts.addDanger(
-          prettifyErrorMessage(
-            `Error getting anomaly summaries for all entities: ${error}`
-          )
-        );
+        const errorMessage = `Error getting anomaly summaries for all entities: ${error}`;
+        console.error(errorMessage);
+        core.notifications.toasts.addDanger(prettifyErrorMessage(errorMessage));
       }
     );
-    console.log('allEntityAnomalySummaries', allEntityAnomalySummaries);
     const entitiesAnomalySummaries = [] as EntityAnomalySummaries[];
-    //@ts-ignore
-    allEntityAnomalySummaries.forEach((entityResponse, i) => {
-      const entityAnomalySummariesResult = parseEntityAnomalySummaryResults(
-        entityResponse,
-        entities[i]
-      );
-      entitiesAnomalySummaries.push(entityAnomalySummariesResult);
-    });
-    console.log('entitiesAnomalySummaries', entitiesAnomalySummaries);
+
+    if (!isEmpty(allEntityAnomalySummaries)) {
+      //@ts-ignore
+      allEntityAnomalySummaries.forEach((entityResponse, i) => {
+        const entityAnomalySummariesResult = parseEntityAnomalySummaryResults(
+          entityResponse,
+          entities[i]
+        );
+        entitiesAnomalySummaries.push(entityAnomalySummariesResult);
+      });
+    }
     setEntityAnomalySummaries(entitiesAnomalySummaries);
-    // }
+    setIsLoadingAnomalyResults(false);
   };
 
+  const fetchEntityAnomalyData = async (heatmapCell: HeatmapCell) => {
+    setIsLoadingAnomalyResults(true);
+    try {
+      if (
+        isDateRangeOversize(
+          heatmapCell.dateRange,
+          detectorInterval,
+          MAX_ANOMALIES
+        )
+      ) {
+        fetchBucketizedEntityAnomalyData(heatmapCell);
+      } else {
+        fetchAllEntityAnomalyData(heatmapCell);
+        setBucketizedAnomalyResults(undefined);
+      }
+    } catch (err) {
+      console.error(
+        `Failed to get anomaly results for entity ${heatmapCell.entityValue}`,
+        err
+      );
+    } finally {
+      setIsLoadingAnomalyResults(false);
+    }
+  };
+
+  const fetchAllEntityAnomalyData = async (heatmapCell: HeatmapCell) => {
+    const params = buildParamsForGetAnomalyResultsWithDateRange(
+      heatmapCell.dateRange.startDate,
+      heatmapCell.dateRange.endDate,
+      false,
+      {
+        //@ts-ignore
+        name: props.detector.categoryField[0],
+        value: heatmapCell.entityValue,
+      }
+    );
+
+    const entityAnomalyResultResponse = await dispatch(
+      getDetectorResults(props.detector.id, params)
+    );
+
+    const entityAnomaliesData = get(
+      entityAnomalyResultResponse,
+      'response',
+      []
+    );
+    const entityAnomaliesResult = {
+      anomalies: get(entityAnomaliesData, 'results', []),
+      featureData: get(entityAnomaliesData, 'featureResults', []),
+    } as Anomalies;
+
+    setAtomicAnomalyResults(entityAnomaliesResult);
+  };
+
+  const fetchBucketizedEntityAnomalyData = async (heatmapCell: HeatmapCell) => {
+    getBucketizedAnomalyResults({
+      //@ts-ignore
+      name: props.detector.categoryField[0],
+      value: heatmapCell.entityValue,
+    });
+  };
   const [atomicAnomalyResults, setAtomicAnomalyResults] = useState<Anomalies>();
   const [rawAnomalyResults, setRawAnomalyResults] = useState<Anomalies>();
   const [hcDetectorAnomalyResults, setHCDetectorAnomalyResults] = useState<
     Anomalies
   >();
 
-  const anomalyResults = isHCDetector
-    ? hcDetectorAnomalyResults
-    : bucketizedAnomalyResults
+  const anomalyResults = bucketizedAnomalyResults
     ? bucketizedAnomalyResults
     : atomicAnomalyResults;
   const handleDateRangeChange = useCallback(

--- a/public/pages/utils/__tests__/constants.ts
+++ b/public/pages/utils/__tests__/constants.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import moment from 'moment';
+import {
+  EntityAnomalySummaries,
+  EntityAnomalySummary,
+} from '../../../../server/models/interfaces';
+import { AnomalyData } from '../../../models/interfaces';
+
+export const FAKE_START_TIME = moment('2019-10-10T09:00:00');
+export const FAKE_END_TIME = FAKE_START_TIME.clone().add(2, 'd');
+export const FAKE_ANOMALY_START_TIME = FAKE_START_TIME.add(
+  1,
+  'minutes'
+).valueOf();
+export const FAKE_ANOMALY_END_TIME = FAKE_START_TIME.add(
+  2,
+  'minutes'
+).valueOf();
+export const FAKE_ANOMALY_PLOT_TIME = FAKE_START_TIME.add(
+  90,
+  'seconds'
+).valueOf();
+export const FAKE_DATE_RANGE = {
+  startDate: FAKE_START_TIME.valueOf(),
+  endDate: FAKE_END_TIME.valueOf(),
+};
+export const FAKE_SINGLE_FEATURE_VALUE = {
+  data: 10,
+  endTime: FAKE_ANOMALY_END_TIME,
+  startTime: FAKE_ANOMALY_START_TIME,
+  plotTime: FAKE_ANOMALY_PLOT_TIME,
+};
+export const FAKE_FEATURE_DATA = {
+  testFeatureId: FAKE_SINGLE_FEATURE_VALUE,
+};
+export const FAKE_ENTITY = { name: 'entityName', value: 'entityValue' };
+export const FAKE_ANOMALY_DATA = [
+  {
+    anomalyGrade: 0.3,
+    confidence: 0.8,
+    startTime: FAKE_ANOMALY_START_TIME,
+    endTime: FAKE_ANOMALY_END_TIME,
+    plotTime: FAKE_ANOMALY_PLOT_TIME,
+    entity: [FAKE_ENTITY],
+    features: FAKE_FEATURE_DATA,
+  } as AnomalyData,
+];
+
+export const FAKE_ANOMALIES_RESULT = {
+  anomalies: FAKE_ANOMALY_DATA,
+  featureData: {
+    testFeatureId: [FAKE_SINGLE_FEATURE_VALUE],
+  },
+};
+
+export const FAKE_ENTITY_ANOMALY_SUMMARY = {
+  startTime: FAKE_ANOMALY_START_TIME,
+  maxAnomaly: 0.9,
+  anomalyCount: 1,
+} as EntityAnomalySummary;
+
+export const FAKE_ENTITY_ANOMALY_SUMMARIES = {
+  entity: FAKE_ENTITY,
+  anomalySummaries: [FAKE_ENTITY_ANOMALY_SUMMARY],
+} as EntityAnomalySummaries;

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -23,9 +23,11 @@ import {
 } from '../../../server/models/interfaces';
 import {
   AD_DOC_FIELDS,
+  DOC_COUNT_FIELD,
   ENTITY_FIELD,
   ENTITY_NAME_PATH_FIELD,
   ENTITY_VALUE_PATH_FIELD,
+  KEY_FIELD,
   MIN_IN_MILLI_SECS,
   SORT_DIRECTION,
 } from '../../../server/utils/constants';
@@ -405,12 +407,11 @@ export const getAnomalySummaryQuery = (
 export const getBucketizedAnomalyResultsQuery = (
   startTime: number,
   endTime: number,
-  interval: number,
   detectorId: string,
   entity: Entity | undefined = undefined
 ) => {
   const fixedInterval = Math.ceil(
-    (endTime - startTime) / (interval * MIN_IN_MILLI_SECS * MAX_DATA_POINTS)
+    (endTime - startTime) / (MIN_IN_MILLI_SECS * MAX_DATA_POINTS)
   );
   return {
     size: 0,
@@ -1035,8 +1036,8 @@ export const parseTopEntityAnomalySummaryResults = (
   ) as any[];
   let topEntityAnomalySummaries = [] as EntityAnomalySummaries[];
   rawEntityAnomalySummaries.forEach((item) => {
-    const anomalyCount = get(item, 'doc_count', 0);
-    const entityValue = get(item, 'key', 0);
+    const anomalyCount = get(item, DOC_COUNT_FIELD, 0);
+    const entityValue = get(item, KEY_FIELD, 0);
     const entity = {
       value: entityValue,
     } as Entity;

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -17,6 +17,11 @@ import { get, isEmpty, orderBy } from 'lodash';
 import moment from 'moment';
 import { Dispatch } from 'redux';
 import {
+  EntityAnomalySummaries,
+  EntityAnomalySummary,
+  Entity,
+} from '../../../server/models/interfaces';
+import {
   AD_DOC_FIELDS,
   MIN_IN_MILLI_SECS,
   SORT_DIRECTION,
@@ -38,7 +43,20 @@ import {
   MISSING_FEATURE_DATA_SEVERITY,
 } from '../../utils/constants';
 import { HeatmapCell } from '../AnomalyCharts/containers/AnomalyHeatmapChart';
+import { AnomalyHeatmapSortType } from '../AnomalyCharts/utils/anomalyChartUtils';
 import { DETECTOR_INIT_FAILURES } from '../DetectorDetail/utils/constants';
+import {
+  COUNT_ANOMALY_AGGS,
+  ENTITY_DATE_BUCKET_ANOMALY_AGGS,
+  ENTITY_FIELD,
+  ENTITY_NAME_PATH_FIELD,
+  ENTITY_VALUE_PATH_FIELD,
+  MAX_ANOMALY_AGGS,
+  MAX_ANOMALY_SORT_AGGS,
+  TOP_ANOMALY_GRADE_SORT_AGGS,
+  TOP_ENTITIES_FIELD,
+  TOP_ENTITY_AGGS,
+} from './constants';
 import { dateFormatter, minuteDateFormatter } from './helpers';
 
 export const getQueryParamsForLiveAnomalyResults = (
@@ -857,4 +875,245 @@ export const filterWithHeatmapFilter = (
       );
   }
   return filterWithDateRange(data, heatmapCell.dateRange, timeField);
+};
+
+export const getTopAnomalousEntitiesQuery = (
+  startTime: number,
+  endTime: number,
+  detectorId: string,
+  size: number,
+  sortType: AnomalyHeatmapSortType
+) => {
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              [AD_DOC_FIELDS.ANOMALY_GRADE]: {
+                gt: 0,
+              },
+            },
+          },
+          {
+            range: {
+              data_end_time: {
+                gte: startTime,
+                lte: endTime,
+              },
+            },
+          },
+          {
+            term: {
+              detector_id: detectorId,
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      [TOP_ENTITIES_FIELD]: {
+        nested: {
+          path: ENTITY_FIELD,
+        },
+        aggs: {
+          [TOP_ENTITY_AGGS]: {
+            terms: {
+              field: ENTITY_VALUE_PATH_FIELD,
+              size: size,
+              ...(sortType === AnomalyHeatmapSortType.SEVERITY
+                ? {
+                    order: {
+                      [TOP_ANOMALY_GRADE_SORT_AGGS]: SORT_DIRECTION.DESC,
+                    },
+                  }
+                : {}),
+            },
+            aggs: {
+              [TOP_ANOMALY_GRADE_SORT_AGGS]: {
+                reverse_nested: {},
+                aggs: {
+                  [MAX_ANOMALY_AGGS]: {
+                    max: {
+                      field: AD_DOC_FIELDS.ANOMALY_GRADE,
+                    },
+                  },
+                },
+              },
+              ...(sortType === AnomalyHeatmapSortType.SEVERITY
+                ? {
+                    [MAX_ANOMALY_SORT_AGGS]: {
+                      bucket_sort: {
+                        sort: [
+                          {
+                            [`${TOP_ANOMALY_GRADE_SORT_AGGS}.${MAX_ANOMALY_AGGS}`]: {
+                              order: SORT_DIRECTION.DESC,
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  }
+                : {}),
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+export const parseTopEntityAnomalySummaryResults = (
+  result: any
+): EntityAnomalySummaries[] => {
+  const rawEntityAnomalySummaries = get(
+    result,
+    `response.aggregations.${TOP_ENTITIES_FIELD}.${TOP_ENTITY_AGGS}.buckets`,
+    []
+  ) as any[];
+  let topEntityAnomalySummaries = [] as EntityAnomalySummaries[];
+  rawEntityAnomalySummaries.forEach((item) => {
+    const anomalyCount = get(item, 'doc_count', 0);
+    const entityValue = get(item, 'key', 0);
+    const entity = {
+      value: entityValue,
+    } as Entity;
+    const maxAnomalyGrade = get(
+      item,
+      [TOP_ANOMALY_GRADE_SORT_AGGS, MAX_ANOMALY_AGGS].join('.'),
+      0
+    );
+    const enityAnomalySummary = {
+      maxAnomaly: maxAnomalyGrade,
+      anomalyCount: anomalyCount,
+    } as EntityAnomalySummary;
+    const enityAnomaliSummaries = {
+      entity: entity,
+      anomalySummaries: [enityAnomalySummary],
+    } as EntityAnomalySummaries;
+    topEntityAnomalySummaries.push(enityAnomaliSummaries);
+  });
+  return topEntityAnomalySummaries;
+};
+
+export const getEntityAnomalySummariesQuery = (
+  startTime: number,
+  endTime: number,
+  detectorId: string,
+  size: number,
+  categoryField: string,
+  entityValue: string
+) => {
+  const fixedInterval = Math.max(
+    Math.ceil((endTime - startTime) / (size * MIN_IN_MILLI_SECS)),
+    1
+  );
+  // bucket key is calculated below
+  // bucket_key = Math.floor(value / interval) * interval
+  // if startTime is not divisible by fixedInterval, there will be remainder,
+  // this can be offset for bucket_key
+  const offsetInMillisec = startTime % (fixedInterval * MIN_IN_MILLI_SECS);
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              [AD_DOC_FIELDS.ANOMALY_GRADE]: {
+                gt: 0,
+              },
+            },
+          },
+          {
+            range: {
+              data_end_time: {
+                gte: startTime,
+                lte: endTime,
+              },
+            },
+          },
+          {
+            term: {
+              detector_id: detectorId,
+            },
+          },
+          {
+            nested: {
+              path: ENTITY_FIELD,
+              query: {
+                term: {
+                  [ENTITY_VALUE_PATH_FIELD]: {
+                    value: entityValue,
+                  },
+                },
+              },
+            },
+          },
+          {
+            nested: {
+              path: ENTITY_FIELD,
+              query: {
+                term: {
+                  [ENTITY_NAME_PATH_FIELD]: {
+                    value: categoryField,
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      [ENTITY_DATE_BUCKET_ANOMALY_AGGS]: {
+        date_histogram: {
+          field: AD_DOC_FIELDS.DATA_END_TIME,
+          fixed_interval: `${fixedInterval}m`,
+          offset: `${offsetInMillisec}ms`,
+        },
+        aggs: {
+          [MAX_ANOMALY_AGGS]: {
+            max: {
+              field: AD_DOC_FIELDS.ANOMALY_GRADE,
+            },
+          },
+          [COUNT_ANOMALY_AGGS]: {
+            value_count: {
+              field: AD_DOC_FIELDS.ANOMALY_GRADE,
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+export const parseEntityAnomalySummaryResults = (
+  result: any,
+  entity: Entity
+): EntityAnomalySummaries => {
+  const rawEntityAnomalySummaries = get(
+    result,
+    `response.aggregations.${ENTITY_DATE_BUCKET_ANOMALY_AGGS}.buckets`,
+    []
+  ) as any[];
+  let anomalySummaries = [] as EntityAnomalySummary[];
+  rawEntityAnomalySummaries.forEach((item) => {
+    const anomalyCount = get(item, `${COUNT_ANOMALY_AGGS}.value`, 0);
+    const startTime = get(item, 'key', 0);
+    const maxAnomalyGrade = get(item, `${MAX_ANOMALY_AGGS}.value`, 0);
+    const enityAnomalySummary = {
+      startTime: startTime,
+      maxAnomaly: maxAnomalyGrade,
+      anomalyCount: anomalyCount,
+    } as EntityAnomalySummary;
+    anomalySummaries.push(enityAnomalySummary);
+  });
+  const enityAnomalySummaries = {
+    entity: entity,
+    anomalySummaries: anomalySummaries,
+  } as EntityAnomalySummaries;
+  return enityAnomalySummaries;
 };

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -23,6 +23,9 @@ import {
 } from '../../../server/models/interfaces';
 import {
   AD_DOC_FIELDS,
+  ENTITY_FIELD,
+  ENTITY_NAME_PATH_FIELD,
+  ENTITY_VALUE_PATH_FIELD,
   MIN_IN_MILLI_SECS,
   SORT_DIRECTION,
 } from '../../../server/utils/constants';
@@ -48,9 +51,6 @@ import { DETECTOR_INIT_FAILURES } from '../DetectorDetail/utils/constants';
 import {
   COUNT_ANOMALY_AGGS,
   ENTITY_DATE_BUCKET_ANOMALY_AGGS,
-  ENTITY_FIELD,
-  ENTITY_NAME_PATH_FIELD,
-  ENTITY_VALUE_PATH_FIELD,
   MAX_ANOMALY_AGGS,
   MAX_ANOMALY_SORT_AGGS,
   TOP_ANOMALY_GRADE_SORT_AGGS,

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -74,3 +74,15 @@ export const GET_SAMPLE_DETECTORS_QUERY_PARAMS = {
 };
 
 export const GET_SAMPLE_INDICES_QUERY = 'opendistro-sample-*';
+
+export const TOP_ENTITIES_FIELD = 'top_entities';
+export const ENTITY_FIELD = 'entity';
+export const ENTITY_VALUE_PATH_FIELD = 'entity.value';
+export const ENTITY_NAME_PATH_FIELD = 'entity.name';
+
+export const TOP_ENTITY_AGGS = 'top_entity_aggs';
+export const TOP_ANOMALY_GRADE_SORT_AGGS = 'top_anomaly_grade_sort_aggs';
+export const MAX_ANOMALY_AGGS = 'max_anomaly_aggs';
+export const COUNT_ANOMALY_AGGS = 'count_anomaly_aggs';
+export const MAX_ANOMALY_SORT_AGGS = 'max_anomaly_sort_aggs';
+export const ENTITY_DATE_BUCKET_ANOMALY_AGGS = 'entity_date_bucket_anomaly';

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -76,9 +76,6 @@ export const GET_SAMPLE_DETECTORS_QUERY_PARAMS = {
 export const GET_SAMPLE_INDICES_QUERY = 'opendistro-sample-*';
 
 export const TOP_ENTITIES_FIELD = 'top_entities';
-export const ENTITY_FIELD = 'entity';
-export const ENTITY_VALUE_PATH_FIELD = 'entity.value';
-export const ENTITY_NAME_PATH_FIELD = 'entity.name';
 
 export const TOP_ENTITY_AGGS = 'top_entity_aggs';
 export const TOP_ANOMALY_GRADE_SORT_AGGS = 'top_anomaly_grade_sort_aggs';

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -1,4 +1,23 @@
 /*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -22,12 +41,12 @@ export interface DefaultHeaders {
 export interface SearchResponse<T> {
   hits: {
     total: { value: number };
-    hits: {
+    hits: Array<{
       _source: T;
       _id: string;
       _seq_no?: number;
       _primary_term?: number;
-    }[];
+    }>;
   };
 }
 
@@ -40,11 +59,11 @@ export interface AlertingApis {
   [API_ROUTE: string]: string;
   readonly ALERTING_BASE: string;
 }
-export type Entity = {
+export interface Entity {
   name: string;
   value: string;
-};
-export type Anomaly = {
+}
+export interface Anomaly {
   anomalyGrade: number;
   confidence: number;
   anomalyScore: number;
@@ -52,23 +71,34 @@ export type Anomaly = {
   endTime: number;
   plotTime: number;
   entity?: Entity[];
-};
-//Plot time is middle of start and end time to provide better visualization to customers
+}
+// Plot time is middle of start and end time to provide better visualization to customers
 // Example, if window is 10 mins, in a given startTime and endTime of 12:10 to 12:20 respectively.
 // plotTime will be 12:15.
-export type FeatureData = {
+export interface FeatureData {
   startTime: number;
   endTime: number;
   plotTime: number;
   data: number;
-};
+}
 export interface AnomalyResults {
   anomalies: Anomaly[];
   featureData: { [key: string]: FeatureData[] };
 }
 
-export type InitProgress = {
+export interface InitProgress {
   percentageStr: string;
   estimatedMinutesLeft: number;
   neededShingles: number;
-};
+}
+
+export interface EntityAnomalySummary {
+  startTime: number;
+  maxAnomaly: number;
+  anomalyCount: number;
+}
+
+export interface EntityAnomalySummaries {
+  entity: Entity;
+  anomalySummaries: EntityAnomalySummary[];
+}

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -1,24 +1,5 @@
 /*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -28,7 +28,13 @@ import {
   DateRangeFilter,
 } from '../models/types';
 import { Router } from '../router';
-import { SORT_DIRECTION, AD_DOC_FIELDS } from '../utils/constants';
+import {
+  SORT_DIRECTION,
+  AD_DOC_FIELDS,
+  ENTITY_FIELD,
+  ENTITY_NAME_PATH_FIELD,
+  ENTITY_VALUE_PATH_FIELD,
+} from '../utils/constants';
 import {
   mapKeysDeep,
   toCamel,
@@ -723,10 +729,10 @@ export default class AdService {
                 ? [
                     {
                       nested: {
-                        path: 'entity',
+                        path: ENTITY_FIELD,
                         query: {
                           term: {
-                            'entity.name': {
+                            [ENTITY_NAME_PATH_FIELD]: {
                               value: entityName,
                             },
                           },
@@ -735,10 +741,10 @@ export default class AdService {
                     },
                     {
                       nested: {
-                        path: 'entity',
+                        path: ENTITY_FIELD,
                         query: {
                           term: {
-                            'entity.value': {
+                            [ENTITY_VALUE_PATH_FIELD]: {
                               value: entityValue,
                             },
                           },

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -668,6 +668,8 @@ export default class AdService {
         sortField = AD_DOC_FIELDS.DATA_START_TIME,
         dateRangeFilter = undefined,
         anomalyThreshold = -1,
+        entityName = undefined,
+        entityValue = undefined,
       } = request.query as {
         from: number;
         size: number;
@@ -675,6 +677,8 @@ export default class AdService {
         sortField?: string;
         dateRangeFilter?: string;
         anomalyThreshold: number;
+        entityName: string;
+        entityValue: string;
       };
 
       //Allowed sorting columns
@@ -715,6 +719,34 @@ export default class AdService {
                   },
                 },
               },
+              ...(entityName && entityValue
+                ? [
+                    {
+                      nested: {
+                        path: 'entity',
+                        query: {
+                          term: {
+                            'entity.name': {
+                              value: entityName,
+                            },
+                          },
+                        },
+                      },
+                    },
+                    {
+                      nested: {
+                        path: 'entity',
+                        query: {
+                          term: {
+                            'entity.value': {
+                              value: entityValue,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  ]
+                : []),
             ],
           },
         },

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -79,3 +79,6 @@ export enum SAMPLE_TYPE {
 export const ENTITY_FIELD = 'entity';
 export const ENTITY_VALUE_PATH_FIELD = 'entity.value';
 export const ENTITY_NAME_PATH_FIELD = 'entity.name';
+
+export const DOC_COUNT_FIELD = 'doc_count';
+export const KEY_FIELD = 'key';

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -75,3 +75,7 @@ export enum SAMPLE_TYPE {
   HOST_HEALTH = 'host-health',
   ECOMMERCE = 'ecommerce',
 }
+
+export const ENTITY_FIELD = 'entity';
+export const ENTITY_VALUE_PATH_FIELD = 'entity.value';
+export const ENTITY_NAME_PATH_FIELD = 'entity.name';


### PR DESCRIPTION
*Issue #, if available:*
#313 
*Description of changes:*
Currently, AnomalyHistory chart loads all anomaly only data and pass it to heatmap chart to do the filtering/sorting for rendering anomaly summaries data on heatmap. The downside of it is 1) we have to manually aggregate/sort raw anomaly data, and it can cause performance issue if there are too many anomalies in specified date range; 2) we miss the feature data of anomaly grade 0 data points, such that it has less friendly UX compared to all feature data is rendered

This PR changes to 1) find anomalous entities via ES query; 2) get anomaly summaries for each entities via ES query;3) get anomaly/feature data only when heatmap cell is selected. 

This moves the heavy aggregation/sorting work to ES from front-end, and has better UX with all feature data is rendered. 

After the change:
Preview: same as before
![Preview_selected](https://user-images.githubusercontent.com/59710443/102664978-cab89300-4138-11eb-95fb-070abbb2bcc4.png)

DetectorResult page: anomaly data points with anomaly grade 0 is also included
![Result_selected_anomaly](https://user-images.githubusercontent.com/59710443/102664998-d441fb00-4138-11eb-96a2-ad16ed1931ec.png)

DetectorResult page: feature data points with anomaly grade 0 is also included
![Result_selected_feature](https://user-images.githubusercontent.com/59710443/102665077-f9cf0480-4138-11eb-8bc9-7b18bba5821d.png)

UT will be added in following commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
