### PR TITLE
Change security plugin to correct name in new version in Github workflow

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -5,7 +5,7 @@ on:
       - main
 env:
   KIBANA_VERSION: 7.10.2
-  ODFE_VERSION: 1.13.0
+  ODFE_VERSION: 1.13.1
   AD_KIBANA_PLUGIN_NAME: opendistroAnomalyDetectionKibana
 jobs:
   test-with-security:
@@ -112,7 +112,7 @@ jobs:
             echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$odfe_version" >> Dockerfile
             ## The ESRestTest Client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
-            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro-security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-security; fi" >> Dockerfile
             docker build -t odfe-ad:test .
           fi
       - name: Run Docker Image


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change security plugin to correct name in new version in Github workflow, use 1.13.1 as new docker version in E2E test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
