### PR TITLE
Update default branch in workflows

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -2,7 +2,7 @@ name: E2E tests workflow
 on:
   push:
     branches:
-      - master
+      - main
 env:
   KIBANA_VERSION: 7.10.2
   ODFE_VERSION: 1.13.0

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -2,7 +2,7 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - master
+      - main
 env:
   KIBANA_VERSION: 7.10.2
 jobs:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the recent efforts to change the default branch name from `master` to `main`, some workflows had `master` hardcoded - this changes those to `main` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
