### PR TITLE
Update lodash to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   },
   "devDependencies": {
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/kbn-eslint-import-resolver-kibana",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.0.4",
+    "@testing-library/user-event": "^12.1.6",
     "@types/react-plotly.js": "^2.2.4",
     "@types/redux-mock-store": "^1.0.1",
     "babel-polyfill": "^6.26.0",
@@ -36,16 +39,12 @@
     "lint-staged": "^9.2.0",
     "moment": "^2.24.0",
     "redux-mock-store": "^1.5.3",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.0.4",
-    "@testing-library/user-event": "^12.1.6",
     "start-server-and-test": "^1.11.7"
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "brace": "0.11.1",
     "formik": "^2.2.5",
-    "lodash": "^4.17.20",
     "plotly.js-dist": "^1.57.1",
     "react-plotly.js": "^2.4.0",
     "react-redux": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,10 +2846,10 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update to use lodash 4.17.21 to patch a security vulnerability. Removed explicit dependency of lodash in `package.json` since it is declared & maintained in the parent `kibana` repository.

Confirmed basic UI workflow works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
