### PR TITLE
Update draft release notes config to use URL

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -5,7 +5,7 @@ template: |
 
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: '* $TITLE (#$NUMBER)'
+change-template: '* $TITLE (#$URL)'
 sort-by: merged_at
 sort-direction: ascending
 replacers:

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -5,7 +5,7 @@ template: |
 
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: '* $TITLE (#$URL)'
+change-template: '* $TITLE ([#$NUMBER]($URL))'
 sort-by: merged_at
 sort-direction: ascending
 replacers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The release drafter GitHub action recently released a new `$URL` env variable, allowing the draft notes to pass the raw PR URL instead of just the PR number. This simplifies and speeds up the creation for the additional release notes files that is created in the `release-notes` dir.

Will confirm this works by checking the draft notes after merging and running the GitHub action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
