### PR TITLE
Fix failure of adding feature to 1st detector in cluster

### DIFF
--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -46,7 +46,7 @@ import {
   isIndexNotFoundError,
   getErrorMessage,
 } from './utils/adHelpers';
-import { set } from 'lodash';
+import { isNumber, set } from 'lodash';
 import {
   RequestHandlerContext,
   KibanaRequest,
@@ -174,7 +174,8 @@ export default class AdService {
         body: requestBody,
       };
       let response;
-      if (ifSeqNo && ifPrimaryTerm) {
+
+      if (isNumber(ifSeqNo) && isNumber(ifPrimaryTerm)) {
         response = await this.client
           .asScoped(request)
           .callAsCurrentUser('ad.updateDetector', params);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/issues/342
*Description of changes:*
When creating 1st detector, adding feature fails because `seqNo` is 0 for the 1st created detector, and in our code, we use `if (ifSeqNo && ifPrimaryTerm)` to determine if we should update detector or create detector. In Javascript, 0 is considered as `false`, that's why there is such issue. Changing to use `isNumber()` fixs the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
