### PR TITLE
Fix dashboard loading state and empty state logic

### DIFF
--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -54,23 +54,17 @@ import { CoreStart } from '../../../../../../src/core/public';
 
 export function DashboardOverview() {
   const core = React.useContext(CoreServicesContext) as CoreStart;
-
   const dispatch = useDispatch();
-
   const adState = useSelector((state: AppState) => state.ad);
-
   const allDetectorList = adState.detectorList;
-
+  const totalRealtimeDetectors = Object.values(allDetectorList).length;
   const errorGettingDetectors = adState.errorMessage;
-
-  const [isLoadingDetectors, setIsLoadingDetectors] = useState(true);
+  const isLoadingDetectors = adState.requesting;
 
   const [currentDetectors, setCurrentDetectors] = useState(
     Object.values(allDetectorList)
   );
-
   const [allDetectorsSelected, setAllDetectorsSelected] = useState(true);
-
   const [selectedDetectorsName, setSelectedDetectorsName] = useState(
     [] as string[]
   );
@@ -169,7 +163,6 @@ export function DashboardOverview() {
   };
 
   const intializeDetectors = async () => {
-    setIsLoadingDetectors(true);
     dispatch(getDetectorList(GET_ALL_DETECTORS_QUERY_PARAMS));
     dispatch(getIndices(''));
     dispatch(getAliases(''));
@@ -188,7 +181,6 @@ export function DashboardOverview() {
           ? prettifyErrorMessage(errorGettingDetectors)
           : 'Unable to get all detectors'
       );
-      setIsLoadingDetectors(false);
     }
   }, [errorGettingDetectors]);
 
@@ -201,7 +193,6 @@ export function DashboardOverview() {
 
   useEffect(() => {
     setCurrentDetectors(Object.values(allDetectorList));
-    setIsLoadingDetectors(false);
   }, [allDetectorList]);
 
   useEffect(() => {
@@ -215,7 +206,7 @@ export function DashboardOverview() {
   return (
     <div style={{ height: '1200px' }}>
       <Fragment>
-        <DashboardHeader hasDetectors={adState.totalDetectors > 0} />
+        <DashboardHeader hasDetectors={totalRealtimeDetectors > 0} />
         {isLoadingDetectors ? (
           <div>
             <EuiLoadingSpinner size="s" />
@@ -226,7 +217,7 @@ export function DashboardOverview() {
             &nbsp;&nbsp;
             <EuiLoadingSpinner size="xl" />
           </div>
-        ) : adState.totalDetectors === 0 ? (
+        ) : totalRealtimeDetectors === 0 ? (
           <EmptyDashboard />
         ) : (
           <Fragment>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes 2 issues:
1. The loading state, which would occasionally flash an incorrect empty state while the detectors are being retrieved from ES (issue #304).
2. The empty state, which was not showing up when no real-time detectors existed, but historical detectors did (issue #372).

Confirmed all UT & IT pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
