### PR TITLE
Add configure model page

### DIFF
--- a/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiText,
+  EuiLink,
+  EuiIcon,
+  EuiFormRow,
+  EuiTitle,
+  EuiFieldNumber,
+} from '@elastic/eui';
+import { Field, FieldProps } from 'formik';
+import React, { useState } from 'react';
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+import {
+  isInvalid,
+  getError,
+  validatePositiveInteger,
+} from '../../../../utils/utils';
+
+interface AdvancedSettingsProps {}
+
+export function AdvancedSettings(props: AdvancedSettingsProps) {
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(
+    false
+  );
+
+  return (
+    <ContentPanel
+      title={
+        <EuiTitle size="s">
+          <h2>Advanced settings </h2>
+        </EuiTitle>
+      }
+      subTitle={
+        <EuiText
+          className="content-panel-subTitle"
+          onClick={() => {
+            setShowAdvancedSettings(!showAdvancedSettings);
+          }}
+        >
+          <EuiLink>{showAdvancedSettings ? 'Hide' : 'Show'}</EuiLink>
+        </EuiText>
+      }
+    >
+      {showAdvancedSettings ? (
+        <Field name="shingleSize" validate={validatePositiveInteger}>
+          {({ field, form }: FieldProps) => (
+            <EuiFormRow
+              label="Window size"
+              helpText={
+                <EuiText className="content-panel-subTitle">
+                  Set the number of intervals to consider in a detection window.
+                  We recommend you choose this value based on your actual data.
+                  If you expect missing values in your data or if you want the
+                  anomalies based on the current interval, choose 1. If your
+                  data is continuously ingested and you want the anomalies based
+                  on multiple intervals, choose a larger window size.{' '}
+                  <EuiLink
+                    href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                    target="_blank"
+                  >
+                    Learn more <EuiIcon size="s" type="popout" />
+                  </EuiLink>
+                </EuiText>
+              }
+              isInvalid={isInvalid(field.name, form)}
+              error={getError(field.name, form)}
+            >
+              <EuiFlexGroup gutterSize="s" alignItems="center">
+                <EuiFlexItem grow={false}>
+                  <EuiFieldNumber
+                    id="shingleSize"
+                    placeholder="Window size"
+                    data-test-subj="shingleSize"
+                    {...field}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiText>
+                    <p className="minutes">intervals</p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFormRow>
+          )}
+        </Field>
+      ) : null}
+    </ContentPanel>
+  );
+}

--- a/public/pages/ConfigureModel/components/AdvancedSettings/index.ts
+++ b/public/pages/ConfigureModel/components/AdvancedSettings/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { AdvancedSettings } from './AdvancedSettings';

--- a/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
+++ b/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+import { useSelector } from 'react-redux';
+import { get } from 'lodash';
+import { EuiFormRow, EuiSelect, EuiComboBox } from '@elastic/eui';
+import { getAllFields } from '../../../../redux/selectors/elasticsearch';
+import {
+  getNumberFieldOptions,
+  getCountableFieldOptions,
+} from '../../utils/helpers';
+import { Field, FieldProps } from 'formik';
+import { AGGREGATION_TYPES } from '../../utils/constants';
+import {
+  requiredSelectField,
+  requiredNonEmptyFieldSelected,
+  isInvalid,
+  getError,
+} from '../../../../utils/utils';
+
+interface AggregationSelectorProps {
+  index?: number;
+}
+export const AggregationSelector = (props: AggregationSelectorProps) => {
+  const numberFields = getNumberFieldOptions(useSelector(getAllFields));
+  const countableFields = getCountableFieldOptions(useSelector(getAllFields));
+  return (
+    <Fragment>
+      <Field
+        id={`featureList.${props.index}.aggregationBy`}
+        name={`featureList.${props.index}.aggregationBy`}
+        validate={requiredSelectField}
+      >
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            label="Aggregation method"
+            helpText="The aggregation method determines what constitutes an anomaly. For example, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature."
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiSelect
+              id={`featureList.${props.index}.aggregationBy`}
+              {...field}
+              name={`featureList.${props.index}.aggregationBy`}
+              options={AGGREGATION_TYPES}
+              onChange={(e) => {
+                const currentValue = field.value;
+                const aggregationOf = get(
+                  form,
+                  `values.featureList.${props.index}.aggregationOf.0.type`
+                );
+                if (
+                  currentValue === 'value_count' &&
+                  aggregationOf !== 'number'
+                ) {
+                  form.setFieldValue(
+                    `featureList.${props.index}.aggregationOf`,
+                    undefined
+                  );
+                }
+                field.onChange(e);
+              }}
+              data-test-subj="aggregationType"
+            />
+          </EuiFormRow>
+        )}
+      </Field>
+
+      <Field
+        id={`featureList.${props.index}.aggregationOf`}
+        name={`featureList.${props.index}.aggregationOf`}
+        validate={requiredNonEmptyFieldSelected}
+      >
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            label="Field"
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiComboBox
+              placeholder="Select field"
+              singleSelection={{ asPlainText: true }}
+              selectedOptions={field.value}
+              onCreateOption={(createdOption: string) => {
+                const normalizedOptions = createdOption.trim();
+                if (!normalizedOptions) return;
+                const customOption = [{ label: normalizedOptions }];
+                form.setFieldValue(
+                  `featureList.${props.index}.aggregationOf`,
+                  customOption
+                );
+              }}
+              //@ts-ignore
+              options={
+                get(form, `values.featureList.${props.index}.aggregationBy`) ===
+                'value_count'
+                  ? countableFields
+                  : numberFields
+              }
+              {...field}
+              onClick={() => {
+                form.setFieldTouched(
+                  `featureList.${props.index}.aggregationOf`,
+                  true
+                );
+              }}
+              onChange={(options: any) => {
+                form.setFieldValue(
+                  `featureList.${props.index}.aggregationOf`,
+                  options
+                );
+              }}
+            />
+          </EuiFormRow>
+        )}
+      </Field>
+    </Fragment>
+  );
+};

--- a/public/pages/ConfigureModel/components/AggregationSelector/__tests__/AggregationSelector.test.tsx
+++ b/public/pages/ConfigureModel/components/AggregationSelector/__tests__/AggregationSelector.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { Formik } from 'formik';
+import { AggregationSelector } from '../AggregationSelector';
+import {
+  initialState,
+  mockedStore,
+} from '../../../../../redux/utils/testUtils';
+import { FeaturesFormikValues } from '../../../models/interfaces';
+import { INITIAL_FEATURE_VALUES } from '../../../utils/constants';
+
+const renderAggregationSelector = (initialValue: FeaturesFormikValues) => ({
+  ...render(
+    <Provider
+      store={mockedStore({
+        ...initialState,
+        elasticsearch: {
+          ...initialState.elasticsearch,
+          dataTypes: {
+            keyword: ['cityName.keyword'],
+            integer: ['age'],
+            text: ['cityName'],
+          },
+        },
+      })}
+    >
+      <Formik initialValues={initialValue} onSubmit={jest.fn()}>
+        {(formikProps) => (
+          <div>
+            <AggregationSelector />
+          </div>
+        )}
+      </Formik>
+    </Provider>
+  ),
+});
+
+describe('<AggregationSelector /> spec', () => {
+  describe('Empty results', () => {
+    test('renders component with aggregation types and defaults to empty', () => {
+      const { container } = renderAggregationSelector(INITIAL_FEATURE_VALUES);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/public/pages/ConfigureModel/components/AggregationSelector/__tests__/__snapshots__/AggregationSelector.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/AggregationSelector/__tests__/__snapshots__/AggregationSelector.test.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AggregationSelector /> spec Empty results renders component with aggregation types and defaults to empty 1`] = `
+<div>
+  <div
+    class="euiFormRow"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Aggregation method
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <select
+            aria-describedby="random_html_id-help"
+            class="euiSelect"
+            data-test-subj="aggregationType"
+            id="random_html_id"
+            name="featureList.undefined.aggregationBy"
+          >
+            <option
+              value="avg"
+            >
+              average()
+            </option>
+            <option
+              value="value_count"
+            >
+              count()
+            </option>
+            <option
+              value="sum"
+            >
+              sum()
+            </option>
+            <option
+              value="min"
+            >
+              min()
+            </option>
+            <option
+              value="max"
+            >
+              max()
+            </option>
+          </select>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFormHelpText euiFormRow__text"
+        id="random_html_id-help"
+      >
+        The aggregation method determines what constitutes an anomaly. For example, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Field
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="euiComboBox"
+        name="featureList.undefined.aggregationOf"
+        role="combobox"
+      >
+        <div
+          class="euiFormControlLayout"
+        >
+          <div
+            class="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+              data-test-subj="comboBoxInput"
+              tabindex="-1"
+            >
+              <p
+                class="euiComboBoxPlaceholder"
+              >
+                Select field
+              </p>
+              <div
+                class="euiComboBox__input"
+                style="font-size: 14px; display: inline-block;"
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="random_html_id"
+                  role="textbox"
+                  style="box-sizing: content-box; width: 2px;"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
+            </div>
+            <div
+              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/ConfigureModel/components/AggregationSelector/index.ts
+++ b/public/pages/ConfigureModel/components/AggregationSelector/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { AggregationSelector } from './AggregationSelector';

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiText,
+  EuiLink,
+  EuiIcon,
+  EuiFormRow,
+  EuiComboBox,
+  EuiCheckbox,
+  EuiTitle,
+  EuiCallOut,
+  EuiSpacer,
+} from '@elastic/eui';
+import { Field, FieldProps, FormikProps } from 'formik';
+import { get, isEmpty } from 'lodash';
+import { MULTI_ENTITY_SHINGLE_SIZE } from '../../../../utils/constants';
+import React, { useState, useEffect } from 'react';
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+import {
+  isInvalid,
+  getError,
+  validateCategoryField,
+} from '../../../../utils/utils';
+import { ModelConfigurationFormikValues } from '../../models/interfaces';
+
+interface CategoryFieldProps {
+  isEdit: boolean;
+  isHCDetector: boolean;
+  categoryFieldOptions: string[];
+  setIsHCDetector(isHCDetector: boolean): void;
+  isLoading: boolean;
+  originalShingleSize: number;
+  formikProps: FormikProps<ModelConfigurationFormikValues>;
+}
+
+export function CategoryField(props: CategoryFieldProps) {
+  const [enabled, setEnabled] = useState<boolean>(
+    get(props, 'formikProps.values.categoryFieldEnabled', false)
+  );
+  const noCategoryFields = isEmpty(props.categoryFieldOptions);
+  const convertedOptions = props.categoryFieldOptions.map((option: string) => {
+    return {
+      label: option,
+    };
+  });
+
+  useEffect(() => {
+    // only update this if we're editing and the detector has finally come
+    if (props.isEdit) {
+      setEnabled(props.isHCDetector);
+    }
+  }, [props.isHCDetector]);
+
+  return (
+    <ContentPanel
+      title={
+        <EuiTitle size="s" id={'categoryFieldTitle'}>
+          <h2>Categorical field </h2>
+        </EuiTitle>
+      }
+      subTitle={
+        <EuiText className="content-panel-subTitle">
+          Categorize anomalies based on unique partitions. For example, with
+          clickstream data you can categorize anomalies into a given day, week,
+          or month.{' '}
+          <EuiLink
+            href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+            target="_blank"
+          >
+            Learn more <EuiIcon size="s" type="popout" />
+          </EuiLink>
+        </EuiText>
+      }
+    >
+      {noCategoryFields && !props.isLoading ? (
+        <EuiCallOut
+          data-test-subj="noCategoryFieldsCallout"
+          title="There are no available category fields for the selected index"
+          color="warning"
+          iconType="alert"
+        ></EuiCallOut>
+      ) : null}
+      {noCategoryFields ? <EuiSpacer size="m" /> : null}
+      <Field
+        name="categoryField"
+        validate={enabled ? validateCategoryField : null}
+      >
+        {({ field, form }: FieldProps) => (
+          <EuiFlexGroup direction="column">
+            <EuiFlexItem>
+              <EuiCheckbox
+                id={'categoryFieldCheckbox'}
+                label="Enable categorical field"
+                checked={enabled}
+                disabled={noCategoryFields}
+                onChange={() => {
+                  if (!enabled) {
+                    props.setIsHCDetector(true);
+                  }
+                  if (enabled) {
+                    props.setIsHCDetector(false);
+                    form.setFieldValue('categoryField', []);
+                    form.setFieldValue(
+                      'shingleSize',
+                      props.originalShingleSize
+                    );
+                  }
+                  setEnabled(!enabled);
+                }}
+              />
+            </EuiFlexItem>
+            {enabled && !noCategoryFields ? (
+              <EuiFlexItem>
+                <EuiFormRow
+                  label="Field"
+                  isInvalid={isInvalid(field.name, form)}
+                  error={getError(field.name, form)}
+                  helpText={`You can only apply the category field to the 'ip' and 'keyword' Elasticsearch data types.`}
+                >
+                  <EuiComboBox
+                    data-test-subj="categoryFieldComboBox"
+                    id="categoryField"
+                    placeholder="Select your category field"
+                    options={convertedOptions}
+                    onBlur={() => {
+                      form.setFieldTouched('categoryField', true);
+                    }}
+                    onChange={(options) => {
+                      const selection = get(options, '0.label');
+                      if (selection) {
+                        form.setFieldValue('categoryField', [selection]);
+                        form.setFieldValue(
+                          'shingleSize',
+                          MULTI_ENTITY_SHINGLE_SIZE
+                        );
+                      } else {
+                        form.setFieldValue('categoryField', []);
+
+                        form.setFieldValue(
+                          'shingleSize',
+                          props.originalShingleSize
+                        );
+                      }
+                    }}
+                    selectedOptions={
+                      (field.value[0] && [{ label: field.value[0] }]) || []
+                    }
+                    singleSelection={{ asPlainText: true }}
+                    isClearable={true}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
+        )}
+      </Field>
+    </ContentPanel>
+  );
+}

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Fragment } from 'react';
+import { render } from '@testing-library/react';
+import { Form, Formik } from 'formik';
+import { CategoryField } from '../CategoryField';
+
+describe('<CategoryField /> spec', () => {
+  test('renders the component when disabled', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={false}
+                categoryFieldOptions={['option 1', 'option 2']}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                originalShingleSize={1}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('renders the component when enabled', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={['option 1', 'option 2']}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                originalShingleSize={1}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).not.toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('shows callout when there are no available category fields', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                originalShingleSize={1}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).not.toBeNull();
+    expect(queryByTestId('categoryFieldComboBox')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+  test('hides callout if component is loading', () => {
+    const { container, queryByText, queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={true}
+                originalShingleSize={1}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(container).toMatchSnapshot();
+    expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
+    expect(queryByText('Enable category field')).not.toBeNull();
+  });
+});

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -1,0 +1,623 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CategoryField /> spec hides callout if component is loading 1`] = `
+<div>
+  <form
+    action="#"
+  >
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    disabled=""
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CategoryField /> spec renders the component when disabled 1`] = `
+<div>
+  <form
+    action="#"
+  >
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoading"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    class="euiCheckbox__input"
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CategoryField /> spec renders the component when enabled 1`] = `
+<div>
+  <form
+    action="#"
+  >
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiFormRow"
+                  id="random_html_id-row"
+                >
+                  <div
+                    class="euiFormRow__labelWrapper"
+                  >
+                    <label
+                      aria-invalid="false"
+                      class="euiFormLabel euiFormRow__label"
+                      for="random_html_id"
+                    >
+                      Field
+                    </label>
+                  </div>
+                  <div
+                    class="euiFormRow__fieldWrapper"
+                  >
+                    <div
+                      aria-describedby="random_html_id-help"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      class="euiComboBox"
+                      data-test-subj="categoryFieldComboBox"
+                      role="combobox"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <div
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                            data-test-subj="comboBoxInput"
+                            tabindex="-1"
+                          >
+                            <p
+                              class="euiComboBoxPlaceholder"
+                            >
+                              Select your category field
+                            </p>
+                            <div
+                              class="euiComboBox__input"
+                              style="font-size: 14px; display: inline-block;"
+                            >
+                              <input
+                                aria-controls=""
+                                data-test-subj="comboBoxSearchInput"
+                                id="random_html_id"
+                                role="textbox"
+                                style="box-sizing: content-box; width: 2px;"
+                                value=""
+                              />
+                              <div
+                                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <button
+                              aria-label="Open list of options"
+                              class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                              data-test-subj="comboBoxToggleListButton"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormHelpText euiFormRow__text"
+                      id="random_html_id-help"
+                    >
+                      You can only apply the category field to the 'ip' and 'keyword' Elasticsearch data types.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`<CategoryField /> spec shows callout when there are no available category fields 1`] = `
+<div>
+  <form
+    action="#"
+  >
+    <div
+      class="euiPage"
+    >
+      <main
+        class="euiPageBody"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium"
+          style="padding: 20px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style="padding: 0px;"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <h2
+                    class="euiTitle euiTitle--small"
+                  >
+                    Category field 
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium content-panel-subTitle"
+                  >
+                    Categorize anomalies based on unique partitions. For example, with clickstream data you can categorize anomalies into a given day, week, or month.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more 
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem"
+                />
+              </div>
+            </div>
+          </div>
+          <hr
+            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+          <div
+            style="padding: 10px 0px;"
+          >
+            <div
+              class="euiCallOut euiCallOut--warning"
+              data-test-subj="noCategoryFieldsCallout"
+            >
+              <div
+                class="euiCallOutHeader"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+                <span
+                  class="euiCallOutHeader__title"
+                >
+                  There are no available category fields for the selected index
+                </span>
+              </div>
+            </div>
+            <div
+              class="euiSpacer euiSpacer--m"
+            />
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiCheckbox"
+                >
+                  <input
+                    checked=""
+                    class="euiCheckbox__input"
+                    disabled=""
+                    id="categoryFieldCheckbox"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="categoryFieldCheckbox"
+                  >
+                    Enable category field
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </form>
+</div>
+`;

--- a/public/pages/ConfigureModel/components/CategoryField/index.ts
+++ b/public/pages/ConfigureModel/components/CategoryField/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { CategoryField } from './CategoryField';

--- a/public/pages/ConfigureModel/components/CustomAggregation/CustomAggregation.tsx
+++ b/public/pages/ConfigureModel/components/CustomAggregation/CustomAggregation.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
+import { Field, FieldProps } from 'formik';
+import { isInvalid, getError } from '../../../../utils/utils';
+
+interface CustomAggregationProps {
+  index: number;
+}
+
+export const validateQuery = (value: string) => {
+  try {
+    JSON.parse(value);
+  } catch (err) {
+    console.log('Returning error', err);
+    return 'Invalid JSON';
+  }
+};
+
+export const CustomAggregation = (props: CustomAggregationProps) => {
+  return (
+    <Field
+      id={`featureList.${props.index}.aggregationQuery`}
+      name={`featureList.${props.index}.aggregationQuery`}
+      validate={validateQuery}
+    >
+      {({ field, form }: FieldProps) => (
+        <EuiFormRow
+          fullWidth
+          label="Expression"
+          helpText="Custom expression uses the Elasticsearch query DSL."
+          isInvalid={isInvalid(field.name, form)}
+          error={getError(field.name, form)}
+          onClick={() => {
+            form.setFieldTouched(
+              `featureList.${props.index}.aggregationQuery`,
+              true
+            );
+          }}
+        >
+          <EuiCodeEditor
+            name={`featureList.${props.index}.aggregationQuery`}
+            mode="object"
+            height="300px"
+            width="100%"
+            setOptions={{
+              showLineNumbers: false,
+              showGutter: false,
+              className: 'custom-query-editor',
+              showPrintMargin: false,
+            }}
+            onChange={(query: string) => {
+              form.setFieldValue(
+                `featureList.${props.index}.aggregationQuery`,
+                query
+              );
+            }}
+            onBlur={field.onBlur}
+            value={field.value}
+          />
+        </EuiFormRow>
+      )}
+    </Field>
+  );
+};

--- a/public/pages/ConfigureModel/components/CustomAggregation/__tests__/CustomAggregation.test.tsx
+++ b/public/pages/ConfigureModel/components/CustomAggregation/__tests__/CustomAggregation.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CustomAggregation, validateQuery } from '../CustomAggregation';
+import { Provider } from 'react-redux';
+import { mockedStore } from '../../../../../redux/utils/testUtils';
+import { Formik } from 'formik';
+import { FeaturesFormikValues } from '../../../models/interfaces';
+import { INITIAL_FEATURE_VALUES } from '../../../utils/constants';
+import { CoreServicesContext } from '../../../../../components/CoreServices/CoreServices';
+import { coreServicesMock } from '../../../../../../test/mocks';
+
+const renderWithFormik = (initialValue: FeaturesFormikValues) => ({
+  ...render(
+    <Provider store={mockedStore()}>
+      <CoreServicesContext.Provider value={coreServicesMock}>
+        <Formik initialValues={initialValue} onSubmit={jest.fn()}>
+          {(formikProps) => (
+            <div>
+              <CustomAggregation index={1} />
+            </div>
+          )}
+        </Formik>
+      </CoreServicesContext.Provider>
+    </Provider>
+  ),
+});
+
+describe('<CustomAggregation /> spec', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  test('renders the component', () => {
+    const { container } = renderWithFormik(INITIAL_FEATURE_VALUES);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+  describe('validateQuery', () => {
+    test('should return undefined if valid query', () => {
+      expect(validateQuery('{}')).toBeUndefined();
+      expect(validateQuery('{"a":{"b":{}}}')).toBeUndefined();
+    });
+    test('should return error message if invalid query', () => {
+      console.log = jest.fn();
+      expect(validateQuery('hello')).toEqual('Invalid JSON');
+      expect(validateQuery('{a : b: {}')).toEqual('Invalid JSON');
+    });
+  });
+});

--- a/public/pages/ConfigureModel/components/CustomAggregation/__tests__/__snapshots__/CustomAggregation.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CustomAggregation/__tests__/__snapshots__/CustomAggregation.test.tsx.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CustomAggregation /> spec renders the component 1`] = `
+<div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Expression
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiCodeEditorWrapper"
+        data-test-subj="codeEditorContainer"
+        style="width: 100%; height: 300px;"
+      >
+        <div
+          class="euiCodeEditorKeyboardHint"
+          data-test-subj="codeEditorHint"
+          id="random_html_id"
+          role="button"
+          tabindex="0"
+        >
+          <p
+            class="euiText"
+          >
+            Press Enter to start editing.
+          </p>
+          <p
+            class="euiText"
+          >
+            When you're done, press Escape to stop editing.
+          </p>
+        </div>
+        <div
+          class=" ace_editor ace-tm"
+          id="featureList.1.aggregationQuery"
+          style="width: 100%; height: 300px;"
+        >
+          <textarea
+            aria-describedby="random_html_id-help"
+            autocapitalize="off"
+            autocorrect="off"
+            class="ace_text-input"
+            spellcheck="false"
+            style="opacity: 0;"
+            tabindex="-1"
+            wrap="off"
+          />
+          <div
+            aria-hidden="true"
+            class="ace_gutter"
+            style="display: none;"
+          >
+            <div
+              class="ace_layer ace_gutter-layer ace_folding-enabled"
+            />
+            <div
+              class="ace_gutter-active-line"
+            />
+          </div>
+          <div
+            class="ace_scroller"
+          >
+            <div
+              class="ace_content"
+            >
+              <div
+                class="ace_layer ace_print-margin-layer"
+              >
+                <div
+                  class="ace_print-margin"
+                  style="left: 4px; visibility: hidden;"
+                />
+              </div>
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_text-layer"
+                style="padding: 0px 4px;"
+              />
+              <div
+                class="ace_layer ace_marker-layer"
+              />
+              <div
+                class="ace_layer ace_cursor-layer ace_hidden-cursors"
+              >
+                <div
+                  class="ace_cursor"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-v"
+            style="display: none; width: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="width: 20px;"
+            />
+          </div>
+          <div
+            class="ace_scrollbar ace_scrollbar-h"
+            style="display: none; height: 20px;"
+          >
+            <div
+              class="ace_scrollbar-inner"
+              style="height: 20px;"
+            />
+          </div>
+          <div
+            style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: hidden;"
+          >
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            />
+            <div
+              style="height: auto; width: auto; top: 0px; left: 0px; visibility: hidden; position: absolute; white-space: pre; overflow: visible;"
+            >
+              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFormHelpText euiFormRow__text"
+        id="random_html_id-help"
+      >
+        Custom expression uses the Elasticsearch query DSL.
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/public/pages/ConfigureModel/components/CustomAggregation/index.ts
+++ b/public/pages/ConfigureModel/components/CustomAggregation/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { CustomAggregation } from './CustomAggregation';

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -1,0 +1,215 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Fragment, useState } from 'react';
+import {
+  EuiFormRow,
+  EuiSelect,
+  EuiAccordion,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiButton,
+  EuiFieldText,
+  EuiCheckbox,
+} from '@elastic/eui';
+import { Field, FieldProps } from 'formik';
+import {
+  required,
+  isInvalid,
+  getError,
+  validateFeatureName,
+} from '../../../../utils/utils';
+import { get } from 'lodash';
+import { FEATURE_TYPE_OPTIONS } from '../../utils/constants';
+import { FEATURE_TYPE } from '../../../../models/interfaces';
+import { formikToSimpleAggregation } from '../../utils/helpers';
+import { AggregationSelector } from '../AggregationSelector';
+import { CustomAggregation } from '../CustomAggregation';
+
+interface FeatureAccordionProps {
+  onDelete(): void;
+  index: number;
+  feature: any;
+  handleChange(event: React.ChangeEvent<HTMLSelectElement>): void;
+}
+
+export const FeatureAccordion = (props: FeatureAccordionProps) => {
+  const initialIsOpen = get(props.feature, 'newFeature', false);
+  const [showSubtitle, setShowSubtitle] = useState<boolean>(!initialIsOpen);
+
+  const simpleAggDescription = (feature: any) => (
+    <Fragment>
+      <span className="content-panel-subTitle" style={{ paddingRight: '20px' }}>
+        Field: {get(feature, 'aggregationOf.0.label')}
+      </span>
+      <span className="content-panel-subTitle" style={{ paddingRight: '20px' }}>
+        Aggregation method: {feature.aggregationBy}
+      </span>
+      <span className="content-panel-subTitle">
+        State: {feature.featureEnabled ? 'Enabled' : 'Disabled'}
+      </span>
+    </Fragment>
+  );
+
+  const customAggDescription = (feature: any) => (
+    <Fragment>
+      <span className="content-panel-subTitle" style={{ paddingRight: '20px' }}>
+        Custom expression
+      </span>
+      <span className="content-panel-subTitle">
+        State: {feature.featureEnabled ? 'Enabled' : 'Disabled'}
+      </span>
+    </Fragment>
+  );
+
+  const showFeatureDescription = (feature: any) => {
+    return feature && feature.featureType === FEATURE_TYPE.SIMPLE
+      ? simpleAggDescription(feature)
+      : customAggDescription(feature);
+  };
+
+  const featureButtonContent = (feature: any, index: number) => {
+    return (
+      <div id={`featureAccordionHeaders.${index}`}>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexItem>
+            <EuiTitle size="xs" className="euiAccordionForm__title">
+              <h5>
+                {feature.featureName ? feature.featureName : 'Add feature'}
+              </h5>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {showSubtitle ? showFeatureDescription(feature) : null}
+      </div>
+    );
+  };
+
+  const deleteAction = (onClick: any) => (
+    <EuiButton size="s" color="danger" onClick={onClick} disabled={false}>
+      Delete
+    </EuiButton>
+  );
+
+  return (
+    <EuiAccordion
+      id={`featureList.${props.index}`}
+      key={props.index}
+      buttonContent={featureButtonContent(props.feature, props.index)}
+      //@ts-ignore
+      buttonClassName={
+        props.index === 0
+          ? 'euiAccordionForm__noTopPaddingButton'
+          : 'euiAccordionForm__button'
+      }
+      className="euiAccordion__noTopBorder"
+      paddingSize="l"
+      initialIsOpen={initialIsOpen}
+      extraAction={deleteAction(props.onDelete)}
+      onToggle={(isOpen: boolean) => {
+        isOpen ? setShowSubtitle(false) : setShowSubtitle(true);
+      }}
+    >
+      <Field
+        id={`featureList.${props.index}.featureName`}
+        name={`featureList.${props.index}.featureName`}
+        validate={validateFeatureName}
+      >
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            label="Feature name"
+            helpText="Enter a descriptive name. The name must be unique within this detector. Feature name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore)."
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiFieldText
+              name={`featureList.${props.index}.featureName`}
+              placeholder="Enter feature name"
+              value={field.value ? field.value : props.feature.featureName}
+              {...field}
+            />
+          </EuiFormRow>
+        )}
+      </Field>
+
+      <Field
+        id={`featureList.${props.index}.featureEnabled`}
+        name={`featureList.${props.index}.featureEnabled`}
+      >
+        {({ field, form }: FieldProps) => (
+          <EuiFormRow
+            label="Feature state"
+            isInvalid={isInvalid(field.name, form)}
+            error={getError(field.name, form)}
+          >
+            <EuiCheckbox
+              id={`featureList.${props.index}.featureEnabled`}
+              label="Enable feature"
+              checked={field.value ? field.value : props.feature.featureEnabled}
+              {...field}
+            />
+          </EuiFormRow>
+        )}
+      </Field>
+
+      <Field
+        id={`featureList.${props.index}.featureType`}
+        name={`featureList.${props.index}.featureType`}
+        validate={required}
+      >
+        {({ field, form }: FieldProps) => (
+          <Fragment>
+            <EuiFormRow
+              label="Find anomalies based on"
+              isInvalid={isInvalid(field.name, form)}
+              error={getError(field.name, form)}
+            >
+              <EuiSelect
+                {...field}
+                options={FEATURE_TYPE_OPTIONS}
+                value={
+                  props.feature.featureType === FEATURE_TYPE.SIMPLE
+                    ? FEATURE_TYPE.SIMPLE
+                    : FEATURE_TYPE.CUSTOM
+                }
+                onChange={(e) => {
+                  props.handleChange(e);
+                  if (
+                    e.currentTarget.value === FEATURE_TYPE.CUSTOM &&
+                    !get(form.errors, `featureList.${props.index}`)
+                  ) {
+                    const aggregationQuery = formikToSimpleAggregation(
+                      props.feature
+                    );
+                    form.setFieldValue(
+                      `featureList.${props.index}.aggregationQuery`,
+                      JSON.stringify(aggregationQuery, null, 4)
+                    );
+                  }
+                }}
+              />
+            </EuiFormRow>
+            {field.value === FEATURE_TYPE.SIMPLE ? (
+              <AggregationSelector index={props.index} />
+            ) : (
+              <CustomAggregation index={props.index} />
+            )}
+          </Fragment>
+        )}
+      </Field>
+    </EuiAccordion>
+  );
+};

--- a/public/pages/ConfigureModel/components/FeatureAccordion/index.ts
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { FeatureAccordion } from './FeatureAccordion';

--- a/public/pages/ConfigureModel/components/Features/Features.tsx
+++ b/public/pages/ConfigureModel/components/Features/Features.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiCallOut,
+  EuiSpacer,
+  EuiText,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiButton,
+  EuiLink,
+  EuiIcon,
+} from '@elastic/eui';
+import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
+
+import { get } from 'lodash';
+import React, { Fragment, useEffect } from 'react';
+import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
+import { Detector } from '../../../../models/interfaces';
+import { initialFeatureValue } from '../../utils/helpers';
+import { MAX_FEATURE_NUM } from '../../../../utils/constants';
+import { FeatureAccordion } from '../FeatureAccordion';
+
+interface FeaturesProps {
+  detector: Detector | undefined;
+  formikProps: FormikProps<any>;
+}
+
+export function Features(props: FeaturesProps) {
+  // If the features list is empty: push a default initial one
+  useEffect(() => {
+    if (get(props, 'formikProps.values.featureList', []).length === 0) {
+      props.formikProps.setFieldValue('featureList', [initialFeatureValue()]);
+      props.formikProps.setFieldTouched('featureList', false);
+    }
+  }, [props.formikProps.values.featureList]);
+
+  return (
+    <ContentPanel
+      title="Features"
+      titleSize="s"
+      subTitle={
+        <EuiText className="content-panel-subTitle">
+          Specify an index field that you want to find anomalies for by defining
+          features. You can add up to 5 features.{' '}
+          <EuiLink
+            href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+            target="_blank"
+          >
+            Learn more <EuiIcon size="s" type="popout" />
+          </EuiLink>
+        </EuiText>
+      }
+    >
+      <EuiFlexGroup direction="column" style={{ margin: '0px' }}>
+        <FieldArray name="featureList" validateOnChange={true}>
+          {({ push, remove, form: { values } }: FieldArrayRenderProps) => {
+            return (
+              <Fragment>
+                {get(props.detector, 'indices.0', '').includes(':') ? (
+                  <div>
+                    <EuiCallOut
+                      title="This detector is using a remote cluster index, so you need to manually input the field."
+                      color="warning"
+                      iconType="alert"
+                    />
+                    <EuiSpacer size="m" />
+                  </div>
+                ) : null}
+                {values.featureList.map((feature: any, index: number) => (
+                  <FeatureAccordion
+                    onDelete={() => {
+                      remove(index);
+                    }}
+                    index={index}
+                    feature={feature}
+                    handleChange={props.formikProps.handleChange}
+                  />
+                ))}
+                <EuiFlexGroup
+                  alignItems="center"
+                  style={{ padding: '12px 0px' }}
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      data-test-subj="addFeature"
+                      isDisabled={values.featureList.length >= MAX_FEATURE_NUM}
+                      onClick={() => {
+                        push(initialFeatureValue());
+                      }}
+                    >
+                      Add another feature
+                    </EuiButton>
+                    <EuiText className="content-panel-subTitle">
+                      <p>
+                        You can add up to{' '}
+                        {Math.max(
+                          MAX_FEATURE_NUM - values.featureList.length,
+                          0
+                        )}{' '}
+                        more features.
+                      </p>
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </Fragment>
+            );
+          }}
+        </FieldArray>
+      </EuiFlexGroup>
+    </ContentPanel>
+  );
+}

--- a/public/pages/ConfigureModel/components/Features/index.ts
+++ b/public/pages/ConfigureModel/components/Features/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export { Features } from './Features';

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -1,0 +1,352 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiPageBody,
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiPage,
+  EuiButton,
+  EuiTitle,
+  EuiButtonEmpty,
+  EuiSpacer,
+} from '@elastic/eui';
+import { FormikProps, Formik } from 'formik';
+import { get, isEmpty } from 'lodash';
+import React, { Fragment, useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
+import { AppState } from '../../../redux/reducers';
+import { getMappings } from '../../../redux/reducers/elasticsearch';
+import { useFetchDetectorInfo } from '../../CreateDetectorSteps/hooks/useFetchDetectorInfo';
+import { BREADCRUMBS } from '../../../utils/constants';
+import { useHideSideNavBar } from '../../main/hooks/useHideSideNavBar';
+import { updateDetector } from '../../../redux/reducers/ad';
+import {
+  validateFeatures,
+  focusOnFirstWrongFeature,
+  getCategoryFields,
+  focusOnCategoryField,
+  getShingleSizeFromObject,
+  modelConfigurationToFormik,
+} from '../utils/helpers';
+import { formikToDetector } from '../../ReviewAndCreate/utils/helpers';
+import { formikToModelConfiguration } from '../utils/helpers';
+import { Features } from '../components/Features';
+import { CategoryField } from '../components/CategoryField';
+import { AdvancedSettings } from '../components/AdvancedSettings';
+import { SampleAnomalies } from './SampleAnomalies';
+import { CoreStart } from '../../../../../../src/core/public';
+import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+import { Detector } from '../../../models/interfaces';
+import { prettifyErrorMessage } from '../../../../server/utils/helpers';
+import { DetectorDefinitionFormikValues } from '../../DefineDetector/models/interfaces';
+import { ModelConfigurationFormikValues } from '../models/interfaces';
+import { CreateDetectorFormikValues } from '../../CreateDetectorSteps/models/interfaces';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+import { getErrorMessage } from '../../../utils/utils';
+
+interface ConfigureModelRouterProps {
+  detectorId?: string;
+}
+
+interface ConfigureModelProps
+  extends RouteComponentProps<ConfigureModelRouterProps> {
+  isEdit: boolean;
+  setStep?(stepNumber: number): void;
+  initialValues?: ModelConfigurationFormikValues;
+  setInitialValues?(initialValues: ModelConfigurationFormikValues): void;
+  detectorDefinitionValues?: DetectorDefinitionFormikValues;
+}
+
+export function ConfigureModel(props: ConfigureModelProps) {
+  const core = React.useContext(CoreServicesContext) as CoreStart;
+  const dispatch = useDispatch();
+  useHideSideNavBar(true, false);
+  const detectorId = get(props, 'match.params.detectorId', '');
+  const { detector, hasError } = useFetchDetectorInfo(detectorId);
+  const indexDataTypes = useSelector(
+    (state: AppState) => state.elasticsearch.dataTypes
+  );
+  const [isHCDetector, setIsHCDetector] = useState<boolean>(
+    props.initialValues ? props.initialValues.categoryFieldEnabled : false
+  );
+  const isLoading = useSelector(
+    (state: AppState) => state.elasticsearch.requesting
+  );
+  const originalShingleSize = getShingleSizeFromObject(detector, isHCDetector);
+
+  // Jump to top of page on first load
+  useEffect(() => {
+    scroll(0, 0);
+  }, []);
+
+  // When detector is loaded: get any category fields (if applicable) and
+  // get all index mappings based on detector's selected index
+  useEffect(() => {
+    if (detector && get(detector, 'categoryField', []).length > 0) {
+      setIsHCDetector(true);
+    }
+    if (detector?.indices) {
+      dispatch(getMappings(detector.indices[0]));
+    }
+  }, [detector]);
+
+  useEffect(() => {
+    if (props.isEdit) {
+      core.chrome.setBreadcrumbs([
+        BREADCRUMBS.ANOMALY_DETECTOR,
+        BREADCRUMBS.DETECTORS,
+        {
+          text: detector && detector.name ? detector.name : '',
+          href: `#/detectors/${detectorId}`,
+        },
+        BREADCRUMBS.EDIT_MODEL_CONFIGURATION,
+      ]);
+    } else {
+      core.chrome.setBreadcrumbs([
+        BREADCRUMBS.ANOMALY_DETECTOR,
+        BREADCRUMBS.DETECTORS,
+        BREADCRUMBS.CREATE_DETECTOR,
+      ]);
+    }
+  }, [detector]);
+
+  useEffect(() => {
+    if (hasError) {
+      props.history.push('/detectors');
+    }
+  }, [hasError]);
+
+  const handleFormValidation = async (
+    formikProps: FormikProps<ModelConfigurationFormikValues>
+  ) => {
+    try {
+      if (props.isEdit && detector.curState === DETECTOR_STATE.RUNNING) {
+        core.notifications.toasts.addDanger(
+          'Detector cannot be updated while it is running'
+        );
+      } else {
+        formikProps.setSubmitting(true);
+        formikProps.setFieldTouched('featureList');
+        formikProps.setFieldTouched('categoryField', isHCDetector);
+        formikProps.setFieldTouched('shingleSize');
+        formikProps.validateForm().then((errors) => {
+          if (isEmpty(errors)) {
+            if (props.isEdit) {
+              // TODO: possibly add logic to also start RT and/or historical from here. Need to think
+              // about adding similar logic from edit detector definition page
+              const detectorToUpdate = formikToModelConfiguration(
+                formikProps.values,
+                detector
+              );
+              handleUpdateDetector(detectorToUpdate);
+            } else {
+              optionallySaveValues({
+                ...formikProps.values,
+                categoryFieldEnabled: isHCDetector,
+              });
+              //@ts-ignore
+              props.setStep(3);
+            }
+          } else {
+            // TODO: can add focus to all components or possibly customize error message too
+            if (get(errors, 'featureList')) {
+              focusOnFirstWrongFeature(errors, formikProps.setFieldTouched);
+            } else if (get(errors, 'categoryField')) {
+              focusOnCategoryField();
+            }
+
+            core.notifications.toasts.addDanger(
+              'One or more input fields is invalid'
+            );
+          }
+        });
+      }
+    } catch (e) {
+    } finally {
+      formikProps.setSubmitting(false);
+    }
+  };
+
+  const handleUpdateDetector = async (detectorToUpdate: Detector) => {
+    dispatch(updateDetector(detectorId, detectorToUpdate))
+      .then((response: any) => {
+        core.notifications.toasts.addSuccess(
+          `Detector updated: ${response.response.name}`
+        );
+        props.history.push(`/detectors/${detectorId}/configurations/`);
+      })
+      .catch((err: any) => {
+        core.notifications.toasts.addDanger(
+          prettifyErrorMessage(
+            getErrorMessage(err, 'There was a problem updating the detector')
+          )
+        );
+      });
+  };
+
+  const optionallySaveValues = (values: ModelConfigurationFormikValues) => {
+    if (props.setInitialValues) {
+      props.setInitialValues(values);
+    }
+  };
+
+  const detectorToCreate = props.isEdit
+    ? detector
+    : formikToDetector({
+        ...props.detectorDefinitionValues,
+        ...props.initialValues,
+      } as CreateDetectorFormikValues);
+
+  return (
+    <Formik
+      initialValues={
+        props.initialValues
+          ? props.initialValues
+          : modelConfigurationToFormik(detector)
+      }
+      enableReinitialize={true}
+      onSubmit={() => {}}
+      validateOnMount={props.isEdit ? false : true}
+      validate={validateFeatures}
+    >
+      {(formikProps) => (
+        <Fragment>
+          <EuiPage
+            style={{
+              marginTop: '-24px',
+            }}
+          >
+            <EuiPageBody>
+              <EuiPageHeader>
+                <EuiPageHeaderSection>
+                  <EuiTitle size="l">
+                    <h1>
+                      {props.isEdit
+                        ? 'Edit model configuration'
+                        : 'Configure model'}{' '}
+                    </h1>
+                  </EuiTitle>
+                </EuiPageHeaderSection>
+              </EuiPageHeader>
+              <Features detector={detector} formikProps={formikProps} />
+              <EuiSpacer />
+              <CategoryField
+                isEdit={props.isEdit}
+                isHCDetector={isHCDetector}
+                categoryFieldOptions={getCategoryFields(indexDataTypes)}
+                setIsHCDetector={setIsHCDetector}
+                isLoading={isLoading}
+                originalShingleSize={originalShingleSize}
+                formikProps={formikProps}
+              />
+              <EuiSpacer />
+              <AdvancedSettings />
+              {!isEmpty(detectorToCreate) ? <EuiSpacer /> : null}
+              {!isEmpty(detectorToCreate) ? (
+                <SampleAnomalies
+                  detector={detectorToCreate}
+                  featureList={formikProps.values.featureList}
+                  shingleSize={formikProps.values.shingleSize}
+                  categoryFields={formikProps.values.categoryField}
+                  errors={formikProps.errors}
+                  setFieldTouched={formikProps.setFieldTouched}
+                />
+              ) : null}
+            </EuiPageBody>
+          </EuiPage>
+
+          <EuiFlexGroup
+            alignItems="center"
+            justifyContent="flexEnd"
+            gutterSize="s"
+            style={{ marginRight: '12px' }}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                onClick={() => {
+                  if (props.isEdit) {
+                    props.history.push(
+                      `/detectors/${detectorId}/configurations/`
+                    );
+                  } else {
+                    props.history.push('/detectors');
+                  }
+                }}
+              >
+                Cancel
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            {props.isEdit ? null : (
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  iconSide="left"
+                  iconType="arrowLeft"
+                  fill={false}
+                  data-test-subj="configureModelPreviousButton"
+                  //isLoading={formikProps.isSubmitting}
+                  //@ts-ignore
+                  onClick={() => {
+                    optionallySaveValues({
+                      ...formikProps.values,
+                      categoryFieldEnabled: isHCDetector,
+                    });
+                    //@ts-ignore
+                    props.setStep(1);
+                  }}
+                >
+                  Previous
+                </EuiButton>
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow={false}>
+              {props.isEdit ? (
+                <EuiButton
+                  type="submit"
+                  fill={true}
+                  data-test-subj="updateDetectorButton"
+                  //@ts-ignore
+                  onClick={() => {
+                    handleFormValidation(formikProps);
+                  }}
+                >
+                  Save changes
+                </EuiButton>
+              ) : (
+                <EuiButton
+                  type="submit"
+                  iconSide="right"
+                  iconType="arrowRight"
+                  fill={true}
+                  data-test-subj="configureModelNextButton"
+                  isLoading={formikProps.isSubmitting}
+                  //@ts-ignore
+                  onClick={() => {
+                    handleFormValidation(formikProps);
+                  }}
+                >
+                  Next
+                </EuiButton>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </Fragment>
+      )}
+    </Formik>
+  );
+}

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -135,52 +135,48 @@ export function ConfigureModel(props: ConfigureModelProps) {
   const handleFormValidation = async (
     formikProps: FormikProps<ModelConfigurationFormikValues>
   ) => {
-    try {
-      if (props.isEdit && detector.curState === DETECTOR_STATE.RUNNING) {
-        core.notifications.toasts.addDanger(
-          'Detector cannot be updated while it is running'
-        );
-      } else {
-        formikProps.setSubmitting(true);
-        formikProps.setFieldTouched('featureList');
-        formikProps.setFieldTouched('categoryField', isHCDetector);
-        formikProps.setFieldTouched('shingleSize');
-        formikProps.validateForm().then((errors) => {
-          if (isEmpty(errors)) {
-            if (props.isEdit) {
-              // TODO: possibly add logic to also start RT and/or historical from here. Need to think
-              // about adding similar logic from edit detector definition page
-              const detectorToUpdate = formikToModelConfiguration(
-                formikProps.values,
-                detector
-              );
-              handleUpdateDetector(detectorToUpdate);
-            } else {
-              optionallySaveValues({
-                ...formikProps.values,
-                categoryFieldEnabled: isHCDetector,
-              });
-              //@ts-ignore
-              props.setStep(3);
-            }
-          } else {
-            // TODO: can add focus to all components or possibly customize error message too
-            if (get(errors, 'featureList')) {
-              focusOnFirstWrongFeature(errors, formikProps.setFieldTouched);
-            } else if (get(errors, 'categoryField')) {
-              focusOnCategoryField();
-            }
-
-            core.notifications.toasts.addDanger(
-              'One or more input fields is invalid'
+    if (props.isEdit && detector.curState === DETECTOR_STATE.RUNNING) {
+      core.notifications.toasts.addDanger(
+        'Detector cannot be updated while it is running'
+      );
+    } else {
+      formikProps.setSubmitting(true);
+      formikProps.setFieldTouched('featureList');
+      formikProps.setFieldTouched('categoryField', isHCDetector);
+      formikProps.setFieldTouched('shingleSize');
+      formikProps.validateForm().then((errors) => {
+        if (isEmpty(errors)) {
+          if (props.isEdit) {
+            // TODO: possibly add logic to also start RT and/or historical from here. Need to think
+            // about adding similar logic from edit detector definition page
+            const detectorToUpdate = formikToModelConfiguration(
+              formikProps.values,
+              detector
             );
+            handleUpdateDetector(detectorToUpdate);
+          } else {
+            optionallySaveValues({
+              ...formikProps.values,
+              categoryFieldEnabled: isHCDetector,
+            });
+            //@ts-ignore
+            props.setStep(3);
           }
-        });
-      }
-    } catch (e) {
-    } finally {
-      formikProps.setSubmitting(false);
+        } else {
+          // TODO: can add focus to all components or possibly customize error message too
+          if (get(errors, 'featureList')) {
+            focusOnFirstWrongFeature(errors, formikProps.setFieldTouched);
+          } else if (get(errors, 'categoryField')) {
+            focusOnCategoryField();
+          }
+
+          core.notifications.toasts.addDanger(
+            'One or more input fields is invalid'
+          );
+        }
+      });
     }
+    formikProps.setSubmitting(false);
   };
 
   const handleUpdateDetector = async (detectorToUpdate: Detector) => {
@@ -299,7 +295,6 @@ export function ConfigureModel(props: ConfigureModelProps) {
                   iconType="arrowLeft"
                   fill={false}
                   data-test-subj="configureModelPreviousButton"
-                  //isLoading={formikProps.isSubmitting}
                   //@ts-ignore
                   onClick={() => {
                     optionallySaveValues({

--- a/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
+++ b/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { get, isEmpty } from 'lodash';
+import moment from 'moment';
+import {
+  getAnomalyHistoryWording,
+  getFeatureBreakdownWording,
+  getFeatureDataWording,
+} from '../../AnomalyCharts/utils/anomalyChartUtils';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import ContentPanel from '../../../components/ContentPanel/ContentPanel';
+import { DateRange, Detector } from '../../../models/interfaces';
+import { AppState } from '../../../redux/reducers';
+import { previewDetector } from '../../../redux/reducers/previewAnomalies';
+import { AnomaliesChart } from '../../AnomalyCharts/containers/AnomaliesChart';
+import { HeatmapCell } from '../../AnomalyCharts/containers/AnomalyHeatmapChart';
+import { FeatureBreakDown } from '../../AnomalyCharts/containers/FeatureBreakDown';
+import { useHideSideNavBar } from '../../main/hooks/useHideSideNavBar';
+import { generateAnomalyAnnotations } from '../../utils/anomalyResultUtils';
+import { focusOnFirstWrongFeature } from '../utils/helpers';
+import { prepareDetector } from '../utils/helpers';
+import { FeaturesFormikValues } from '../models/interfaces';
+import { prettifyErrorMessage } from '../../../../server/utils/helpers';
+import { CoreStart } from '../../../../../../src/core/public';
+import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+
+interface SampleAnomaliesProps {
+  detector: Detector;
+  featureList: FeaturesFormikValues[];
+  shingleSize: number;
+  categoryFields: string[];
+  errors: any;
+  setFieldTouched: any;
+}
+
+export function SampleAnomalies(props: SampleAnomaliesProps) {
+  const core = React.useContext(CoreServicesContext) as CoreStart;
+  const dispatch = useDispatch();
+  useHideSideNavBar(true, false);
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [previewDone, setPreviewDone] = useState<boolean>(false);
+  const [firstPreview, setFirstPreview] = useState<boolean>(true);
+  const [newDetector, setNewDetector] = useState<Detector>(props.detector);
+  const initialStartDate = moment().subtract(7, 'days');
+  const initialEndDate = moment();
+  const [dateRange, setDateRange] = useState<DateRange>({
+    startDate: initialStartDate.valueOf(),
+    endDate: initialEndDate.valueOf(),
+  });
+
+  const [zoomRange, setZoomRange] = useState<DateRange>({
+    startDate: initialStartDate.valueOf(),
+    endDate: initialEndDate.valueOf(),
+  });
+
+  const [selectedHeatmapCell, setSelectedHeatmapCell] = useState<HeatmapCell>();
+
+  const isHCDetector = !isEmpty(get(newDetector, 'categoryField', []));
+
+  useEffect(() => {
+    if (!firstPreview) {
+      getSampleAnomalies();
+    }
+  }, [dateRange]);
+
+  const handleDateRangeChange = useCallback(
+    (startDate: number, endDate: number, dateRangeOption: string) => {
+      setDateRange({
+        startDate: startDate,
+        endDate: endDate,
+      });
+    },
+    []
+  );
+
+  const handleZoomChange = useCallback((startDate: number, endDate: number) => {
+    setZoomRange({
+      startDate: startDate,
+      endDate: endDate,
+    });
+  }, []);
+
+  const handleHeatmapCellSelected = useCallback((heatmapCell: HeatmapCell) => {
+    setSelectedHeatmapCell(heatmapCell);
+  }, []);
+
+  const anomaliesResult = useSelector(
+    (state: AppState) => state.anomalies.anomaliesResult
+  );
+
+  const getPreviewErrorMessage = (err: any, defaultMessage: string) => {
+    if (typeof err === 'string') return err;
+    if (err) {
+      if (err.msg === 'Bad Request') {
+        return err.response || defaultMessage;
+      }
+      if (err.msg) return err.msg;
+    }
+    return defaultMessage;
+  };
+
+  async function getSampleAdResult(detector: Detector) {
+    try {
+      setIsLoading(true);
+      await dispatch(
+        previewDetector({
+          periodStart: dateRange.startDate.valueOf(),
+          periodEnd: dateRange.endDate.valueOf(),
+          detector: detector,
+        })
+      );
+      setIsLoading(false);
+      setPreviewDone(true);
+      setFirstPreview(false);
+    } catch (err) {
+      console.error(`Fail to preview detector ${detector.id}`, err);
+      setIsLoading(false);
+      core.notifications.toasts.addDanger(
+        prettifyErrorMessage(
+          getPreviewErrorMessage(
+            err,
+            'There was a problem previewing the detector'
+          )
+        )
+      );
+    }
+  }
+
+  const getSampleAnomalies = () => {
+    setSelectedHeatmapCell(undefined);
+    try {
+      const updatedDetector = prepareDetector(
+        props.featureList,
+        props.shingleSize,
+        props.categoryFields,
+        newDetector,
+        true
+      );
+      setPreviewDone(false);
+      setZoomRange({ ...dateRange });
+      setNewDetector(updatedDetector);
+      getSampleAdResult(updatedDetector);
+    } catch (err) {
+      console.error(
+        `Fail to get sample anomalies for detector ${newDetector.id}`,
+        err
+      );
+    }
+  };
+
+  return (
+    <ContentPanel title="Sample anomalies">
+      <EuiCallOut
+        title={'You can preview anomalies based on sample feature input'}
+        iconType="eye"
+      >
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText>
+              {firstPreview
+                ? 'You can preview how your anomalies may look like from sample feature output and adjust the feature settings as needed.'
+                : 'Use the sample data as a reference to fine tune settings. To see the latest preview with your adjustments, click "Refresh preview". Once you are done with your edits, save your changes and run the detector to see real time anomalies for the new data set.'}{' '}
+              <EuiLink
+                href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/"
+                target="_blank"
+              >
+                Learn more <EuiIcon size="s" type="popout" />
+              </EuiLink>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              type="button"
+              data-test-subj="previewDetector"
+              onClick={() => {
+                if (
+                  !focusOnFirstWrongFeature(props.errors, props.setFieldTouched)
+                ) {
+                  getSampleAnomalies();
+                }
+              }}
+              fill={!firstPreview}
+              isLoading={isLoading}
+            >
+              {firstPreview ? 'Preview anomalies' : 'Refresh preview'}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiCallOut>
+      <EuiSpacer />
+      {previewDone && !anomaliesResult.anomalies.length ? (
+        <EuiCallOut
+          title={`No sample anomaly result generated. Please check detector interval and make sure you have >400 data points${
+            isHCDetector ? ' for some entities ' : ' '
+          }during preview date range`}
+          color="warning"
+          iconType="alert"
+        ></EuiCallOut>
+      ) : null}
+      {!firstPreview ? (
+        <Fragment>
+          <AnomaliesChart
+            title={getAnomalyHistoryWording(false, false)}
+            onDateRangeChange={handleDateRangeChange}
+            onZoomRangeChange={handleZoomChange}
+            isLoading={isLoading}
+            dateRange={dateRange}
+            detector={props.detector}
+            isHCDetector={isHCDetector}
+            detectorCategoryField={newDetector.categoryField}
+            onHeatmapCellSelected={handleHeatmapCellSelected}
+            selectedHeatmapCell={selectedHeatmapCell}
+            newDetector={newDetector}
+            zoomRange={zoomRange}
+            anomaliesResult={anomaliesResult}
+            showAlerts={false}
+            isNotSample={false}
+          />
+          <EuiSpacer />
+          {isLoading ? (
+            <EuiFlexGroup
+              justifyContent="spaceAround"
+              style={{ height: '200px', paddingTop: '100px' }}
+            >
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="xl" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : isHCDetector ? null : (
+            <FeatureBreakDown
+              title={getFeatureBreakdownWording(false)}
+              detector={newDetector}
+              anomaliesResult={anomaliesResult}
+              annotations={generateAnomalyAnnotations(
+                get(anomaliesResult, 'anomalies', [])
+              )}
+              isLoading={isLoading}
+              dateRange={zoomRange}
+              featureDataSeriesName={getFeatureDataWording(false)}
+              showFeatureMissingDataPointAnnotation={false}
+            />
+          )}
+        </Fragment>
+      ) : null}
+    </ContentPanel>
+  );
+}

--- a/public/pages/ConfigureModel/models/interfaces.ts
+++ b/public/pages/ConfigureModel/models/interfaces.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { FEATURE_TYPE } from '../../../models/interfaces';
+import { AggregationOption } from '../../../models/types';
+
+// Formik values used when creating/editing the model configuration
+export interface ModelConfigurationFormikValues {
+  featureList: FeaturesFormikValues[];
+  categoryFieldEnabled: boolean;
+  categoryField: string[];
+  shingleSize: number;
+}
+
+export interface FeaturesFormikValues {
+  featureId: string;
+  featureName: string | undefined;
+  featureType: FEATURE_TYPE;
+  featureEnabled: boolean;
+  aggregationQuery: string;
+  aggregationBy?: string;
+  aggregationOf?: AggregationOption[];
+  newFeature?: boolean;
+}

--- a/public/pages/ConfigureModel/utils/constants.tsx
+++ b/public/pages/ConfigureModel/utils/constants.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { FEATURE_TYPE } from '../../../models/interfaces';
+import {
+  ModelConfigurationFormikValues,
+  FeaturesFormikValues,
+} from '../../ConfigureModel/models/interfaces';
+
+export const INITIAL_MODEL_CONFIGURATION_VALUES: ModelConfigurationFormikValues = {
+  featureList: [],
+  categoryFieldEnabled: false,
+  categoryField: [],
+  shingleSize: 4,
+};
+
+export const INITIAL_FEATURE_VALUES: FeaturesFormikValues = {
+  featureId: '',
+  featureName: '',
+  featureEnabled: true,
+  featureType: FEATURE_TYPE.SIMPLE,
+  aggregationQuery: JSON.stringify(
+    { aggregation_name: { sum: { field: 'field_name' } } },
+    null,
+    4
+  ),
+  aggregationBy: '',
+  aggregationOf: [],
+};
+
+export const FEATURE_TYPES = [
+  { text: 'Custom Aggregation', value: FEATURE_TYPE.CUSTOM },
+  { text: 'Defined Aggregation', value: FEATURE_TYPE.SIMPLE },
+];
+
+export const FEATURE_TYPE_OPTIONS = [
+  { text: 'Field value', value: FEATURE_TYPE.SIMPLE },
+  { text: 'Custom expression', value: FEATURE_TYPE.CUSTOM },
+];
+
+export enum SAVE_FEATURE_OPTIONS {
+  START_AD_JOB = 'start_ad_job',
+  KEEP_AD_JOB_STOPPED = 'keep_ad_job_stopped',
+}
+
+export const AGGREGATION_TYPES = [
+  { value: 'avg', text: 'average()' },
+  { value: 'value_count', text: 'count()' },
+  { value: 'sum', text: 'sum()' },
+  { value: 'min', text: 'min()' },
+  { value: 'max', text: 'max()' },
+];
+
+export const FEATURE_FIELDS = [
+  'featureName',
+  'aggregationOf',
+  'aggregationBy',
+  'aggregationQuery',
+];

--- a/public/pages/ConfigureModel/utils/helpers.ts
+++ b/public/pages/ConfigureModel/utils/helpers.ts
@@ -1,0 +1,346 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  DATA_TYPES,
+  MULTI_ENTITY_SHINGLE_SIZE,
+  SINGLE_ENTITY_SHINGLE_SIZE,
+} from '../../../utils/constants';
+import {
+  FEATURE_TYPE,
+  FeatureAttributes,
+  Detector,
+} from '../../../models/interfaces';
+import { v4 as uuidv4 } from 'uuid';
+import { get, forOwn, cloneDeep, isEmpty } from 'lodash';
+import { DataTypes } from '../../../redux/reducers/elasticsearch';
+import {
+  ModelConfigurationFormikValues,
+  FeaturesFormikValues,
+} from '../../ConfigureModel/models/interfaces';
+import { INITIAL_MODEL_CONFIGURATION_VALUES } from '../../ConfigureModel/utils/constants';
+import {
+  featuresToUIMetadata,
+  formikToFeatureAttributes,
+} from '../../ReviewAndCreate/utils/helpers';
+
+export const getFieldOptions = (
+  allFields: { [key: string]: string[] },
+  validTypes: DATA_TYPES[]
+) =>
+  validTypes
+    .map((dataType) =>
+      allFields[dataType]
+        ? {
+            label: dataType,
+            options: allFields[dataType].map((field) => ({
+              label: field,
+              type: dataType,
+            })),
+          }
+        : []
+    )
+    .filter(Boolean);
+
+export const getNumberFieldOptions = (allFields: { [key: string]: string[] }) =>
+  getFieldOptions(allFields, [DATA_TYPES.NUMBER]);
+
+export const getCountableFieldOptions = (allFields: {
+  [key: string]: string[];
+}) => {
+  const countableDataTypes = [
+    DATA_TYPES.NUMBER,
+    DATA_TYPES.BOOLEAN,
+    DATA_TYPES.KEYWORD,
+    DATA_TYPES.DATE,
+  ];
+  return getFieldOptions(
+    allFields,
+    Object.keys(allFields)
+      .map((field) => field as DATA_TYPES)
+      .filter((field) => countableDataTypes.includes(field))
+  );
+};
+
+export const initialFeatureValue = () => ({
+  featureId: uuidv4(),
+  featureName: undefined,
+  featureType: FEATURE_TYPE.SIMPLE,
+  featureEnabled: true,
+  importance: 1,
+  aggregationBy: 'sum',
+  aggregationQuery: JSON.stringify(
+    {
+      aggregation_name: { sum: { field: 'field_name' } },
+    },
+    null,
+    4
+  ),
+  newFeature: true,
+});
+
+export const validateFeatures = (values: any) => {
+  const featureList = get(values, 'featureList', []);
+  let featureNameCount = new Map<string, number>();
+
+  featureList.forEach((attribute: FeatureAttributes) => {
+    if (attribute.featureName) {
+      const featureName = attribute.featureName.toLowerCase();
+      if (featureNameCount.has(featureName)) {
+        featureNameCount.set(
+          featureName,
+          // @ts-ignore
+          featureNameCount.get(featureName) + 1
+        );
+      } else {
+        featureNameCount.set(featureName, 1);
+      }
+    }
+  });
+
+  let hasError = false;
+  const featureErrors = featureList.map((attribute: FeatureAttributes) => {
+    if (attribute.featureName) {
+      // @ts-ignore
+      if (featureNameCount.get(attribute.featureName.toLowerCase()) > 1) {
+        hasError = true;
+        return { featureName: 'Duplicate feature name' };
+      } else {
+        return undefined;
+      }
+    } else {
+      hasError = true;
+      // @ts-ignore
+      return {
+        featureName: 'You must enter a feature name',
+      };
+    }
+  });
+  return hasError ? { featureList: featureErrors } : undefined;
+};
+
+export const generateInitialFeatures = (
+  detector: Detector
+): FeaturesFormikValues[] => {
+  const featureUiMetaData = get(detector, 'uiMetadata.features', []);
+  const features = get(detector, 'featureAttributes', []);
+  // @ts-ignore
+  return features.map((feature: FeatureAttributes) => {
+    return {
+      ...featureUiMetaData[feature.featureName],
+      ...feature,
+      aggregationQuery: JSON.stringify(feature['aggregationQuery'], null, 4),
+      aggregationOf: get(
+        featureUiMetaData,
+        `${feature.featureName}.aggregationOf`
+      )
+        ? [
+            {
+              label: get(
+                featureUiMetaData,
+                `${feature.featureName}.aggregationOf`
+              ),
+            },
+          ]
+        : [],
+      featureType: get(featureUiMetaData, `${feature.featureName}.featureType`)
+        ? get(featureUiMetaData, `${feature.featureName}.featureType`)
+        : FEATURE_TYPE.CUSTOM,
+    };
+  });
+};
+
+export const focusOnFirstWrongFeature = (errors: any, setFieldTouched: any) => {
+  if (
+    //@ts-ignore
+    !!get(errors, 'featureList', []).filter((featureError) => featureError)
+      .length
+  ) {
+    const featureList = get(errors, 'featureList', []);
+    for (let i = featureList.length - 1; i >= 0; i--) {
+      if (featureList[i]) {
+        forOwn(featureList[i], function (value, key) {
+          setFieldTouched(`featureList.${i}.${key}`, true);
+        });
+        focusOnFeatureAccordion(i);
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+export const focusOnFeatureAccordion = (index: number) => {
+  const featureAccordion = document.getElementById(
+    `featureAccordionHeaders.${index}`
+  );
+  //@ts-ignore
+  featureAccordion.setAttribute('tabindex', '-1');
+  //@ts-ignore
+  featureAccordion.focus();
+  const header =
+    //@ts-ignore
+    featureAccordion.parentElement.parentElement.parentElement.parentElement;
+  //@ts-ignore
+  if (!header.className.includes('euiAccordion-isOpen')) {
+    //@ts-ignore
+    featureAccordion.click();
+  }
+};
+
+export const focusOnCategoryField = () => {
+  const component = document.getElementById('categoryFieldCheckbox');
+  component?.focus();
+};
+
+export const getCategoryFields = (dataTypes: DataTypes) => {
+  const keywordFields = get(dataTypes, 'keyword', []);
+  const ipFields = get(dataTypes, 'ip', []);
+  return keywordFields.concat(ipFields);
+};
+
+export const getShingleSizeFromObject = (
+  obj: object,
+  isHCDetector: boolean
+) => {
+  return get(
+    obj,
+    'shingleSize',
+    isHCDetector ? MULTI_ENTITY_SHINGLE_SIZE : SINGLE_ENTITY_SHINGLE_SIZE
+  );
+};
+
+export function clearModelConfiguration(ad: Detector): Detector {
+  return {
+    ...ad,
+    featureAttributes: [],
+    uiMetadata: {
+      ...ad.uiMetadata,
+      features: {},
+    },
+    categoryField: undefined,
+    shingleSize: SINGLE_ENTITY_SHINGLE_SIZE,
+  };
+}
+
+export function modelConfigurationToFormik(
+  detector: Detector
+): ModelConfigurationFormikValues {
+  const initialValues = cloneDeep(INITIAL_MODEL_CONFIGURATION_VALUES);
+  if (isEmpty(detector)) {
+    return initialValues;
+  }
+  return {
+    ...initialValues,
+    featureList: featuresToFormik(detector),
+    categoryFieldEnabled: !isEmpty(get(detector, 'categoryField', []))
+      ? true
+      : false,
+    categoryField: get(detector, 'categoryField', []),
+    shingleSize: get(detector, 'shingleSize', 4),
+  };
+}
+
+function featuresToFormik(detector: Detector): FeaturesFormikValues[] {
+  const featureUiMetaData = get(detector, 'uiMetadata.features', []);
+  const features = get(detector, 'featureAttributes', []);
+  // @ts-ignore
+  return features.map((feature: FeatureAttributes) => {
+    return {
+      ...featureUiMetaData[feature.featureName],
+      ...feature,
+      aggregationQuery: JSON.stringify(feature['aggregationQuery'], null, 4),
+      aggregationOf: get(
+        featureUiMetaData,
+        `${feature.featureName}.aggregationOf`
+      )
+        ? [
+            {
+              label: get(
+                featureUiMetaData,
+                `${feature.featureName}.aggregationOf`
+              ),
+            },
+          ]
+        : [],
+      featureType: get(featureUiMetaData, `${feature.featureName}.featureType`)
+        ? get(featureUiMetaData, `${feature.featureName}.featureType`)
+        : FEATURE_TYPE.CUSTOM,
+    };
+  });
+}
+
+export function formikToModelConfiguration(
+  values: ModelConfigurationFormikValues,
+  detector: Detector
+): Detector {
+  let detectorBody = {
+    ...detector,
+    uiMetadata: {
+      ...detector.uiMetadata,
+      features: { ...featuresToUIMetadata(values.featureList) },
+    },
+    featureAttributes: formikToFeatureAttributes(values.featureList),
+    shingleSize: values.shingleSize,
+    categoryField: !isEmpty(values?.categoryField)
+      ? values.categoryField
+      : undefined,
+  } as Detector;
+
+  return detectorBody;
+}
+
+export function prepareDetector(
+  featureValues: FeaturesFormikValues[],
+  shingleSizeValue: number,
+  categoryFields: string[],
+  ad: Detector,
+  forPreview: boolean = false
+): Detector {
+  const detector = cloneDeep(ad);
+  const featureAttributes = formikToFeatures(featureValues, forPreview);
+
+  return {
+    ...detector,
+    featureAttributes: [...featureAttributes],
+    shingleSize: shingleSizeValue,
+    categoryField: isEmpty(categoryFields) ? undefined : categoryFields,
+    uiMetadata: {
+      ...detector.uiMetadata,
+      features: { ...featuresToUIMetadata(featureValues) },
+    },
+  };
+}
+
+function formikToFeatures(values: FeaturesFormikValues[], forPreview: boolean) {
+  const featureAttribute = formikToFeatureAttributes(values, forPreview);
+  return featureAttribute;
+}
+
+export function formikToSimpleAggregation(value: FeaturesFormikValues) {
+  if (
+    value.aggregationBy &&
+    value.aggregationOf &&
+    value.aggregationOf.length > 0
+  ) {
+    return {
+      [value.featureName]: {
+        [value.aggregationBy]: { field: value.aggregationOf[0].label },
+      },
+    };
+  } else {
+    return {};
+  }
+}

--- a/public/pages/ConfigureModel/utils/helpers.ts
+++ b/public/pages/ConfigureModel/utils/helpers.ts
@@ -246,8 +246,6 @@ export function modelConfigurationToFormik(
     ...initialValues,
     featureList: featuresToFormik(detector),
     categoryFieldEnabled: !isEmpty(get(detector, 'categoryField', []))
-      ? true
-      : false,
     categoryField: get(detector, 'categoryField', []),
     shingleSize: get(detector, 'shingleSize', 4),
   };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**This PR is 2 of 9 related to the new single flow changes. We will merge all changes into the single-flow-development branch 
first, and finally merge into main.**

**Please ignore test-related code for now, this is currently being refactored and updated, will be addressed in a later PR**

This PR adds the configure model page (step 2 in the creation flow). Specifically, the changes include:
- Adds the new `ConfigureModel` page, which is mostly a refactored & renamed version of the current `EditFeatures` page. The motivation for creating this new page was to make it clear that this page is about all model configuration settings, rather than just the created features, as well as make the layout and logic consistent with the other create flow pages for easier future maintainability and readability. Also note that the functionality of the components themselves (feature list, advanced settings, preview) have not changed, just moved to this new directory.
- Adds new props to `ConfigureModel` container compared to `EditFeatures` which makes it consistent with the rest of the new create flow pages (`setStep()`, `setInitialValues`, etc.)
- Update and move the helper functions to convert detector fields to Formik and vice versa
- Changes validation to be consistent with the rest of the new create flow pages

Screenshot:
![screencapture-localhost-5601-app-opendistro-anomaly-detection-kibana-2021-04-05-11_08_32](https://user-images.githubusercontent.com/62119629/113609946-56c7cb00-9601-11eb-8250-74a02a450549.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
