### PR TITLE
Remove copyright year for newly added files

### DIFF
--- a/public/pages/CreateHistoricalDetector/components/Configuration/Configuration.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/Configuration.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/__tests__/Configuration.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/__tests__/Configuration.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/ExistingDetectors/ExistingDetectors.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/ExistingDetectors/ExistingDetectors.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/ExistingDetectors/utils/helpers.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/ExistingDetectors/utils/helpers.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/Features/Features.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/Features/Features.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/OperationSettings/OperationSettings.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/OperationSettings/OperationSettings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/Timestamp/Timestamp.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/Timestamp/Timestamp.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/ExistingDetectors.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/ExistingDetectors.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/Features.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/Features.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/OperationSettings.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/OperationSettings.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/Timestamp.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/Timestamp.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/IndexChooser/IndexChooser.tsx
+++ b/public/pages/CreateHistoricalDetector/components/IndexChooser/IndexChooser.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/IndexChooser/__tests__/IndexChooser.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/IndexChooser/__tests__/IndexChooser.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Info/Info.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Info/Info.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/Info/__tests__/Info.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/Info/__tests__/Info.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/TimeRange/TimeRange.tsx
+++ b/public/pages/CreateHistoricalDetector/components/TimeRange/TimeRange.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/components/TimeRange/__tests__/TimeRange.test.tsx
+++ b/public/pages/CreateHistoricalDetector/components/TimeRange/__tests__/TimeRange.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/containers/CreateHistoricalDetector.tsx
+++ b/public/pages/CreateHistoricalDetector/containers/CreateHistoricalDetector.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/containers/__tests__/CreateHistoricalDetector.test.tsx
+++ b/public/pages/CreateHistoricalDetector/containers/__tests__/CreateHistoricalDetector.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/index.ts
+++ b/public/pages/CreateHistoricalDetector/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/utils/constants.ts
+++ b/public/pages/CreateHistoricalDetector/utils/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/CreateHistoricalDetector/utils/helpers.ts
+++ b/public/pages/CreateHistoricalDetector/utils/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/components/HistoricalDetectorConfig/HistoricalDetectorConfig.tsx
+++ b/public/pages/HistoricalDetectorDetail/components/HistoricalDetectorConfig/HistoricalDetectorConfig.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/components/HistoricalDetectorControls/HistoricalDetectorControls.tsx
+++ b/public/pages/HistoricalDetectorDetail/components/HistoricalDetectorControls/HistoricalDetectorControls.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/components/__tests__/HistoricalDetectorConfig.test.tsx
+++ b/public/pages/HistoricalDetectorDetail/components/__tests__/HistoricalDetectorConfig.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/components/__tests__/HistoricalDetectorControls.test.tsx
+++ b/public/pages/HistoricalDetectorDetail/components/__tests__/HistoricalDetectorControls.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/ActionModals/DeleteHistoricalDetectorModal/DeleteHistoricalDetectorModal.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/ActionModals/DeleteHistoricalDetectorModal/DeleteHistoricalDetectorModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/ActionModals/EditHistoricalDetectorModal/EditHistoricalDetectorModal.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/ActionModals/EditHistoricalDetectorModal/EditHistoricalDetectorModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/ActionModals/__tests__/DeleteHistoricalDetectorModal.test.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/ActionModals/__tests__/DeleteHistoricalDetectorModal.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/ActionModals/__tests__/EditHistoricalDetectorModal.test.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/ActionModals/__tests__/EditHistoricalDetectorModal.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/HistoricalDetectorDetail/HistoricalDetectorDetail.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/HistoricalDetectorDetail/HistoricalDetectorDetail.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/containers/HistoricalDetectorDetail/__tests__/HistoricalDetectorDetail.test.tsx
+++ b/public/pages/HistoricalDetectorDetail/containers/HistoricalDetectorDetail/__tests__/HistoricalDetectorDetail.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/index.ts
+++ b/public/pages/HistoricalDetectorDetail/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/utils/constants.tsx
+++ b/public/pages/HistoricalDetectorDetail/utils/constants.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorDetail/utils/helpers.tsx
+++ b/public/pages/HistoricalDetectorDetail/utils/helpers.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
+++ b/public/pages/HistoricalDetectorList/components/EmptyHistoricalDetectorMessage/EmptyHistoricalDetectorMessage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/components/HistoricalDetectorFilters/HistoricalDetectorFilters.tsx
+++ b/public/pages/HistoricalDetectorList/components/HistoricalDetectorFilters/HistoricalDetectorFilters.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
+++ b/public/pages/HistoricalDetectorList/containers/HistoricalDetectorList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
+++ b/public/pages/HistoricalDetectorList/containers/__tests__/HistoricalDetectorList.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/index.ts
+++ b/public/pages/HistoricalDetectorList/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/utils/constants.tsx
+++ b/public/pages/HistoricalDetectorList/utils/constants.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/public/pages/HistoricalDetectorList/utils/helpers.tsx
+++ b/public/pages/HistoricalDetectorList/utils/helpers.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.


### PR DESCRIPTION
*Issue #, if available:* #365

*Description of changes:*

This PR removes the copyright year in the license headers from recently added files. It is now recommended based on Amazon open source code standards to not include a year on files. New files created from this point on should adopt this strategy, and headers in all files should now just be this:

```
/*
 * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License").
 * You may not use this file except in compliance with the License.
 * A copy of the License is located at
 *
 * http://www.apache.org/licenses/LICENSE-2.0
 *
 * or in the "license" file accompanying this file. This file is distributed
 * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
