### PR TITLE
Remove stopped annotations for historical detector chart

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -308,7 +308,8 @@ export const AnomalyDetailsChart = React.memo(
                     }
                     theme={ANOMALY_CHART_THEME}
                   />
-                  {props.isHCDetector && !props.selectedHeatmapCell ? null : (
+                  {(props.isHCDetector && !props.selectedHeatmapCell) ||
+                  props.isHistorical ? null : (
                     <RectAnnotation
                       dataValues={disabledHistoryAnnotations(
                         zoomRange,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR removes the stopped annotation from showing up for the historical detectors, if the user expands the results chart beyond the detection date range.

Before:
![image](https://user-images.githubusercontent.com/62119629/106636960-1f706b80-6537-11eb-8592-fb0ffb815c7d.png)

After:
![image](https://user-images.githubusercontent.com/62119629/106636666-036cca00-6537-11eb-9d5b-d8bdbbe21afa.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
